### PR TITLE
Add pre-state-change notifications for AFURLConnection starting and finishing

### DIFF
--- a/AFNetworking/AFURLConnectionOperation.h
+++ b/AFNetworking/AFURLConnectionOperation.h
@@ -35,9 +35,19 @@ extern NSString * const AFNetworkingErrorDomain;
 extern NSString * const AFNetworkingOperationDidStartNotification;
 
 /**
+ Posted just before an operation begins executing.
+ */
+extern NSString * const AFNetworkingOperationWillStartNotification;
+
+/**
  Posted when an operation finishes.
  */
 extern NSString * const AFNetworkingOperationDidFinishNotification;
+
+/**
+ Posted just before an operation finishes.
+ */
+extern NSString * const AFNetworkingOperationWillFinishNotification;
 
 /**
  `AFURLConnectionOperation` is an `NSOperation` that implements NSURLConnection delegate methods.

--- a/AFNetworking/AFURLConnectionOperation.m
+++ b/AFNetworking/AFURLConnectionOperation.m
@@ -39,6 +39,8 @@ NSString * const AFNetworkingErrorDomain = @"com.alamofire.networking.error";
 
 NSString * const AFNetworkingOperationDidStartNotification = @"com.alamofire.networking.operation.start";
 NSString * const AFNetworkingOperationDidFinishNotification = @"com.alamofire.networking.operation.finish";
+NSString * const AFNetworkingOperationWillStartNotification = @"com.alamofire.networking.operation.willstart";
+NSString * const AFNetworkingOperationWillFinishNotification = @"com.alamofire.networking.operation.willfinish";
 
 typedef void (^AFURLConnectionOperationProgressBlock)(NSInteger bytes, NSInteger totalBytes, NSInteger totalBytesExpected);
 typedef void (^AFURLConnectionOperationAuthenticationChallengeBlock)(NSURLConnection *connection, NSURLAuthenticationChallenge *challenge);
@@ -236,6 +238,17 @@ static inline BOOL AFStateTransitionIsValid(AFOperationState fromState, AFOperat
     if (AFStateTransitionIsValid(self.state, state, [self isCancelled])) {
         NSString *oldStateKey = AFKeyPathFromOperationState(self.state);
         NSString *newStateKey = AFKeyPathFromOperationState(state);
+        
+        switch (state) {
+            case AFHTTPOperationExecutingState:
+                [[NSNotificationCenter defaultCenter] postNotificationName:AFNetworkingOperationWillStartNotification object:self];
+                break;
+            case AFHTTPOperationFinishedState:
+                [[NSNotificationCenter defaultCenter] postNotificationName:AFNetworkingOperationWillFinishNotification object:self];
+                break;
+            default:
+                break;
+        }
         
         [self willChangeValueForKey:newStateKey];
         [self willChangeValueForKey:oldStateKey];


### PR DESCRIPTION
AFHttpRequestOperation completion blocks are currently called after the operation changes state, so if you are watching the state of the operations in the queue you'll actually see operations finish before their completion blocks have been called. This notification gives you a hook to do something with the operation immediately before the state changes to start or finish.
