### PR TITLE
Check for null error pointer before setting it on the invocation

### DIFF
--- a/AFNetworking/AFJSONUtilities.m
+++ b/AFNetworking/AFJSONUtilities.m
@@ -142,7 +142,9 @@ id AFJSONDecode(NSData *data, NSError **error) {
         
         NSUInteger parseOptionFlags = 0;
         [invocation setArgument:&parseOptionFlags atIndex:2]; // arguments 0 and 1 are self and _cmd respectively, automatically set by NSInvocation
-        [invocation setArgument:error atIndex:3];
+        if (error != NULL) {
+            [invocation setArgument:error atIndex:3];
+        }
         
         [invocation invoke];
         [invocation getReturnValue:&JSON];
@@ -162,7 +164,9 @@ id AFJSONDecode(NSData *data, NSError **error) {
         
         NSUInteger yajlParserOptions = 0;
         [invocation setArgument:&yajlParserOptions atIndex:2]; // arguments 0 and 1 are self and _cmd respectively, automatically set by NSInvocation
-        [invocation setArgument:error atIndex:3];
+        if (error != NULL) {
+            [invocation setArgument:error atIndex:3];
+        }
         
         [invocation invoke];
         [invocation getReturnValue:&JSON];
@@ -173,7 +177,9 @@ id AFJSONDecode(NSData *data, NSError **error) {
         invocation.selector = _NXJsonParserSelector;
         
         [invocation setArgument:&data atIndex:2]; // arguments 0 and 1 are self and _cmd respectively, automatically set by NSInvocation
-        [invocation setArgument:error atIndex:3];
+        if (error != NULL) {
+            [invocation setArgument:error atIndex:3];
+        }
         [invocation setArgument:&nullOption atIndex:4];
         
         [invocation invoke];
@@ -189,7 +195,9 @@ id AFJSONDecode(NSData *data, NSError **error) {
         [invocation setArgument:&data atIndex:2]; // arguments 0 and 1 are self and _cmd respectively, automatically set by NSInvocation
         NSUInteger readOptions = 0;
         [invocation setArgument:&readOptions atIndex:3];
-        [invocation setArgument:error atIndex:4];
+        if (error != NULL) {
+            [invocation setArgument:error atIndex:4];
+        }
 
         [invocation invoke];
         [invocation getReturnValue:&JSON];


### PR DESCRIPTION
Some people like to run with scissors, but if you try to call

``` objective-c
[invocation setArgument:error atIndex:4];
```

with a NULL error pointer, you get an exception. This patch only sets the error argument if it's non-NULL.
