### PR TITLE
Adding support for a separate dispatch queue for image processing in AFImageRequestOperation

### DIFF
--- a/AFNetworking/AFImageRequestOperation.h
+++ b/AFNetworking/AFImageRequestOperation.h
@@ -67,6 +67,11 @@
 @property (nonatomic, assign) CGFloat imageScale;
 #endif
 
+/** 
+ The dispatch queue used for image processing. If `NULL` (default), the successCallbackQueue is used.
+ */
+@property (nonatomic) dispatch_queue_t imageProcessingQueue;
+
 /**
  An image constructed from the response data. If an error occurs during the request, `nil` will be returned, and the `error` property will be set to the error.
  */


### PR DESCRIPTION
Image processing can be quite expensive. Therefore it is often important to get it off the main thread, even though the final image is to be returned and used on the main thread. 

This patch adds support for using a separate dispatch queue for the image processing block. 

Currently this patch only implements the iOS version. The equivalent OSX method would need to be changed accordingly as well. 

But please take a look and consider if this code is correct and if it could make sense to integrate it into the official AFNetworking implementation.
