### PR TITLE
Fixing upload/download typo.

### DIFF
--- a/AFNetworking/AFURLConnectionOperation.h
+++ b/AFNetworking/AFURLConnectionOperation.h
@@ -174,18 +174,18 @@ extern NSString * const AFNetworkingOperationDidFinishNotification;
 ///---------------------------------
 
 /**
- Sets a callback to be called when an undetermined number of bytes have been downloaded from the server.
+ Sets a callback to be called when an undetermined number of bytes have been uploaded to the server.
  
- @param block A block object to be called when an undetermined number of bytes have been downloaded from the server. This block has no return value and takes three arguments: the number of bytes written since the last time the upload progress block was called, the total bytes written, and the total bytes expected to be written during the request, as initially determined by the length of the HTTP body. This block may be called multiple times.
+ @param block A block object to be called when an undetermined number of bytes have been uploaded to the server. This block has no return value and takes three arguments: the number of bytes written since the last time the upload progress block was called, the total bytes written, and the total bytes expected to be written during the request, as initially determined by the length of the HTTP body. This block may be called multiple times.
  
  @see setDownloadProgressBlock
  */
 - (void)setUploadProgressBlock:(void (^)(NSInteger bytesWritten, NSInteger totalBytesWritten, NSInteger totalBytesExpectedToWrite))block;
 
 /**
- Sets a callback to be called when an undetermined number of bytes have been uploaded to the server.
+ Sets a callback to be called when an undetermined number of bytes have been downloaded from the server.
  
- @param block A block object to be called when an undetermined number of bytes have been uploaded to the server. This block has no return value and takes three arguments: the number of bytes read since the last time the upload progress block was called, the total bytes read, and the total bytes expected to be read during the request, as initially determined by the expected content size of the `NSHTTPURLResponse` object. This block may be called multiple times.
+ @param block A block object to be called when an undetermined number of bytes have been downloaded from the server. This block has no return value and takes three arguments: the number of bytes read since the last time the download progress block was called, the total bytes read, and the total bytes expected to be read during the request, as initially determined by the expected content size of the `NSHTTPURLResponse` object. This block may be called multiple times.
  
  @see setUploadProgressBlock
  */


### PR DESCRIPTION
In AFURLConnectionOperation.h, the documentation seems to have "upload" in the setDownloadProgressBlock: and "download" in the setUploadProgressBlock: .  This change fixes that.
