### PR TITLE
Fix issue with multipart boundaries.

### DIFF
--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -381,6 +381,10 @@ static NSString * AFPropertyListStringFromParameters(NSDictionary *parameters) {
 
 #pragma mark -
 
+static inline NSString * AFMultipartFormInitialBoundary() {
+    return [NSString stringWithFormat:@"--%@%@", kAFMultipartFormBoundary, kAFMultipartFormLineDelimiter];
+}
+
 static inline NSString * AFMultipartFormEncapsulationBoundary() {
     return [NSString stringWithFormat:@"%@--%@%@", kAFMultipartFormLineDelimiter, kAFMultipartFormBoundary, kAFMultipartFormLineDelimiter];
 }
@@ -424,7 +428,11 @@ static inline NSString * AFMultipartFormFinalBoundary() {
 #pragma mark - AFMultipartFormData
 
 - (void)appendPartWithHeaders:(NSDictionary *)headers body:(NSData *)body {
-    [self appendString:AFMultipartFormEncapsulationBoundary()];
+    if ([self.mutableData length] == 0) {
+        [self appendString:AFMultipartFormInitialBoundary()];
+    } else {
+        [self appendString:AFMultipartFormEncapsulationBoundary()];
+    }
     
     for (NSString *field in [headers allKeys]) {
         [self appendString:[NSString stringWithFormat:@"%@: %@%@", field, [headers valueForKey:field], kAFMultipartFormLineDelimiter]];


### PR DESCRIPTION
The first boundary should not have a preceeding newline. This causes
some multipart parsers to miss the inital boundary.

An example of a parser facing this issue is https://github.com/felixge/node-formidable.

Let me know if you need anything else from me for this, or changes to the code, etc.
