### PR TITLE
AcceptableContentTypes filter ability and Debug delay feature are broken

### DIFF
--- a/AFNetworking/AFHTTPOperation.m
+++ b/AFNetworking/AFHTTPOperation.m
@@ -66,6 +66,14 @@ NSString * const AFHTTPOperationParsedDataErrorKey = @"com.alamofire.http-operat
 
 - (void)finishWithError:(NSError *)error {
 	[super finishWithError:error];
+	
+#if ! defined(NDEBUG)
+	if (self.debugDelayTimer != nil) {
+		// There is a debug delay, so don't do anything and wait.
+		// When the timer will fire this method will be called back ;-)
+		return;
+	}
+#endif
     
     NSDictionary *data = nil;
     if (self.contentTypeAcceptable) {

--- a/AFNetworking/QHTTPOperation/QHTTPOperation.h
+++ b/AFNetworking/QHTTPOperation/QHTTPOperation.h
@@ -148,6 +148,7 @@
 #if ! defined(NDEBUG)
 @property (copy,   readwrite) NSError *             debugError;             // default is nil
 @property (assign, readwrite) NSTimeInterval        debugDelay;             // default is none
+@property (retain,  readonly) NSTimer *             debugDelayTimer;
 #endif
 
 // Things you can configure up to the point where you start receiving data. 


### PR DESCRIPTION
Bad test which is breaking acceptableContentTypes filter ability

Indeed the test removed broke the acceptableContentTypes filter because it's hardly test against "application/json" and not on all acceptable content types already stored in the self.acceptableContentTypes var

---

Overriding of the finishWithError method breaks the debug delay feature

In AFHTTPOperation.m, the overriding of the  -
(void)finishWithError:(NSError *)error method don't take into account if
there is or not a debug delay.
