### PR TITLE
Handle responses with no content (ex. http status code 204)

### DIFF
--- a/AFNetworking/AFJSONRequestOperation.m
+++ b/AFNetworking/AFJSONRequestOperation.m
@@ -61,6 +61,10 @@
             if (failure) {
                 failure(error);
             }
+        } else if ([data length] == 0) {
+            if (success) {
+                success(nil);
+            }
         } else {
             id JSON = nil;
 


### PR DESCRIPTION
Ran into an issue where AFJSONRequestOperation tries to parse empty response data, which in turn causes JSONKit to raise an NSInvalidArgumentException, reason: 'The string argument is NULL.'

This patch checks for 0 length data before attempting to parse.
