### PR TITLE
Allow creating NSMutableURLRequests with JSON body

### DIFF
--- a/AFNetworking/AFHTTPClient.h
+++ b/AFNetworking/AFHTTPClient.h
@@ -142,6 +142,19 @@
 ///-------------------------------
 
 /**
+ Creates a `NSMutableURLRequest` object with the specified HTTP method, path, and string containing serialized JSON for the HTTP body. Because the JSON is used as the body, the HTTP method must be `POST`, `PUT`, or `DELETE`.
+ 
+ @param method The HTTP method for the request; must be one of `POST`, `PUT`, or `DELETE`.
+ @param path The path to be appended to the HTTP client's base URL and used as the request URL.
+ @param parameters The string containing serialized JSON to be used as the request HTTP body.
+ 
+ @return An `NSMutableURLRequest` object
+ */
+- (NSMutableURLRequest *)requestWithMethod:(NSString *)method
+                                      path:(NSString *)path
+                                  jsonBody:(NSString *)jsonBody;
+
+/**
  Creates an `NSMutableURLRequest` object with the specified HTTP method and path. If the HTTP method is `GET`, the parameters will be used to construct a url-encoded query string that is appended to the request's URL. If `POST`, `PUT`, or `DELETE`, the parameters will be encoded into a `application/x-www-form-urlencoded` HTTP body.
  
  @param method The HTTP method for the request, such as `GET`, `POST`, `PUT`, or `DELETE`.


### PR DESCRIPTION
Hi guys,

Thanks for the library which is proving very useful in an iPhone app I'm writing. One stumbling block I encountered, however, is that if you want to create a `NSMutableURLRequest` with data to send to the server, you need to encode it as a dictionary and use `requestWithMethod:path:parameters`. A lot of times I just want to make a `POST`, `PUT`, or `DELETE` request and use some JSON as the HTTP body.
The second commit in this pull request adds a `requestWithMethod:path:jsonBody` method that allows doing just that. While it would be possible to create my own `NSMutableURLRequest` outside of `AFHTTPClient`, that means I don't get the goodness of resolving the path to a `URL`, and I can't apply the default headers. (As a side note, `defaultHeaders` is a `property` in `AFHTTPClient.m`, but is not declared as one in `AFHTTPClient.h`. Was that intentional?)

Thanks, and bear with me as this is my first pull request I'm sending...
- Mike
