### PR TITLE
Adding notifications for network reachability changes to AFHTTPClient

### DIFF
--- a/AFNetworking/AFHTTPClient.h
+++ b/AFNetworking/AFHTTPClient.h
@@ -27,7 +27,18 @@
 @protocol AFMultipartFormData;
 
 /**
- Method used to encode parameters into request body 
+ Posted when network reachability changes.
+ The notification object is an `NSNumber` object containing the boolean value for the current network reachability.
+ This notification contains no information in the `userInfo` dictionary.
+ 
+ @warning In order for network reachability to be monitored, include the `SystemConfiguration` framework in the active target's "Link Binary With Library" build phase, and add `#import <SystemConfiguration/SystemConfiguration.h>` to the header prefix of the project (Prefix.pch).
+ */
+#ifdef _SYSTEMCONFIGURATION_H
+extern NSString * const AFNetworkingReachabilityDidChangeNotification;
+#endif
+
+/**
+ Method used to encode parameters into request body. 
  */
 typedef enum {
     AFFormURLParameterEncoding,


### PR DESCRIPTION
Responding to the feedback from @itavor in Issue #157, this patch makes `AFHTTPClient` automatically post network reachability notifications, with the option to specifically set a callback block as before.

My concerns are whether or not to expose the `-startMonitoringNetworkReachability` / `-stopMonitoringNetworkReachability`, whether to start monitoring automatically, and whether or not it is important to include the URL posting the notification in `userInfo` (this would add some complexity to the network reachability callback function).

Any feedback on these points, or any others you see would be greatly appreciated.
