### PR TITLE
Added in "image/jpg" acceptable content type for Image Requests

### DIFF
--- a/AFNetworking/AFImageRequestOperation.m
+++ b/AFNetworking/AFImageRequestOperation.m
@@ -127,7 +127,7 @@ static dispatch_queue_t image_request_operation_processing_queue() {
 #endif
 
 + (NSSet *)defaultAcceptableContentTypes {
-    return [NSSet setWithObjects:@"image/tiff", @"image/jpeg", @"image/gif", @"image/png", @"image/ico", @"image/x-icon" @"image/bmp", @"image/x-bmp", @"image/x-xbitmap", @"image/x-win-bitmap", nil];
+    return [NSSet setWithObjects:@"image/tiff", @"image/jpg", @"image/jpeg", @"image/gif", @"image/png", @"image/ico", @"image/x-icon" @"image/bmp", @"image/x-bmp", @"image/x-xbitmap", @"image/x-win-bitmap", nil];
 }
 
 + (NSSet *)defaultAcceptablePathExtensions {


### PR DESCRIPTION
I ran into an API that was returning images as "image/jpg", which I
noticed was not included as a default content type for the image
request.  This change fixes that.
