### PR TITLE
Fix stray network indicator activity.

### DIFF
--- a/AFNetworking/AFHTTPRequestOperation.m
+++ b/AFNetworking/AFHTTPRequestOperation.m
@@ -275,6 +275,12 @@ static NSThread *_networkRequestThread = nil;
     self.isCancelled = YES;
     
     [self.connection cancel];    
+    
+    if(self.state == AFHTTPOperationExecutingState){
+        [[AFNetworkActivityIndicatorManager sharedManager] stopAnimating];
+    }
+    
+    self.state = AFHTTPOperationCancelledState;
 }
 
 #pragma mark - AFHTTPRequestOperation


### PR DESCRIPTION
Fixes some stray network indicator activity. Operations cancelled while executing would leave the indicator count at +1.
