### PR TITLE
Check only content length, ignore status code.

### DIFF
--- a/AFNetworking/AFHTTPRequestOperation.m
+++ b/AFNetworking/AFHTTPRequestOperation.m
@@ -75,7 +75,7 @@
 }
 
 - (BOOL)hasContent {
-    return [self.responseData length] > 0 || [self.response statusCode] != 204;
+    return [self.responseData length] > 0;
 }
 
 - (BOOL)hasAcceptableStatusCode {


### PR DESCRIPTION
Super trivial change to hasContent to make any response with non-0 content length return true for `-(BOOL)hasContent`. `-(NSError *)error` only checks response response mime-type if hasContent true, so this change allows any response with no content to skip mime type checking.

Per discussion here: https://github.com/gowalla/AFNetworking/pull/88#issuecomment-2486149.
