### PR TITLE
Ignore ';charset=utf8' in content type check

### DIFF
--- a/AFNetworking/AFHTTPRequestOperation.m
+++ b/AFNetworking/AFHTTPRequestOperation.m
@@ -128,7 +128,8 @@ static NSString * AFStringFromIndexSet(NSIndexSet *indexSet) {
 }
 
 - (BOOL)hasAcceptableContentType {
-    return !self.acceptableContentTypes || [self.acceptableContentTypes containsObject:[self.response MIMEType]];
+    NSString *contentType = [[[self.response MIMEType] componentsSeparatedByString:@";"] objectAtIndex:0];
+    return !self.acceptableContentTypes || [self.acceptableContentTypes containsObject:contentType];
 }
 
 - (void)setSuccessCallbackQueue:(dispatch_queue_t)successCallbackQueue {


### PR DESCRIPTION
Fix issue where AFNetworking rejects content-type due to trailing charset string. In my case, the server was responding with:

Content-Type:application/json;charset=utf8

which is the correct content type, but wasn't correct according to hasAcceptableContentType.
