### PR TITLE
remote obsolete KVO change calls.

### DIFF
--- a/AFNetworking/AFImageRequestOperation.m
+++ b/AFNetworking/AFImageRequestOperation.m
@@ -170,9 +170,7 @@ static dispatch_queue_t image_request_operation_processing_queue() {
         return;
     }
     
-    [self willChangeValueForKey:@"imageScale"];
     _imageScale = imageScale;
-    [self didChangeValueForKey:@"imageScale"];
     
     self.responseImage = nil;
 }

--- a/iOS Example/Classes/Views/TweetTableViewCell.m
+++ b/iOS Example/Classes/Views/TweetTableViewCell.m
@@ -50,9 +50,7 @@
 }
 
 - (void)setTweet:(Tweet *)tweet {
-    [self willChangeValueForKey:@"tweet"];
     _tweet = tweet;
-    [self didChangeValueForKey:@"tweet"];
 
     self.textLabel.text = _tweet.user.username;
     self.detailTextLabel.text = _tweet.text;


### PR DESCRIPTION
See http://petersteinberger.com/blog/2012/dont-call-willchangevalueforkey/.

I didn't remove the call in the AFNetworkActivityIndicatorManager, since I already removed this in my other pull request.
