### PR TITLE
Made the batch operation completion block and progress block return on the main thread by default.

### DIFF
--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -456,7 +456,9 @@ static void AFReachabilityCallback(SCNetworkReachabilityRef __unused target, SCN
         AFCompletionBlock originalCompletionBlock = [[operation.completionBlock copy] autorelease];
         operation.completionBlock = ^{
             if (progressBlock) {
-                progressBlock([[batchedOperation.dependencies filteredArrayUsingPredicate:finishedOperationPredicate] count], [batchedOperation.dependencies count]);
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    progressBlock([[batchedOperation.dependencies filteredArrayUsingPredicate:finishedOperationPredicate] count], [batchedOperation.dependencies count]);
+                });
             }
             
             if (originalCompletionBlock) {


### PR DESCRIPTION
I have been working with batched operations for the past few days and noticed (after a few headaches) that the `completionBlock` and `progressBlock` are not called on the main thread. I feel by default these should be returned on the main thread and have made these changes in the pull request.

Recently, custom queue callbacks were added for individual operations. This brings up the question of whether there should be an option to have the batch `completionBlock` and `progressBlock` return on custom queues as well.

To me, there are two options that come to mind to facilitate this. First, a new object could be created for batches that have properties for completion queue and progress queue, much like that of `AFHTTPRequestOperation`. I see this being useful since it would work a lot like that class, but it seems kind of bloated for just adding two parameters.

The other option would be to have parameters added to the `- (void)enqueueBatchOfHTTPRequestOperations:progressBlock:completionBlock:` call that include the queues that `progressBlock` and `completionBlock` should be called on. This is a smaller fix, but I know passing the queue might become cumbersome overtime as well.

My personal suggestion would be to go with a new object, but I wanted to see what the consensus was before attempting to add anything else to the pull request other than this fix.
