### PR TITLE
The cache policy set here was from the WRONG enum.

### DIFF
--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -693,7 +693,7 @@ static inline NSString * AFMultipartFormFinalBoundary() {
     }
     
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:fileURL];
-    [request setCachePolicy:NSURLCacheStorageNotAllowed];
+    [request setCachePolicy:NSURLRequestReloadIgnoringLocalCacheData];
     
     NSURLResponse *response = nil;
     NSData *data = [NSURLConnection sendSynchronousRequest:request returningResponse:&response error:error];


### PR DESCRIPTION
So NSURLCacheStorgeNotAllowed has the value 2, which maps to NSURLRequestReturnCacheDataElseLoad. I'm not sure why this is here in the first place, but the correct enum is of the type NSURLRequestCachePolicy.
