### PR TITLE
Added additional Reachability Information (viaWWAN, viaWiFi) to AFHTTPClient

### DIFF
--- a/AFNetworking/AFHTTPClient.h
+++ b/AFNetworking/AFHTTPClient.h
@@ -43,9 +43,9 @@ extern NSString * const AFNetworkingReachabilityDidChangeNotification;
 #ifdef _SYSTEMCONFIGURATION_H
 typedef enum{
     AFReachabilityStatusUnknown = 0,
-    AFReachabilityStatusUnavilable,
-    AFReachabilityStatusAvailableViaWWAN,
-    AFReachabilityStatusAvailableViaWiFi,
+    AFReachabilityStatusNotReachable,
+    AFReachabilityStatusReachableViaWWAN,
+    AFReachabilityStatusReachableViaWiFi,
 }AFReachabilityStatus;
 #endif
 

--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -248,20 +248,20 @@ static void AFReachabilityCallback(SCNetworkReachabilityRef __unused target, SCN
     BOOL needsConnection = ((flags & kSCNetworkReachabilityFlagsConnectionRequired) != 0);
     BOOL isNetworkReachable = (isReachable && !needsConnection);
     
-    AFReachabilityStatus status = AFReachabilityStatusUnavilable;
+    AFReachabilityStatus status = AFReachabilityStatusUnknown;
     if(isNetworkReachable == NO){
-        status = AFReachabilityStatusUnavilable;
+        status = AFReachabilityStatusNotReachable;
     }
 #if	TARGET_OS_IPHONE
     else if((flags & kSCNetworkReachabilityFlagsIsWWAN) != 0){
-        status = AFReachabilityStatusAvailableViaWWAN;
+        status = AFReachabilityStatusReachableViaWWAN;
     }
     else{
-        status = AFReachabilityStatusAvailableViaWiFi;
+        status = AFReachabilityStatusReachableViaWiFi;
     }
 #else
     else {
-        status = AFReachabilityStatusAvailableViaWiFi;
+        status = AFReachabilityStatusReachableViaWiFi;
     }
 #endif
     AFNetworkReachabilityStatusBlock block = (AFNetworkReachabilityStatusBlock)info;


### PR DESCRIPTION
As discussed by @mattt in #197, this pull request takes a stab at exposing the Reachability state via an enum property, similar to `Reachability` itself allowing the user to know if the `baseURL` is reachable via WiFi or WWAN. A couple notes...

First off, this is a breaking change from the current implementation. Currently, the `AFNetworkReachabilityStatusBlock` returns a BOOL indicating whether or not a network connection is available. Unfortunately, this isn't quite enough in one of my projects where we need to know the actual connection type, as some features are only available via a WiFi connection.

Taking a page from `Reachability`, I have added an enum to represent the various network connection states (`AFReachabilityStatus` with Unknown, Unavailable, ViaWWAN, and ViaWiFi).  I have modified the `AFReachabilityCallback()` function to instead of calculating the BOOL flag, return the appropriate status modeled after Apple's `Reachability`. I have also modified the callback block and the notification to return this value instead of the BOOL. If people find this cumbersome, the BOOL could always be added back in addition to the enum, but it feels like overkill to have both coming back.

I also have seen a requirement where I need to be able to occasionally poll the status, instead of waiting for a callback block or notification. For example, I have a project where I need to fail a request immediately if a request is made while connected via WWAN. By exposing a property through the `AFHTTPClient`, I can poll that value in `enqueueHTTPRequestOperation:` and immediately fail if necessary. I'm sure there are other uses out there where people way want to grab current status, instead of waiting on callback or notification. If don't want that property I can remove it and leave it up to the client to track and change with their own custom reachability callback block implementation in their `AFHTTPClient` subclass.

Would love to get feedback on this. I'm guessing @mattt didn't go this route to begin with in order to make the reachability logic easier (either your connected or your not) so perhaps the final solution is somewhere in the middle of the initial approach and this one.
