### PR TITLE
Replace custom base-URL method with standard NSURL one

### DIFF
--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -81,16 +81,6 @@ static NSString * AFBase64EncodedStringFromString(NSString *string) {
     return [[[NSString alloc] initWithData:mutableData encoding:NSASCIIStringEncoding] autorelease];
 }
 
-static NSURL * AFURLWithPathRelativeToURL(NSString *path, NSURL *baseURL) {
-    NSURL *url = [baseURL URLByAppendingPathComponent:[path stringByTrimmingCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@"/"]]];
-    NSString *URLString = [url absoluteString];
-    if ([path hasSuffix:@"/"]) {
-        URLString = [URLString stringByAppendingString:@"/"];
-    }
-    
-    return [NSURL URLWithString:URLString];
-}
-
 static NSString * AFURLEncodedStringFromString(NSString *string) {
     static NSString * const kAFLegalCharactersToBeEscaped = @"?!@#$^&%*+,:;='\"`<>()[]{}/\\|~ ";
     
@@ -249,7 +239,8 @@ static NSString * AFPropertyListStringFromParameters(NSDictionary *parameters) {
                                       path:(NSString *)path 
                                 parameters:(NSDictionary *)parameters 
 {	
-    NSURL *url = AFURLWithPathRelativeToURL(path, self.baseURL);
+    NSURL *url = [NSURL URLWithString:path relativeToURL:self.baseURL];
+
 	NSMutableURLRequest *request = [[[NSMutableURLRequest alloc] initWithURL:url] autorelease];
     [request setHTTPMethod:method];
     [request setAllHTTPHeaderFields:self.defaultHeaders];


### PR DESCRIPTION
Unless I'm missing something, I don't see the need for `AFURLWithPathRelativeToURL()`. It seems like `[NSURL +URLWithString:relativeToURL:]` does the same thing, but more correctly.
