### PR TITLE
Builds now if you have ALL of xcodes warnings and errors turned on

### DIFF
--- a/AFNetworking/AFHTTPRequestOperation.m
+++ b/AFNetworking/AFHTTPRequestOperation.m
@@ -331,8 +331,9 @@ didReceiveResponse:(NSURLResponse *)response
     if (self.outputStream) {
         [self.outputStream open];
     } else {
-        NSUInteger capacity = MIN(MAX(abs(response.expectedContentLength), kAFHTTPMinimumInitialDataCapacity), kAFHTTPMaximumInitialDataCapacity);
-        self.dataAccumulator = [NSMutableData dataWithCapacity:capacity];
+        NSUInteger maxContentLength = MAX(abs((int)response.expectedContentLength), 1024);
+        NSUInteger contentLength = MIN(maxContentLength, 1024u * 1024u * 8u);
+        self.dataAccumulator = [NSMutableData dataWithCapacity:contentLength];
     }
 }
 
@@ -351,7 +352,7 @@ didReceiveResponse:(NSURLResponse *)response
     }
     
     if (self.downloadProgress) {
-        self.downloadProgress(self.totalBytesRead, self.response.expectedContentLength);
+        self.downloadProgress(self.totalBytesRead, (NSUInteger)self.response.expectedContentLength);
     }
 }
 


### PR DESCRIPTION
Hi we are running xcode with max errors and warnings turned on. One of our guys altered a few things in AFHTTPRequestOperation.m so that it dosnt give you build errors any more.
