### PR TITLE
Avoid crash with `nil` URL in request

### DIFF
--- a/AFNetworking/AFURLConnectionOperation.m
+++ b/AFNetworking/AFURLConnectionOperation.m
@@ -353,7 +353,10 @@ static inline BOOL AFStateTransitionIsValid(AFOperationState fromState, AFOperat
         [self.connection cancel];
         
         // Manually send this delegate message since `[self.connection cancel]` causes the connection to never send another message to its delegate
-        NSDictionary *userInfo = [NSDictionary dictionaryWithObject:[self.request URL] forKey:NSURLErrorFailingURLErrorKey];
+        NSDictionary *userInfo = nil;
+	if (self.request.URL) {
+		userInfo = [NSDictionary dictionaryWithObject:[self.request URL] forKey:NSURLErrorFailingURLErrorKey];
+	}
         [self performSelector:@selector(connection:didFailWithError:) withObject:self.connection withObject:[NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorCancelled userInfo:userInfo]];
     }
 }


### PR DESCRIPTION
I'm not sure what is causing this. I think it's related to the `UIImageView` category. Anyway, this fixed intermit crashing for when scrolling quickly through a table view using lots of image views with the category.
