### PR TITLE
Consistent use of main thread for success/failure callbacks in AFJSONRequestOperation

### DIFF
--- a/AFNetworking/AFJSONRequestOperation.m
+++ b/AFNetworking/AFJSONRequestOperation.m
@@ -84,11 +84,15 @@ static dispatch_queue_t json_request_operation_processing_queue() {
         
         if (error) {
             if (failure) {
-                failure(request, response, error);
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    failure(request, response, error);
+                });
             }
         } else if ([data length] == 0) {
             if (success) {
-                success(request, response, nil);
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    success(request, response, nil);
+                });
             }
         } else {
             dispatch_async(json_request_operation_processing_queue(), ^(void) {


### PR DESCRIPTION
Making sure the success/failure callbacks for operationWithRequest are always
called on the main thread.
