### PR TITLE
Fixing a leak as a result of a race condition in the sample Gowalla client

### DIFF
--- a/Example/Classes/AFGowallaAPIClient.m
+++ b/Example/Classes/AFGowallaAPIClient.m
@@ -32,11 +32,10 @@ NSString * const kAFGowallaBaseURLString = @"https://api.gowalla.com/";
 @implementation AFGowallaAPIClient
 
 + (id)sharedClient {
-    if (_sharedClient == nil) {
-        @synchronized(self) {
-            _sharedClient = [[self alloc] init];
-        }
-    }
+    static dispatch_once_t oncePredicate;
+    dispatch_once(&oncePredicate, ^{
+        _sharedClient = [[self alloc] init];
+    });
     
     return _sharedClient;
 }


### PR DESCRIPTION
The allocation for the shared client could occur twice resulting in a leak. Two
threads could pass the nil check. One would acquire the lock and create the
sharedClient. The second thread would eventually get the lock and also acquire
a sharedClient.
