### PR TITLE
Cancel request if there is an authentication challenge but no credentials for it

### DIFF
--- a/AFNetworking/AFURLConnectionOperation.m
+++ b/AFNetworking/AFURLConnectionOperation.m
@@ -337,6 +337,8 @@ didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge
         
         if (credential) {
             [[challenge sender] useCredential:credential forAuthenticationChallenge:challenge];
+        } else {
+            [[challenge sender] continueWithoutCredentialForAuthenticationChallenge:challenge];
         }
     } else {
         [[challenge sender] continueWithoutCredentialForAuthenticationChallenge:challenge];


### PR DESCRIPTION
If no authenticationBlock is provided and a credential can't be found, call `continueWithoutCredentialForAuthenticationChallenge`. Otherwise, `connectionDidFinishLoading:` or `connection:didFailWithError:` never get called
