### PR TITLE
Added yet another mime type for JSON

### DIFF
--- a/AFNetworking/AFJSONRequestOperation.m
+++ b/AFNetworking/AFJSONRequestOperation.m
@@ -63,7 +63,7 @@ static dispatch_queue_t json_request_operation_processing_queue() {
 }
 
 + (NSSet *)defaultAcceptableContentTypes {
-    return [NSSet setWithObjects:@"application/json", @"text/json", @"text/javascript", nil];
+    return [NSSet setWithObjects:@"application/json", @"text/json", @"text/javascript", @"application/javascript", nil];
 }
 
 + (NSSet *)defaultAcceptablePathExtensions {


### PR DESCRIPTION
Jenkins/Hudson JSON API returns this type, as do some other nonsensical Java apps - I know this is annoying but I needed this, and I am sure I am not the only one that will suffer this!
