### PR TITLE
Make JSON requests allow text/javascript content

### DIFF
--- a/AFNetworking/AFJSONRequestOperation.m
+++ b/AFNetworking/AFJSONRequestOperation.m
@@ -63,7 +63,7 @@ static dispatch_queue_t json_request_operation_processing_queue() {
 }
 
 + (NSSet *)defaultAcceptableContentTypes {
-    return [NSSet setWithObjects:@"application/json", @"text/json", nil];
+    return [NSSet setWithObjects:@"application/json", @"text/json", @"text/javascript", nil];
 }
 
 + (NSSet *)defaultAcceptablePathExtensions {


### PR DESCRIPTION
The Facebook API returns JSON with a Content-Type of `text/javascript`. This makes `AFJSONRequestOperation` error, since it's expecting `text/json` or `application/json`. Seems reasonable for `AFJSONRequestOperation` to accept `text/javascript`, since JSON is a subset of JavaScript.
