### PR TITLE
Small addition to AFHTTClient

### DIFF
--- a/AFNetworking/AFHTTPClient.h
+++ b/AFNetworking/AFHTTPClient.h
@@ -34,6 +34,7 @@
     NSStringEncoding _stringEncoding;
     NSMutableDictionary *_defaultHeaders;
     NSOperationQueue *_operationQueue;
+    BOOL _HTTPShouldHandleCookies;
 }
 
 /**
@@ -50,6 +51,11 @@
  The operation queue which manages operations enqueued by the HTTP client.
  */
 @property (readonly, nonatomic, retain) NSOperationQueue *operationQueue;
+
+/**
+ The value to pass on to the request indicating if cookies should be handled 
+ */	
+@property (nonatomic, assign) BOOL HTTPShouldHandleCookies;
 
 ///---------------------------------------------
 /// @name Creating and Initializing HTTP Clients

--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -94,6 +94,7 @@ static NSString * AFURLEncodedStringFromStringWithEncoding(NSString *string, NSS
 @synthesize stringEncoding = _stringEncoding;
 @synthesize defaultHeaders = _defaultHeaders;
 @synthesize operationQueue = _operationQueue;
+@synthesize HTTPShouldHandleCookies = _HTTPShouldHandleCookies;
 
 + (AFHTTPClient *)clientWithBaseURL:(NSURL *)url {
     return [[[self alloc] initWithBaseURL:url] autorelease];
@@ -184,7 +185,7 @@ static NSString * AFURLEncodedStringFromStringWithEncoding(NSString *string, NSS
     
 	[request setURL:url];
 	[request setHTTPMethod:method];
-	[request setHTTPShouldHandleCookies:NO];
+	[request setHTTPShouldHandleCookies:self.HTTPShouldHandleCookies];
 	[request setAllHTTPHeaderFields:headers];
     
 	return request;


### PR DESCRIPTION
Hi,
needed a way to set NSURLReuqest's HTTPShouldHandleCookies property from my AFHTTPClient subclass, so i've added a property to AFHTTPClient.

any special reason it was hardcoded in the first place?
