### PR TITLE
Scaling in AFImageCache

### DIFF
--- a/AFNetworking/AFImageCache.h
+++ b/AFNetworking/AFImageCache.h
@@ -32,6 +32,13 @@
  */
 @interface AFImageCache : NSCache
 
+#if __IPHONE_OS_VERSION_MIN_REQUIRED
+/**
+ The scale factor used when interpreting the cached image data. Specifying a scale factor of 1.0 results in an image whose size matches the pixel-based dimensions of the image. Applying a different scale factor changes the size of the image as reported by the size property. This is set to the value of `[[UIScreen mainScreen] scale]` by default, which automatically scales images for retina displays, for instance.
+ */
+@property (nonatomic, assign) CGFloat imageScale;
+#endif
+
 /**
  Returns the shared image cache object for the system.
  

--- a/AFNetworking/AFImageCache.m
+++ b/AFNetworking/AFImageCache.m
@@ -28,6 +28,10 @@ static inline NSString * AFImageCacheKeyFromURLAndCacheName(NSURL *url, NSString
 
 @implementation AFImageCache
 
+#if __IPHONE_OS_VERSION_MIN_REQUIRED
+@synthesize imageScale = _imageScale;
+#endif
+
 + (AFImageCache *)sharedImageCache {
     static AFImageCache *_sharedImageCache = nil;
     static dispatch_once_t oncePredicate;
@@ -39,11 +43,26 @@ static inline NSString * AFImageCacheKeyFromURLAndCacheName(NSURL *url, NSString
     return _sharedImageCache;
 }
 
+- (id)init {
+	self = [super init];
+	if (self) {
+		#if __IPHONE_OS_VERSION_MIN_REQUIRED
+		self.imageScale = [[UIScreen mainScreen] scale];
+		#endif
+	}
+	
+	return self;
+}
+
 #if __IPHONE_OS_VERSION_MIN_REQUIRED
 - (UIImage *)cachedImageForURL:(NSURL *)url
                      cacheName:(NSString *)cacheName
 {
-    return [UIImage imageWithData:[self objectForKey:AFImageCacheKeyFromURLAndCacheName(url, cacheName)]];
+	UIImage *image = [UIImage imageWithData:[self objectForKey:AFImageCacheKeyFromURLAndCacheName(url, cacheName)]];
+	if (image) {
+		return [UIImage imageWithCGImage:[image CGImage] scale:self.imageScale orientation:image.imageOrientation];
+	}
+    return image;
 }
 #elif __MAC_OS_X_VERSION_MIN_REQUIRED
 - (NSImage *)cachedImageForURL:(NSURL *)url


### PR DESCRIPTION
I found inconsistency in UIImageView+AFNetworking in loading image from network and from cache. When image is loaded from network, it is scaled, but when it is loaded from cache, it does not. This pull request only added scaling to AFImageCache from AFImageRequestOperation.
