### PR TITLE
"Content-disposition" should be "form-data" for a single file.

### DIFF
--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -451,7 +451,7 @@ static inline NSString * AFMultipartFormFinalBoundary() {
 
 - (void)appendPartWithFileData:(NSData *)data name:(NSString *)name fileName:(NSString *)fileName mimeType:(NSString *)mimeType {    
     NSMutableDictionary *mutableHeaders = [NSMutableDictionary dictionary];
-    [mutableHeaders setValue:[NSString stringWithFormat:@"file; name=\"%@\"; filename=\"%@\"", name, fileName] forKey:@"Content-Disposition"];
+    [mutableHeaders setValue:[NSString stringWithFormat:@"form-data; name=\"%@\"; filename=\"%@\"", name, fileName] forKey:@"Content-Disposition"];
     [mutableHeaders setValue:mimeType forKey:@"Content-Type"];
     
     [self appendPartWithHeaders:mutableHeaders body:data];


### PR DESCRIPTION
The `Content-disposition` should only be `file` if one of multiple files in a subpart. See the end of http://www.w3.org/TR/html4/interact/forms.html, section 17.13.4, for details.
Without this patch, we experienced Tornado failing to accept a file upload.
