### PR TITLE
Fixing a couple of issues in the JSON and XML operation classes

### DIFF
--- a/AFNetworking/AFJSONRequestOperation.m
+++ b/AFNetworking/AFJSONRequestOperation.m
@@ -65,9 +65,7 @@ static dispatch_queue_t json_request_operation_processing_queue() {
             }
         } else {
             dispatch_async(json_request_operation_processing_queue(), ^(void) {
-                NSError *error = nil;
                 id JSON = operation.responseJSON;
-                operation.error = error;
                 
                 dispatch_async(dispatch_get_main_queue(), ^(void) {
                     if (operation.error) {

--- a/AFNetworking/AFXMLRequestOperation.m
+++ b/AFNetworking/AFXMLRequestOperation.m
@@ -70,7 +70,9 @@ static dispatch_queue_t xml_request_operation_processing_queue() {
         } else {
             NSXMLParser *XMLParser = operation.responseXMLParser;
             if (success) {
-                success(operation.request, operation.response, XMLParser);
+                dispatch_async(dispatch_get_main_queue(), ^(void) {
+                    success(operation.request, operation.response, XMLParser);
+                });
             }
         }
     };


### PR DESCRIPTION
AFJSONRequestOperation.m:
  -Fixing an issue where all JSON parse errors are ignored. The operation.error
  was always being set to nil no what responseJSON set the error property to.

AFXMLRequestOperation.m:
  -Making sure the success callback for the iOS case is run on the main thread
