### PR TITLE
Improved reachability check, detects severed internet connections.

### DIFF
--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -223,10 +223,10 @@ static void AFReachabilityCallback(SCNetworkReachabilityRef __unused target, SCN
     if (info) {
         AFNetworkReachabilityStatusBlock block = (AFNetworkReachabilityStatusBlock)info;
         
-        BOOL isReachable = ((flags & kSCNetworkFlagsReachable) != 0);
-        BOOL needsConnection = ((flags & kSCNetworkFlagsConnectionRequired) != 0);
-        
+        BOOL isReachable = ((flags & kSCNetworkReachabilityFlagsReachable) != 0);
+        BOOL needsConnection = ((flags & kSCNetworkReachabilityFlagsConnectionRequired) != 0);
         BOOL isNetworkReachable = (isReachable && !needsConnection);
+        
         block(isNetworkReachable);
     }
 }


### PR DESCRIPTION
Using `[AFHTTPClient setReachabilityStatusChangeBlock:]` I noticed `isNetworkReachable` was inaccurate (always yielded YES). Flag check has been updated respectively, now works as expected.
