### PR TITLE
Fixed bug with JSON decodes not returning errors

### DIFF
--- a/AFNetworking/AFJSONUtilities.m
+++ b/AFNetworking/AFJSONUtilities.m
@@ -143,7 +143,7 @@ id AFJSONDecode(NSData *data, NSError **error) {
         NSUInteger parseOptionFlags = 0;
         [invocation setArgument:&parseOptionFlags atIndex:2]; // arguments 0 and 1 are self and _cmd respectively, automatically set by NSInvocation
         if (error != NULL) {
-            [invocation setArgument:error atIndex:3];
+            [invocation setArgument:&error atIndex:3];
         }
         
         [invocation invoke];
@@ -165,7 +165,7 @@ id AFJSONDecode(NSData *data, NSError **error) {
         NSUInteger yajlParserOptions = 0;
         [invocation setArgument:&yajlParserOptions atIndex:2]; // arguments 0 and 1 are self and _cmd respectively, automatically set by NSInvocation
         if (error != NULL) {
-            [invocation setArgument:error atIndex:3];
+            [invocation setArgument:&error atIndex:3];
         }
         
         [invocation invoke];
@@ -178,7 +178,7 @@ id AFJSONDecode(NSData *data, NSError **error) {
         
         [invocation setArgument:&data atIndex:2]; // arguments 0 and 1 are self and _cmd respectively, automatically set by NSInvocation
         if (error != NULL) {
-            [invocation setArgument:error atIndex:3];
+            [invocation setArgument:&error atIndex:3];
         }
         [invocation setArgument:&nullOption atIndex:4];
         
@@ -196,7 +196,7 @@ id AFJSONDecode(NSData *data, NSError **error) {
         NSUInteger readOptions = 0;
         [invocation setArgument:&readOptions atIndex:3];
         if (error != NULL) {
-            [invocation setArgument:error atIndex:4];
+            [invocation setArgument:&error atIndex:4];
         }
 
         [invocation invoke];


### PR DESCRIPTION
While debugging my app I noticed that when I used AFJSONRequestOperation to fetch improperly-encoded JSON, the parse error wasn't being passed back to the failure callback. It seems that NSInvocation's `setArgument:atIndex:` method needs a pointer to the argument rather than the argument itself, so this change does that. I confirmed that JSONKit's NSError was showing up in the operation's failure block, but any sanity-checking would be welcome.
