### PR TITLE
AFHTTPClient to include any suffixes on the baseURL it is given

### DIFF
--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -293,7 +293,7 @@ static void AFReachabilityCallback(SCNetworkReachabilityRef __unused target, SCN
                                       path:(NSString *)path 
                                 parameters:(NSDictionary *)parameters 
 {	
-    NSURL *url = [NSURL URLWithString:path relativeToURL:self.baseURL];
+    NSURL *url = [NSURL URLWithString:[self.baseURL.path stringByAppendingString:path] relativeToURL:self.baseURL];
 	NSMutableURLRequest *request = [[[NSMutableURLRequest alloc] initWithURL:url] autorelease];
     [request setHTTPMethod:method];
     [request setAllHTTPHeaderFields:self.defaultHeaders];


### PR DESCRIPTION
When using AFHTTPClient to requestWithMethod:path:parameters
with a baseURL with a suffix like "http://google.com/suffix"
the resulting request will now include the suffix in the URL
of the request. So calling this method with @"/apath" will
result in using "http://google.com/suffix/apth".

I'm unsure if this behaviour is desirable, it certainly isn't backwards compatible.
However, when I use AFNetworking, this was the behaviour I expected.
Maybe a compromise could be made where there is another method
that includes a suffix, such as `requestWithMethod:path:parameters:withSuffix`
where `withSuffix` is a boolean to include the suffix or not.
