### PR TITLE
Return JSON error or HTTP error.

### DIFF
--- a/AFNetworking/AFJSONRequestOperation.m
+++ b/AFNetworking/AFJSONRequestOperation.m
@@ -37,7 +37,7 @@ static dispatch_queue_t json_request_operation_processing_queue() {
 
 @interface AFJSONRequestOperation ()
 @property (readwrite, nonatomic, retain) id responseJSON;
-@property (readwrite, nonatomic, retain) NSError *error;
+@property (readwrite, nonatomic, retain) NSError *JSONError;
 
 + (NSSet *)defaultAcceptableContentTypes;
 + (NSSet *)defaultAcceptablePathExtensions;
@@ -45,7 +45,7 @@ static dispatch_queue_t json_request_operation_processing_queue() {
 
 @implementation AFJSONRequestOperation
 @synthesize responseJSON = _responseJSON;
-@synthesize error = _JSONError;
+@synthesize JSONError = _JSONError;
 
 + (AFJSONRequestOperation *)JSONRequestOperationWithRequest:(NSURLRequest *)urlRequest
                                                     success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, id JSON))success
@@ -129,10 +129,18 @@ static dispatch_queue_t json_request_operation_processing_queue() {
 #endif
         }
         
-        self.error = error;
+        self.JSONError = error;
     }
     
     return _responseJSON;
+}
+
+- (NSError *)error {
+    if (_JSONError) {
+        return _JSONError;
+    } else {
+        return [super error];
+    }
 }
 
 #pragma mark - AFHTTPClientOperation


### PR DESCRIPTION
Failure callback wasn't getting called for non-2xx responses. The error property of AFJSONRequestOperation seemed to be hiding the HTTP error property of the superclass. 
