### PR TITLE
UIImageView+AFNetworking success callback runs after setting the image

### DIFF
--- a/AFNetworking/UIImageView+AFNetworking.m
+++ b/AFNetworking/UIImageView+AFNetworking.m
@@ -102,16 +102,16 @@ static char kAFImageRequestOperationObjectKey;
         
         AFImageRequestOperation *requestOperation = [[[AFImageRequestOperation alloc] initWithRequest:urlRequest] autorelease];
         [requestOperation setCompletionBlockWithSuccess:^(AFHTTPRequestOperation *operation, id responseObject) {
-            if (success) {
-                success(operation.request, operation.response, responseObject);
-            }
-            
             if ([[urlRequest URL] isEqual:[[self.af_imageRequestOperation request] URL]]) {
                 self.image = responseObject;
             } else {
                 self.image = placeholderImage;
             }
-            
+
+            if (success) {
+                success(operation.request, operation.response, responseObject);
+            }
+
             [[AFImageCache sharedImageCache] cacheImageData:operation.responseData forURL:[urlRequest URL] cacheName:nil];
         } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
             if (failure) {


### PR DESCRIPTION
I've moved the success callback below the assignment of the retrieved image. 

This allows the consumer to manipulate the returned image and apply it instead of the image returned from the web, and is symmetrical with the order of operations in case the image is cached. 
