### PR TITLE
Should check for NSJSON first, since it's the default iOS JSON library

### DIFF
--- a/AFNetworking/AFJSONUtilities.h
+++ b/AFNetworking/AFJSONUtilities.h
@@ -32,7 +32,19 @@ static NSData * AFJSONEncode(id object, NSError **error) {
     id _NSJSONSerializationClass = NSClassFromString(@"NSJSONSerialization");
     SEL _NSJSONSerializationSelector = NSSelectorFromString(@"dataWithJSONObject:options:error:");
     
-    if (_JSONKitSelector && [object respondsToSelector:_JSONKitSelector]) {
+    if (_NSJSONSerializationClass && [_NSJSONSerializationClass respondsToSelector:_NSJSONSerializationSelector]) { 
+        NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:[_NSJSONSerializationClass methodSignatureForSelector:_NSJSONSerializationSelector]];
+        invocation.target = _NSJSONSerializationClass;
+        invocation.selector = _NSJSONSerializationSelector;
+        
+        [invocation setArgument:&object atIndex:2]; // arguments 0 and 1 are self and _cmd respectively, automatically set by NSInvocation
+        NSUInteger writeOptions = 0;
+        [invocation setArgument:&writeOptions atIndex:3];
+        [invocation setArgument:error atIndex:4];
+        
+        [invocation invoke];
+        [invocation getReturnValue:&data];
+    } else if (_JSONKitSelector && [object respondsToSelector:_JSONKitSelector]) {
         NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:[object methodSignatureForSelector:_JSONKitSelector]];
         invocation.target = object;
         invocation.selector = _JSONKitSelector;
@@ -68,18 +80,6 @@ static NSData * AFJSONEncode(id object, NSError **error) {
         @catch (NSException *exception) {
             *error = [[[NSError alloc] initWithDomain:NSStringFromClass([exception class]) code:0 userInfo:[exception userInfo]] autorelease];
         }
-    } else if (_NSJSONSerializationClass && [_NSJSONSerializationClass respondsToSelector:_NSJSONSerializationSelector]) { 
-        NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:[_NSJSONSerializationClass methodSignatureForSelector:_NSJSONSerializationSelector]];
-        invocation.target = _NSJSONSerializationClass;
-        invocation.selector = _NSJSONSerializationSelector;
-        
-        [invocation setArgument:&object atIndex:2]; // arguments 0 and 1 are self and _cmd respectively, automatically set by NSInvocation
-        NSUInteger writeOptions = 0;
-        [invocation setArgument:&writeOptions atIndex:3];
-        [invocation setArgument:error atIndex:4];
-        
-        [invocation invoke];
-        [invocation getReturnValue:&data];
     } else {
         NSDictionary *userInfo = [NSDictionary dictionaryWithObject:NSLocalizedString(@"Please either target a platform that supports NSJSONSerialization or add one of the following libraries to your project: JSONKit, SBJSON, or YAJL", nil) forKey:NSLocalizedRecoverySuggestionErrorKey];
         [[NSException exceptionWithName:NSInternalInconsistencyException reason:NSLocalizedString(@"No JSON generation functionality available", nil) userInfo:userInfo] raise];
@@ -97,8 +97,20 @@ static id AFJSONDecode(NSData *data, NSError **error) {
     
     id _NSJSONSerializationClass = NSClassFromString(@"NSJSONSerialization");
     SEL _NSJSONSerializationSelector = NSSelectorFromString(@"JSONObjectWithData:options:error:");
-    
-    if (_JSONKitSelector && [data respondsToSelector:_JSONKitSelector]) {
+   
+    if (_NSJSONSerializationClass && [_NSJSONSerializationClass respondsToSelector:_NSJSONSerializationSelector]) { 
+        NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:[_NSJSONSerializationClass methodSignatureForSelector:_NSJSONSerializationSelector]];
+        invocation.target = _NSJSONSerializationClass;
+        invocation.selector = _NSJSONSerializationSelector;
+        
+        [invocation setArgument:&data atIndex:2]; // arguments 0 and 1 are self and _cmd respectively, automatically set by NSInvocation
+        NSUInteger readOptions = 0;
+        [invocation setArgument:&readOptions atIndex:3];
+        [invocation setArgument:error atIndex:4];
+        
+        [invocation invoke];
+        [invocation getReturnValue:&JSON];
+    } else if (_JSONKitSelector && [data respondsToSelector:_JSONKitSelector]) {
         NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:[data methodSignatureForSelector:_JSONKitSelector]];
         invocation.target = data;
         invocation.selector = _JSONKitSelector;
@@ -126,18 +138,6 @@ static id AFJSONDecode(NSData *data, NSError **error) {
         NSUInteger yajlParserOptions = 0;
         [invocation setArgument:&yajlParserOptions atIndex:2]; // arguments 0 and 1 are self and _cmd respectively, automatically set by NSInvocation
         [invocation setArgument:error atIndex:3];
-        
-        [invocation invoke];
-        [invocation getReturnValue:&JSON];
-    } else if (_NSJSONSerializationClass && [_NSJSONSerializationClass respondsToSelector:_NSJSONSerializationSelector]) { 
-        NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:[_NSJSONSerializationClass methodSignatureForSelector:_NSJSONSerializationSelector]];
-        invocation.target = _NSJSONSerializationClass;
-        invocation.selector = _NSJSONSerializationSelector;
-        
-        [invocation setArgument:&data atIndex:2]; // arguments 0 and 1 are self and _cmd respectively, automatically set by NSInvocation
-        NSUInteger readOptions = 0;
-        [invocation setArgument:&readOptions atIndex:3];
-        [invocation setArgument:error atIndex:4];
         
         [invocation invoke];
         [invocation getReturnValue:&JSON];


### PR DESCRIPTION
When encoding and decoding JSON, we should check to see if NSJSONSerialization exists first since it's the default JSON library from iOS 5 and onwards. This will ensure that AFNetworking won't be effected by bugs in third party libraries, or bugs such as bug #152.
