### PR TITLE
Shouldn't AFURLConnectionOperation cancel NSURLConnection on the network thread?

### DIFF
--- a/AFNetworking/AFURLConnectionOperation.m
+++ b/AFNetworking/AFURLConnectionOperation.m
@@ -334,21 +334,25 @@ static inline BOOL AFStateTransitionIsValid(AFOperationState fromState, AFOperat
     self.state = AFHTTPOperationFinishedState;
 }
 
+-(void)cancelConnection {
+    [self willChangeValueForKey:@"isCancelled"];
+    _cancelled = YES;
+
+    if (self.connection) {
+        [self.connection cancel];
+        //We must send this delegate protcol message ourselves since the above [self.connection cancel] causes the connection to never send another message to its delegate.
+        NSDictionary *userInfo = [NSDictionary dictionaryWithObject:[self.request URL] forKey:NSURLErrorFailingURLErrorKey];
+        [self performSelector:@selector(connection:didFailWithError:) withObject:self.connection withObject:[NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorCancelled userInfo:userInfo]];
+    }
+
+    [self didChangeValueForKey:@"isCancelled"];
+}
+
 - (void)cancel {
     [self.lock lock];
     if (![self isFinished] && ![self isCancelled]) {
-        [super cancel];
-        
-        [self willChangeValueForKey:@"isCancelled"];
-        _cancelled = YES;
-        if (self.connection) {
-            [self.connection cancel];
-            
-            // We must send this delegate protcol message ourselves since the above [self.connection cancel] causes the connection to never send another message to its delegate.
-            NSDictionary *userInfo = [NSDictionary dictionaryWithObject:[self.request URL] forKey:NSURLErrorFailingURLErrorKey];
-            [self performSelector:@selector(connection:didFailWithError:) withObject:self.connection withObject:[NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorCancelled userInfo:userInfo]];
-        }
-        [self didChangeValueForKey:@"isCancelled"];
+      [super cancel];
+      [self performSelector:@selector(cancelConnection) onThread:[[self class] networkRequestThread] withObject:nil waitUntilDone:NO modes:[self.runLoopModes allObjects]];
     }
     [self.lock unlock];
 }


### PR DESCRIPTION
Proposed fix to the crash that occurs when stressing AFURLConnectionOperation.
This cancels the NSURLConnection on the same thread as the one where it was created.

Hopefully this fixes issue #58 ( https://github.com/AFNetworking/AFNetworking/issues/58 ) where requests sometimes are cancelled before they are created.

Please see this example project for info on how to recreate the crash.
https://github.com/erikolsson/AFNetworking-Stress-Test

In the proposed change, maybe the cancelOperation should contain locks as well?
