### PR TITLE
Fixed missing comma in the defaultAcceptableContentTypes of the AFImageRequestOperation

### DIFF
--- a/AFNetworking/AFImageRequestOperation.m
+++ b/AFNetworking/AFImageRequestOperation.m
@@ -127,7 +127,7 @@ static dispatch_queue_t image_request_operation_processing_queue() {
 #endif
 
 + (NSSet *)defaultAcceptableContentTypes {
-    return [NSSet setWithObjects:@"image/tiff", @"image/jpeg", @"image/gif", @"image/png", @"image/ico", @"image/x-icon" @"image/bmp", @"image/x-bmp", @"image/x-xbitmap", @"image/x-win-bitmap", nil];
+    return [NSSet setWithObjects:@"image/tiff", @"image/jpeg", @"image/gif", @"image/png", @"image/ico", @"image/x-icon", @"image/bmp", @"image/x-bmp", @"image/x-xbitmap", @"image/x-win-bitmap", nil];
 }
 
 + (NSSet *)defaultAcceptablePathExtensions {


### PR DESCRIPTION
I ran into the problem that images in the x-icon type was not downloaded as I saw that the comma is missing.
