### PR TITLE
Fixed leak in AFURLConnectionOperation to return nil if the cache policy for the request was NSURLRequestReloadIgnoringLocalCacheData

### DIFF
--- a/AFNetworking/AFURLConnectionOperation.m
+++ b/AFNetworking/AFURLConnectionOperation.m
@@ -497,7 +497,11 @@ didReceiveResponse:(NSURLResponse *)response
     if ([self isCancelled]) {
         return nil;
     }
-    
+
+    if ((self.request) && (self.request.cachePolicy==NSURLRequestReloadIgnoringLocalCacheData)) {
+        return nil;
+    }
+
     return cachedResponse;
 }
 


### PR DESCRIPTION
By not returning nil in connection:willCacheResponse: was causing mad leaks of underlying CF\* objects.  Discovered this attempting to open more than 200K download requests in an app.  Memory usage for those 200K was in the 180MB range.  With this fix, back down to 20MB for the entire app.

Signed-off-by: Jon Gilkison jon.gilkison@gmail.com
