### PR TITLE
JSON exception created but never raised: fix #175

### DIFF
--- a/AFNetworking/AFJSONUtilities.h
+++ b/AFNetworking/AFJSONUtilities.h
@@ -143,7 +143,7 @@ static id AFJSONDecode(NSData *data, NSError **error) {
         [invocation getReturnValue:&JSON];
     } else {
         NSDictionary *userInfo = [NSDictionary dictionaryWithObject:NSLocalizedString(@"Please either target a platform that supports NSJSONSerialization or add one of the following libraries to your project: JSONKit, SBJSON, or YAJL", nil) forKey:NSLocalizedRecoverySuggestionErrorKey];
-        [NSException exceptionWithName:NSInternalInconsistencyException reason:NSLocalizedString(@"No JSON parsing functionality available", nil) userInfo:userInfo];
+        [[NSException exceptionWithName:NSInternalInconsistencyException reason:NSLocalizedString(@"No JSON parsing functionality available", nil) userInfo:userInfo] raise];
     }
         
     return JSON;


### PR DESCRIPTION
In the JSON decoder an exception was created if a JSON library could not be found, however it was never raised. The exception for encoding was already being raised.
