### PR TITLE
Fixed crash in special case for custom callback queues

### DIFF
--- a/AFNetworking/AFHTTPRequestOperation.m
+++ b/AFNetworking/AFHTTPRequestOperation.m
@@ -135,6 +135,7 @@ static NSString * AFStringFromIndexSet(NSIndexSet *indexSet) {
     if (successCallbackQueue != _successCallbackQueue) {
         if (_successCallbackQueue) {
             dispatch_release(_successCallbackQueue);
+            _successCallbackQueue = NULL;
         }
      
         if (successCallbackQueue) {
@@ -148,6 +149,7 @@ static NSString * AFStringFromIndexSet(NSIndexSet *indexSet) {
     if (failureCallbackQueue != _failureCallbackQueue) {
         if (_failureCallbackQueue) {
             dispatch_release(_failureCallbackQueue);
+            _failureCallbackQueue = NULL;
         }
         
         if (failureCallbackQueue) {


### PR DESCRIPTION
This update is to fix a fairly obscure crash that occurs when using custom callback queues. The code below will currently crash the application when the completion block is called with a success. The same will occur with the failure block if the failureCallbackQueue is set the same way as below.

As a side note, If `queue` is not released then the app will not crash, but the completion block will be called on the queue that was originally set.

```
// Create AFHTTPRequestOperation called "operation"

dispatch_queue_t queue = dispatch_queue_create("aQueue", DISPATCH_QUEUE_CONCURRENT);

[operation setSuccessCallbackQueue:queue];
[operation setSuccessCallbackQueue:NULL];

dispatch_release(queue);

// Fire operation
```
