### PR TITLE
Improving the check for NSJSONSerialization.

### DIFF
--- a/AFNetworking/AFJSONRequestOperation.m
+++ b/AFNetworking/AFJSONRequestOperation.m
@@ -23,6 +23,8 @@
 #import "AFJSONRequestOperation.h"
 #import "JSONKit.h"
 
+#include <Availability.h>
+
 @implementation AFJSONRequestOperation
 
 + (id)operationWithRequest:(NSURLRequest *)urlRequest                
@@ -61,13 +63,17 @@
             }
         } else {
             id JSON = nil;
-            
+
+            #if __IPHONE_OS_VERSION_MIN_REQUIRED > __IPHONE_4_3
             if ([NSJSONSerialization class]) {
                 JSON = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
             } else {
                 JSON = [[JSONDecoder decoder] objectWithData:data error:&error];
-            }             
-            
+            }
+            #else
+            JSON = [[JSONDecoder decoder] objectWithData:data error:&error];
+            #endif
+
             if (error) {
                 if (failure) {
                     failure(error);


### PR DESCRIPTION
We now only attempt to use NSJSONSerialization if we're compiling
against a Base SDK that includes it.  If we are, we still retain the
NS_CLASS_AVAILABLE-based `class` check to test whether or not it's
available at runtime.

The fallback in both cases is to use JSONKit.
