### PR TITLE
Use SBJsonParser/SBJsonWriter instead of NSObject+SBJson

### DIFF
--- a/AFNetworking/AFJSONUtilities.m
+++ b/AFNetworking/AFJSONUtilities.m
@@ -148,7 +148,7 @@ id AFJSONDecode(NSData *data, NSError **error) {
         NSUInteger parseOptionFlags = 0;
         [invocation setArgument:&parseOptionFlags atIndex:2]; // arguments 0 and 1 are self and _cmd respectively, automatically set by NSInvocation
         if (error != NULL) {
-            [invocation setArgument:error atIndex:3];
+            [invocation setArgument:&error atIndex:3];
         }
         
         [invocation invoke];
@@ -172,7 +172,7 @@ id AFJSONDecode(NSData *data, NSError **error) {
         NSUInteger yajlParserOptions = 0;
         [invocation setArgument:&yajlParserOptions atIndex:2]; // arguments 0 and 1 are self and _cmd respectively, automatically set by NSInvocation
         if (error != NULL) {
-            [invocation setArgument:error atIndex:3];
+            [invocation setArgument:&error atIndex:3];
         }
         
         [invocation invoke];
@@ -185,7 +185,7 @@ id AFJSONDecode(NSData *data, NSError **error) {
         
         [invocation setArgument:&data atIndex:2]; // arguments 0 and 1 are self and _cmd respectively, automatically set by NSInvocation
         if (error != NULL) {
-            [invocation setArgument:error atIndex:3];
+            [invocation setArgument:&error atIndex:3];
         }
         [invocation setArgument:&nullOption atIndex:4];
         
@@ -203,7 +203,7 @@ id AFJSONDecode(NSData *data, NSError **error) {
         NSUInteger readOptions = 0;
         [invocation setArgument:&readOptions atIndex:3];
         if (error != NULL) {
-            [invocation setArgument:error atIndex:4];
+            [invocation setArgument:&error atIndex:4];
         }
 
         [invocation invoke];


### PR DESCRIPTION
- SBJsonParser can be used standalone when JSON posting is not used
- No NSString <-> NSData conversion
- Possibility to implement error handling (although [parser/writer error] returns a NSString...)
- Documented interface:
  http://stig.github.com/json-framework/api/3.0/interfaceSBJsonParser.html
  http://stig.github.com/json-framework/api/3.0/interfaceSBJsonWriter.html
