### PR TITLE
fix crash-inducing finish/cancel race condition in AFURLConnectionOperation

### DIFF
--- a/AFNetworking/AFURLConnectionOperation.m
+++ b/AFNetworking/AFURLConnectionOperation.m
@@ -54,7 +54,7 @@ static inline NSString * AFKeyPathFromOperationState(AFOperationState state) {
 @interface AFURLConnectionOperation ()
 @property (readwrite, nonatomic, assign) AFOperationState state;
 @property (readwrite, nonatomic, assign, getter = isCancelled) BOOL cancelled;
-@property (readwrite, nonatomic, assign) NSURLConnection *connection;
+@property (readwrite, atomic, assign) NSURLConnection *connection;
 @property (readwrite, nonatomic, retain) NSURLRequest *request;
 @property (readwrite, nonatomic, retain) NSURLResponse *response;
 @property (readwrite, nonatomic, retain) NSError *error;
@@ -289,6 +289,7 @@ static inline NSString * AFKeyPathFromOperationState(AFOperationState state) {
 
 - (void)finish {
     self.state = AFHTTPOperationFinishedState;
+    self.connection = nil;
 }
 
 - (void)cancel {


### PR DESCRIPTION
When a connection on the networking thread calls `finish`, it should (atomically) set the `connection` property to nil so that calls to `cancel` from the main thread are guaranteed to reach a live object. Elsewise, the `cancel` message can be sent to a deallocated (invalid) connection object when the connection is both finished and cancelled at nearly the same time.
