### PR TITLE
In iOS Example, added call to super in -[SpotTableViewCell prepareForReuse]

### DIFF
--- a/iOS Example/Classes/Views/SpotTableViewCell.m
+++ b/iOS Example/Classes/Views/SpotTableViewCell.m
@@ -69,6 +69,7 @@
 #pragma mark - UITableViewCell
 
 - (void)prepareForReuse {
+    [super prepareForReuse];
     [self.imageView cancelImageRequestOperation];
     self.textLabel.text = nil;
     self.detailTextLabel.text = nil;


### PR DESCRIPTION
In the iOS Example, the SpotTableViewCell class overrides -[UITableViewCell prepareForReuse] .  I wasn't familiar with that method, so I looked it up.  

It appears that Apple's UITableViewCell documentation requires that super is called when overriding this method.
http://developer.apple.com/library/IOS/#documentation/UIKit/Reference/UITableViewCell_Class/Reference/Reference.html#//apple_ref/occ/instm/UITableViewCell/prepareForReuse

Not sure if it's purposefully omitted here in the example or not.  If not, here's a version with the call to super added.
