### PR TITLE
Updated "File Upload with Progress Callback" code snippet in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,13 +73,15 @@ NSOperationQueue *queue = [[[NSOperationQueue alloc] init] autorelease];
 ### File Upload with Progress Callback
 
 ``` objective-c
+NSURL *url = [NSURL URLWithString:@"http://api-base-url.com"];
+AFHTTPClient *httpClient = [[AFHTTPClient alloc] initWithBaseURL:url];
 NSData *imageData = UIImageJPEGRepresentation([UIImage imageNamed:@"avatar.jpg"], 0.5);
-NSMutableURLRequest *request = [[AFHTTPClient sharedClient] multipartFormRequestWithMethod:@"POST" path:@"/upload" parameters:nil constructingBodyWithBlock: ^(id <AFMultipartFormData>formData) {
-  [formData appendPartWithFileData:data mimeType:@"image/jpeg" name:@"avatar"];
+NSMutableURLRequest *request = [httpClient multipartFormRequestWithMethod:@"POST" path:@"/upload" parameters:nil constructingBodyWithBlock: ^(id <AFMultipartFormData>formData) {
+    [formData appendPartWithFileData:imageData name:@"avatar" fileName:@"avatar.jpg" mimeType:@"image/jpeg"];
 }];
 
 AFHTTPRequestOperation *operation = [[[AFHTTPRequestOperation alloc] initWithRequest:request] autorelease];
-[operation setUploadProgressBlock:^(NSUInteger totalBytesWritten, NSUInteger totalBytesExpectedToWrite) {
+[operation setUploadProgressBlock:^(NSInteger bytesWritten, NSInteger totalBytesWritten, NSInteger totalBytesExpectedToWrite) {
     NSLog(@"Sent %d of %d bytes", totalBytesWritten, totalBytesExpectedToWrite);
 }];
 


### PR DESCRIPTION
- Resolved a mismatch between variable names imageData and data.
- Updated to the current appendPartWithFileData:name:fileName:mimeType: method signature.
- Updated to the current upload progress block signature ^(NSInteger bytesWritten, NSInteger totalBytesWritten, NSInteger totalBytesExpectedToWrite) {...}
- Added two lines that create an ad-hoc AFHTTPClient instance, instead of referencing a hypothetical [AFHTTPClient sharedClient] singleton, which new users might be confused by when they're trying to get the example working.
