### PR TITLE
don't allow caching with secure (https) connections.

### DIFF
--- a/AFNetworking/AFURLConnectionOperation.m
+++ b/AFNetworking/AFURLConnectionOperation.m
@@ -509,7 +509,11 @@ didReceiveResponse:(NSURLResponse *)response
             return nil;
         }
         
-        return cachedResponse; 
+        if ([[[[cachedResponse response] URL] scheme] isEqual:@"https"]) {
+            return nil;
+        }else {
+            return cachedResponse; 
+        }
     }
 }
 


### PR DESCRIPTION
Seems to be a good idea, especially since iOS5's NSURLCache saves to disk.

See https://developer.apple.com/library/ios/#documentation/Cocoa/Conceptual/URLLoadingSystem/Tasks/UsingNSURLConnection.html
