### PR TITLE
Raise an exception if JSON generation capability doesn't exist

### DIFF
--- a/AFNetworking/AFJSONUtilities.h
+++ b/AFNetworking/AFJSONUtilities.h
@@ -82,7 +82,7 @@ static NSData * AFJSONEncode(id object, NSError **error) {
         [invocation getReturnValue:&data];
     } else {
         NSDictionary *userInfo = [NSDictionary dictionaryWithObject:NSLocalizedString(@"Please either target a platform that supports NSJSONSerialization or add one of the following libraries to your project: JSONKit, SBJSON, or YAJL", nil) forKey:NSLocalizedRecoverySuggestionErrorKey];
-        [NSException exceptionWithName:NSInternalInconsistencyException reason:NSLocalizedString(@"No JSON generation functionality available", nil) userInfo:userInfo];
+        [[NSException exceptionWithName:NSInternalInconsistencyException reason:NSLocalizedString(@"No JSON generation functionality available", nil) userInfo:userInfo] raise];
     }
 
     return data;


### PR DESCRIPTION
`AFJSONEncode()` will create an exception if it cannot find a way to generate JSON, but it never raises the exception.
