### PR TITLE
fix unnecessary up-cast as discussed in #122

### DIFF
--- a/AFNetworking/AFJSONRequestOperation.h
+++ b/AFNetworking/AFJSONRequestOperation.h
@@ -62,7 +62,7 @@
  @return A new JSON request operation
  */
 + (AFJSONRequestOperation *)JSONRequestOperationWithRequest:(NSURLRequest *)urlRequest
-                                                    success:(void (^)(NSURLRequest *request, NSURLResponse *response, id JSON))success 
-                                                    failure:(void (^)(NSURLRequest *request, NSURLResponse *response, NSError *error, id JSON))failure;
+                                                    success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, id JSON))success 
+                                                    failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, id JSON))failure;
 
 @end

--- a/AFNetworking/AFJSONRequestOperation.m
+++ b/AFNetworking/AFJSONRequestOperation.m
@@ -45,8 +45,8 @@ static dispatch_queue_t json_request_operation_processing_queue() {
 @synthesize JSONError = _JSONError;
 
 + (AFJSONRequestOperation *)JSONRequestOperationWithRequest:(NSURLRequest *)urlRequest
-                                                    success:(void (^)(NSURLRequest *request, NSURLResponse *response, id JSON))success 
-                                                    failure:(void (^)(NSURLRequest *request, NSURLResponse *response, NSError *error, id JSON))failure
+                                                    success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, id JSON))success 
+                                                    failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, id JSON))failure
 {
     AFJSONRequestOperation *requestOperation = [[[self alloc] initWithRequest:urlRequest] autorelease];
     [requestOperation setCompletionBlockWithSuccess:^(AFHTTPRequestOperation *operation, id responseObject) {


### PR DESCRIPTION
`AFHTTPRequestOperation.response` is defined as `NSURLHTTPResponse`. It's not good to upcast to `NSURLResponse` and lose HTTP speciality.
