### PR TITLE
Fixed a leak of AFHTTPRequestOperation in setCompletionBlock:

### DIFF
--- a/AFNetworking/AFHTTPRequestOperation.m
+++ b/AFNetworking/AFHTTPRequestOperation.m
@@ -203,13 +203,16 @@ static NSString * AFStringFromIndexSet(NSIndexSet *indexSet) {
 }
 
 - (void)setCompletionBlock:(void (^)(void))block {
+    __block AFHTTPRequestOperation *blockSelf = self;
+    dispatch_once_t *blockOnceToken = &_onceToken;
+    
     [super setCompletionBlock:^{
         if(block) {
             block();
         }
         // Dispatch once is used to ensure that setting the block with this block will not cause multiple calls to 'dispatch_group_leave'
-        dispatch_once(&_onceToken, ^{
-            dispatch_group_leave(self.dispatchGroup);
+        dispatch_once(blockOnceToken, ^{
+            dispatch_group_leave(blockSelf.dispatchGroup);
         });
     }];
 }


### PR DESCRIPTION
This is to fix a leak that was introduced when I submitted the pull request #288. The `setCompletionBlock:` method was creating a retain cycle for the operation and so the operation was never being deallocated.

The way this was fixed was to add a reference to self that is declared as `__block` variabel so that it would not be retained by the block. Also a local reference to the `_onceToken` was made since accessing an instance variable by reference within a block also retains self. 

Credit goes to @note173 who found the issue (#301) and proposed the fix that is in this pull request.   
