### PR TITLE
Fix for multiple values in request "Accept" header

### DIFF
--- a/AFNetworking/AFImageRequestOperation.m
+++ b/AFNetworking/AFImageRequestOperation.m
@@ -194,7 +194,9 @@ static dispatch_queue_t image_request_operation_processing_queue() {
 #pragma mark - AFHTTPClientOperation
 
 + (BOOL)canProcessRequest:(NSURLRequest *)request {
-    return [[self defaultAcceptableContentTypes] containsObject:[request valueForHTTPHeaderField:@"Accept"]] || [[self defaultAcceptablePathExtensions] containsObject:[[request URL] pathExtension]];
+    NSSet *requestAceptableTypes = [NSSet setWithArray:[[request valueForHTTPHeaderField:@"Accept"] componentsSeparatedByString:@","]];
+    BOOL canProcess = [[self defaultAcceptableContentTypes] intersectsSet:requestAceptableTypes] || [[self defaultAcceptablePathExtensions] containsObject:[[request URL] pathExtension]];
+    return canProcess;
 }
 
 #if __IPHONE_OS_VERSION_MIN_REQUIRED

--- a/AFNetworking/AFJSONRequestOperation.m
+++ b/AFNetworking/AFJSONRequestOperation.m
@@ -71,7 +71,9 @@ static dispatch_queue_t json_request_operation_processing_queue() {
 }
 
 + (BOOL)canProcessRequest:(NSURLRequest *)request {
-    return [[self defaultAcceptableContentTypes] containsObject:[request valueForHTTPHeaderField:@"Accept"]] || [[self defaultAcceptablePathExtensions] containsObject:[[request URL] pathExtension]];
+    NSSet *requestAceptableTypes = [NSSet setWithArray:[[request valueForHTTPHeaderField:@"Accept"] componentsSeparatedByString:@","]];
+    BOOL canProcess = [[self defaultAcceptableContentTypes] intersectsSet:requestAceptableTypes] || [[self defaultAcceptablePathExtensions] containsObject:[[request URL] pathExtension]];
+    return canProcess;
 }
 
 - (id)initWithRequest:(NSURLRequest *)urlRequest {

--- a/AFNetworking/AFPropertyListRequestOperation.m
+++ b/AFNetworking/AFPropertyListRequestOperation.m
@@ -112,7 +112,9 @@ static dispatch_queue_t property_list_request_operation_processing_queue() {
 }
 
 + (BOOL)canProcessRequest:(NSURLRequest *)request {
-    return [[self defaultAcceptableContentTypes] containsObject:[request valueForHTTPHeaderField:@"Accept"]] || [[self defaultAcceptablePathExtensions] containsObject:[[request URL] pathExtension]];
+    NSSet *requestAceptableTypes = [NSSet setWithArray:[[request valueForHTTPHeaderField:@"Accept"] componentsSeparatedByString:@","]];
+    BOOL canProcess = [[self defaultAcceptableContentTypes] intersectsSet:requestAceptableTypes] || [[self defaultAcceptablePathExtensions] containsObject:[[request URL] pathExtension]];
+    return canProcess;
 }
 
 - (void)setCompletionBlockWithSuccess:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success

--- a/AFNetworking/AFXMLRequestOperation.m
+++ b/AFNetworking/AFXMLRequestOperation.m
@@ -173,7 +173,9 @@ static dispatch_queue_t xml_request_operation_processing_queue() {
 }
 
 + (BOOL)canProcessRequest:(NSURLRequest *)request {
-    return [[self defaultAcceptableContentTypes] containsObject:[request valueForHTTPHeaderField:@"Accept"]] || [[self defaultAcceptablePathExtensions] containsObject:[[request URL] pathExtension]];
+    NSSet *requestAceptableTypes = [NSSet setWithArray:[[request valueForHTTPHeaderField:@"Accept"] componentsSeparatedByString:@","]];
+    BOOL canProcess = [[self defaultAcceptableContentTypes] intersectsSet:requestAceptableTypes] || [[self defaultAcceptablePathExtensions] containsObject:[[request URL] pathExtension]];
+    return canProcess;
 }
 
 - (void)setCompletionBlockWithSuccess:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success


### PR DESCRIPTION
When a request "Accept" header contains multiple values separated by
coma, canProcessRequest should test each value against
defaultAcceptableContentTypes.
