### PR TITLE
Set cancelled on main thread to avoid crashes when canceling the same connection before it has had time to cancel.

### DIFF
--- a/AFNetworking/AFURLConnectionOperation.m
+++ b/AFNetworking/AFURLConnectionOperation.m
@@ -337,8 +337,11 @@ static inline BOOL AFStateTransitionIsValid(AFOperationState fromState, AFOperat
 - (void)cancel {
     [self.lock lock];
     if (![self isFinished] && ![self isCancelled]) {
+        [self willChangeValueForKey:@"isCancelled"];
+        _cancelled = YES;
         [super cancel];
-        
+        [self didChangeValueForKey:@"isCancelled"];
+
         // Cancel the connection on the thread it runs on to prevent race conditions 
         [self performSelector:@selector(cancelConnection) onThread:[[self class] networkRequestThread] withObject:nil waitUntilDone:NO modes:[self.runLoopModes allObjects]];
     }
@@ -347,8 +350,7 @@ static inline BOOL AFStateTransitionIsValid(AFOperationState fromState, AFOperat
 }
 
 - (void)cancelConnection {
-    [self willChangeValueForKey:@"isCancelled"];
-    _cancelled = YES;
+
     
     if (self.connection) {
         [self.connection cancel];
@@ -357,7 +359,7 @@ static inline BOOL AFStateTransitionIsValid(AFOperationState fromState, AFOperat
         NSDictionary *userInfo = [NSDictionary dictionaryWithObject:[self.request URL] forKey:NSURLErrorFailingURLErrorKey];
         [self performSelector:@selector(connection:didFailWithError:) withObject:self.connection withObject:[NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorCancelled userInfo:userInfo]];
     }
-    [self didChangeValueForKey:@"isCancelled"];
+
 }
 
 #pragma mark - NSURLConnectionDelegate


### PR DESCRIPTION
I updated the stress test in order to provoke the crash discussed in https://github.com/AFNetworking/AFNetworking/issues/212 

https://github.com/erikolsson/AFNetworking-Stress-Test
Sorry about the formatting ;)
