### PR TITLE
Small fix for the tweet example.

### DIFF
--- a/iOS Example/Classes/Controllers/PublicTimelineViewController.m
+++ b/iOS Example/Classes/Controllers/PublicTimelineViewController.m
@@ -42,8 +42,10 @@
     self.navigationItem.rightBarButtonItem.enabled = NO;
     
     [Tweet publicTimelineTweetsWithBlock:^(NSArray *tweets) {
-        _tweets = tweets;
-        [self.tableView reloadData];
+        if (tweets) {
+            _tweets = tweets;
+            [self.tableView reloadData];
+        }
         
         [_activityIndicatorView stopAnimating];
         self.navigationItem.rightBarButtonItem.enabled = YES;

--- a/iOS Example/Classes/Models/Tweet.m
+++ b/iOS Example/Classes/Models/Tweet.m
@@ -65,6 +65,12 @@
         }
     } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
         NSLog(@"Error: %@", error);
+        
+        [[[UIAlertView alloc] initWithTitle:@"Error" message:[error localizedDescription] delegate:nil cancelButtonTitle:nil otherButtonTitles:@"Ok", nil] show];
+        
+        if (block) {
+            block(nil);
+        }
     }];
 }
 


### PR DESCRIPTION
fixes a blocked reload button once we hit an error.
Also shows an alert on an error. (even if the actual error JSON doesn't get parsed)
