### PR TITLE
Added timeoutInterval to AFHTTPClient

### DIFF
--- a/AFNetworking/AFHTTPClient.h
+++ b/AFNetworking/AFHTTPClient.h
@@ -107,6 +107,7 @@ extern NSString * AFQueryStringFromParametersWithEncoding(NSDictionary *paramete
     NSMutableArray *_registeredHTTPOperationClassNames;
     NSMutableDictionary *_defaultHeaders;
     NSOperationQueue *_operationQueue;
+    NSTimeInterval _timeoutInterval;
 }
 
 ///---------------------------------------
@@ -132,6 +133,11 @@ extern NSString * AFQueryStringFromParametersWithEncoding(NSDictionary *paramete
  The operation queue which manages operations enqueued by the HTTP client.
  */
 @property (readonly, nonatomic, retain) NSOperationQueue *operationQueue;
+
+/**
+ Timeout for NSURLRequests
+ */
+@property (nonatomic, assign) NSTimeInterval timeoutInterval;
 
 ///---------------------------------------------
 /// @name Creating and Initializing HTTP Clients

--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -133,6 +133,7 @@ static NSString * AFPropertyListStringFromParameters(NSDictionary *parameters) {
 @synthesize registeredHTTPOperationClassNames = _registeredHTTPOperationClassNames;
 @synthesize defaultHeaders = _defaultHeaders;
 @synthesize operationQueue = _operationQueue;
+@synthesize timeoutInterval = _timeoutInterval;
 
 + (AFHTTPClient *)clientWithBaseURL:(NSURL *)url {
     return [[[self alloc] initWithBaseURL:url] autorelease];
@@ -233,6 +234,9 @@ static NSString * AFPropertyListStringFromParameters(NSDictionary *parameters) {
 	NSMutableURLRequest *request = [[[NSMutableURLRequest alloc] initWithURL:url] autorelease];
     [request setHTTPMethod:method];
     [request setAllHTTPHeaderFields:self.defaultHeaders];
+    if (self.timeoutInterval > 0) {
+        [request setTimeoutInterval:self.timeoutInterval];
+    }
 	
     if (parameters) {        
         if ([method isEqualToString:@"GET"]) {


### PR DESCRIPTION
I exposed the NSTimeInterval timeoutInterval property of NSURLRequest to AFHTTPClient to make it accessible in AFHTTPClient subclasses.
