### PR TITLE
fixes a race condition where NSURLConnection was already deallocated.

### DIFF
--- a/AFNetworking/AFURLConnectionOperation.m
+++ b/AFNetworking/AFURLConnectionOperation.m
@@ -354,7 +354,6 @@ static inline BOOL AFStateTransitionIsValid(AFOperationState fromState, AFOperat
     
     if (self.connection) {
         [self.connection cancel];
-        self.connection = nil;
         
         // Manually send this delegate message since `[self.connection cancel]` causes the connection to never send another message to its delegate
         NSDictionary *userInfo = [NSDictionary dictionaryWithObject:[self.request URL] forKey:NSURLErrorFailingURLErrorKey];


### PR DESCRIPTION
...before we tried calling cancelConnection on it.

I do not fully understand why NSURLConnection was not retained in the first place, in my tests i found that when creating LOTS of connections very fast (thus, scrolling through a table that loads images from the web) AFURLNetworking constantly crashed with calling cancel on a already deallocated NSURLConnection. Retaining the connection fixes it.
