### PR TITLE
NSURLConnection premature release

### DIFF
--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -467,7 +467,7 @@ static inline NSString * AFMultipartFormFinalBoundary() {
     NSURLResponse *response = nil;
     NSData *data = [NSURLConnection sendSynchronousRequest:request returningResponse:&response error:error];
     
-    if (response && !*error) {
+    if (response && !error) {
         [self appendPartWithFileData:data name:name fileName:[response suggestedFilename] mimeType:[response MIMEType]];
         
         return YES;


### PR DESCRIPTION
Fixes a CFNetwork problem that occurred at least on Mac OS X. I don't know how this didn't affect anyone else. Half the time my requests would hang up the thread and log CFNetwork Internal error forcing me to hard reboot my computer.
