### PR TITLE
Adding code to set the responceImage to the correct size.

### DIFF
--- a/AFNetworking/AFImageRequestOperation.m
+++ b/AFNetworking/AFImageRequestOperation.m
@@ -212,13 +212,11 @@ static dispatch_queue_t image_request_operation_processing_queue() {
 #elif __MAC_OS_X_VERSION_MIN_REQUIRED 
 - (NSImage *)responseImage {
     if (!_responseImage && [self isFinished]) {
-        self.responseImage = [[[NSImage alloc] initWithData:self.responseData] autorelease];
-        
-        // The size of an NSImage can sometimes be incorrect, so make a CGImage which is more
-        // like a single pixel-based representation so it is the correct size, and then
-        // set the size based on what the CGImage says it is.
-        CGImageRef cgimage = [[NSBitmapImageRep imageRepWithData:self.responseData] CGImage];
-        [self.responseImage setSize:NSMakeSize(CGImageGetWidth(cgimage), CGImageGetHeight(cgimage))];
+        // Ensure that the image is set to it's correct pixel width and height
+        NSBitmapImageRep *bitimage = [[NSBitmapImageRep alloc] initWithData:self.responseData];
+        self.responseImage = [[[NSImage alloc] initWithSize:NSMakeSize([bitimage pixelsWide], [bitimage pixelsHigh])] autorelease];
+        [self.responseImage addRepresentation:bitimage];
+        [bitimage release];
     }
     
     return _responseImage;


### PR DESCRIPTION
I've been working on a Dribbble framework and I just switched over to using AFNetworking and it's working great! One issue I ran into with my networking code, and now with AFNetworking, is that sometimes `NSImage` displays an image at the wrong size. The solution I found was to get a `CGImage` then set the width and height of the `NSImage` to what the `CGImage` says it is.

Some context from the docs on why this is happening and why the CGImage fixes it:

> An NSImage is potentially resolution independent, and may have representations that allow it to draw well in many contexts. A CGImage is more like a single pixel-based representation. This method produces a snapshot of how the NSImage would draw if it was asked to draw in the proposed rectangle in the graphics context.

Unfortunately the NSImage is not drawing well. Here is an example of what I'm seeing before and after this change:

![](http://f.cl.ly/items/3h1E1C0d2L2z1Y2C2V1e/beforeafter.png)

Here is a link to this test app: http://cl.ly/BtrZ

These are the urls from the Dribbble API I used for testing:
- http://dribbble.com/system/users/13774/screenshots/322302/_87_teaser.jpg?1321541774
- http://dribbble.com/system/users/4454/screenshots/322241/max100_20_teaser.jpg?1321537468

I haven't seen this issue with `UIImage`.
