### PR TITLE
Removed (seemingly) unused _cachedRequests NSMutableSet.

### DIFF
--- a/Example/Classes/AFImageRequest.m
+++ b/Example/Classes/AFImageRequest.m
@@ -24,15 +24,12 @@
 #import "AFImageRequestOperation.h"
 
 static NSOperationQueue *_operationQueue = nil;
-static NSMutableSet *_cachedRequests = nil;
 
 @implementation AFImageRequest
 
 + (void)initialize {
 	_operationQueue = [[NSOperationQueue alloc] init];
 	[_operationQueue setMaxConcurrentOperationCount:6];
-	
-    _cachedRequests = [[NSMutableSet alloc] init];
 }
 
 + (void)requestImageWithURLString:(NSString *)urlString options:(AFImageRequestOptions)options block:(void (^)(UIImage *image))block {


### PR DESCRIPTION
Thinking this may be an orphaned NSMutableSet. Can't seem to find any other references to it anywhere else, causing a leak right now.
