### PR TITLE
Fixing multiPartFormRequest to allow data

### DIFF
--- a/AFNetworking/AFHTTPClient.h
+++ b/AFNetworking/AFHTTPClient.h
@@ -37,7 +37,7 @@
 }
 
 /**
- The url used as the base for paths specified in methods such as `getPath:parameters:success:failure`
+ The url used as the base for paths specified in methods such as `getPath:parameteres:success:failure`
  */
 @property (readonly, nonatomic, retain) NSURL *baseURL;
 
@@ -49,7 +49,7 @@
 /**
  The operation queue which manages operations enqueued by the HTTP client.
  */
-@property (readonly, nonatomic, retain) NSOperationQueue *operationQueue;
+@property (readonly, nonatomic, retain) NSOperationQueue *operationQueue;;
 
 ///---------------------------------------------
 /// @name Creating and Initializing HTTP Clients
@@ -266,6 +266,8 @@
  @param fileName The filename to be associated with the file contents. This parameter must not be `nil`.
  */
 - (void)appendPartWithFile:(NSURL *)fileURL mimeType:(NSString *)mimeType fileName:(NSString *)fileName;
+
+- (void)appendPartWithFileData:(NSData *)data mimeType:(NSString *)mimeType name:(NSString *)name;
 
 /**
  Appends encoded data to the form data.


### PR DESCRIPTION
Upon upgrading I found that my POSTing of image data crashed the application, because encoding it with nsutf8 returned a nil object. At least, I think that's what was happening. This was last night, and I can't remember exactly. I know, helpful. Anyway, even when I got it not to crash, it wouldn't work right. I added a mimeType option and made it pass data without encoding, as well as a few other things. I've tested POSTing with a parameters dictionary and appendPartWithFormData with success.
