### PR TITLE
Added in cancel changes based on @zdzisiekpu's recommendation

### DIFF
--- a/AFNetworking/AFURLConnectionOperation.m
+++ b/AFNetworking/AFURLConnectionOperation.m
@@ -192,6 +192,8 @@ static inline BOOL AFStateTransitionIsValid(AFOperationState fromState, AFOperat
     [_authenticationChallenge release];
     [_authenticationAgainstProtectionSpace release];
     
+    [_connection release];
+    
     [super dealloc];
 }
 


### PR DESCRIPTION
I implemented @zdzisiekpu's recommendation in #212.  

In `AFURLConnectionOperation`, I updated the `connection` property to be retained, and set the `connection` to nil in `connectionDidFinishLoading:`, `connnection:didFailWithError:`, and `cancelConnection`. This appears to solve my crash, but I am not sure if this a complete solution, or if flipping the property to retain opens up other unknown issues from some hidden retain cycle somewhere.
