### PR TITLE
xml_request_operation_processing_queue() is Mac-only.

### DIFF
--- a/AFNetworking/AFXMLRequestOperation.m
+++ b/AFNetworking/AFXMLRequestOperation.m
@@ -24,6 +24,7 @@
 
 #include <Availability.h>
 
+#if __MAC_OS_X_VERSION_MIN_REQUIRED
 static dispatch_queue_t af_xml_request_operation_processing_queue;
 static dispatch_queue_t xml_request_operation_processing_queue() {
     if (af_xml_request_operation_processing_queue == NULL) {
@@ -32,6 +33,7 @@ static dispatch_queue_t xml_request_operation_processing_queue() {
     
     return af_xml_request_operation_processing_queue;
 }
+#endif
 
 @interface AFXMLRequestOperation ()
 @property (readwrite, nonatomic, retain) NSXMLParser *responseXMLParser;


### PR DESCRIPTION
Wrap xml_request_operation_processing_queue() in a test for
__MAC_OS_X_VERSION_MIN_REQUIRED because it is only used by a
Mac-specific code block down below.

This addresses an unused symbol warning when compiling with strict
settings.
