### PR TITLE
imageByScalingAndCroppingImage Orientation Ratio Bug

### DIFF
--- a/AFNetworking/UIImage+AFNetworking.m
+++ b/AFNetworking/UIImage+AFNetworking.m
@@ -38,7 +38,7 @@
     CGFloat heightFactor = size.height / image.size.height;
     CGFloat scaleFactor = (widthFactor > heightFactor) ? widthFactor : heightFactor;
     scaledSize.width = image.size.width * scaleFactor;
-    scaledSize.width = image.size.height * scaleFactor;
+    scaledSize.height = image.size.height * scaleFactor;
     if (widthFactor > heightFactor) {
         thumbnailPoint.y = (size.height - scaledSize.height) * 0.5; 
     } else if (widthFactor < heightFactor) {


### PR DESCRIPTION
There was a bug with the code to scale/crop an image that caused it to stretch images needlessly when they were in portrait instead of landscape orientation.  Super tiny fix as you can see...
