### PR TITLE
Ignore Content-Type for 204 No Content response.

### DIFF
--- a/AFNetworking/AFHTTPRequestOperation.m
+++ b/AFNetworking/AFHTTPRequestOperation.m
@@ -78,7 +78,7 @@
 }
 
 - (BOOL)hasAcceptableContentType {
-    return !self.acceptableContentTypes || [self.response statusCode] == 204 || [self.acceptableContentTypes containsObject:[self.response MIMEType]];
+    return !self.acceptableContentTypes || [self.responseData length] == 0 || [self.acceptableContentTypes containsObject:[self.response MIMEType]];
 }
 
 #pragma mark - AFHTTPClientOperation


### PR DESCRIPTION
Bumped into this while upgrading from 0.5.0: integrating with a service that serves 204 No Content as text/plain even though the client requests application/json. 0.5.0 allowed text/plain for JSON requests, 0.7.0 is a bit stricter. Seems safe to ignore content type when there is no content so that AFHTTPRequestOperation doesn't treat it as an error.
