### PR TITLE
(Potentially) improving AFImageCache performance 

### DIFF
--- a/AFNetworking/AFImageCache.h
+++ b/AFNetworking/AFImageCache.h
@@ -63,13 +63,13 @@
 #endif
 
 /**
- Stores image data into cache, associated with a given URL and cache name.
+ Stores image into cache, associated with a given URL and cache name.
  
- @param imageData The image data to be stored in cache.
+ @param image The image to be stored in cache.
  @param url The URL to be associated with the image.
  @param cacheName The cache name to be associated with the image in the cache. This allows for multiple versions of an image to be associated for a single URL, such as image thumbnails, for instance.
  */
-- (void)cacheImageData:(NSData *)imageData
+- (void)cacheImage:(id)image
                 forURL:(NSURL *)url
              cacheName:(NSString *)cacheName;
 

--- a/AFNetworking/AFImageCache.m
+++ b/AFNetworking/AFImageCache.m
@@ -59,7 +59,7 @@ static inline NSString * AFImageCacheKeyFromURLAndCacheName(NSURL *url, NSString
 - (UIImage *)cachedImageForURL:(NSURL *)url
                      cacheName:(NSString *)cacheName
 {
-	UIImage *image = [UIImage imageWithData:[self objectForKey:AFImageCacheKeyFromURLAndCacheName(url, cacheName)]];
+	UIImage *image = [self objectForKey:AFImageCacheKeyFromURLAndCacheName(url, cacheName)];
 	if (image) {
 		return [UIImage imageWithCGImage:[image CGImage] scale:self.imageScale orientation:image.imageOrientation];
 	}
@@ -69,15 +69,15 @@ static inline NSString * AFImageCacheKeyFromURLAndCacheName(NSURL *url, NSString
 - (NSImage *)cachedImageForURL:(NSURL *)url
                      cacheName:(NSString *)cacheName
 {
-    return [[[NSImage alloc] initWithData:[self objectForKey:AFImageCacheKeyFromURLAndCacheName(url, cacheName)]] autorelease];
+    return [self objectForKey:AFImageCacheKeyFromURLAndCacheName(url, cacheName)];
 }
 #endif
 
-- (void)cacheImageData:(NSData *)imageData
+- (void)cacheImage:(id)image
                 forURL:(NSURL *)url
              cacheName:(NSString *)cacheName
 {
-    [self setObject:[NSPurgeableData dataWithData:imageData] forKey:AFImageCacheKeyFromURLAndCacheName(url, cacheName)];
+    [self setObject:image forKey:AFImageCacheKeyFromURLAndCacheName(url, cacheName)];
 }
 
 @end

--- a/AFNetworking/UIImageView+AFNetworking.m
+++ b/AFNetworking/UIImageView+AFNetworking.m
@@ -112,7 +112,7 @@ static char kAFImageRequestOperationObjectKey;
                 success(operation.request, operation.response, responseObject);
             }
 
-            [[AFImageCache sharedImageCache] cacheImageData:operation.responseData forURL:[urlRequest URL] cacheName:nil];
+            [[AFImageCache sharedImageCache] cacheImage:responseObject forURL:[urlRequest URL] cacheName:nil];
         } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
             if (failure) {
                 failure(operation.request, operation.response, error);


### PR DESCRIPTION
Hiya,

I'll preface this by saying that I am not sure if this is a valid change to be making to AFNetworking. My hesitation stems from the fact that the code was not like this to begin with and surely I'm not the first person to have thought of this "improvement". :-)

With that out of the way; I've removed a level of indirection wherein the image _data_ is being cached by `AFImageCache` rather than the image objects themselves (`UIImage` or `NSImage`, whichever takes your fancy). I found that caching the image data meant having to re-render the image to a bitmap each time an image was pulled out of the cache and displayed. Caching the images themselves meant that they only needed to be "rendered" into a bitmap once.

This improvements performance quite substantially, especially on iOS devices. A quick test (loading an image 100 times) shows a tenfold speed improvement by caching the image objects rather than their backing data.

Is there something (obvious|subtle) that I am missing? Why is the code not already like this?
