### PR TITLE
Try-catch in Objective-C should not be used to recover from exceptions

### DIFF
--- a/AFNetworking/AFURLConnectionOperation.m
+++ b/AFNetworking/AFURLConnectionOperation.m
@@ -128,18 +128,9 @@ static inline BOOL AFStateTransitionIsValid(AFOperationState fromState, AFOperat
 
 + (void)networkRequestThreadEntryPoint:(id)__unused object {
     do {
-        NSAutoreleasePool *exceptionPool = [[NSAutoreleasePool alloc] init];
-        NSException *caughtException = nil;
-        @try {
-            NSAutoreleasePool *runLoopPool = [[NSAutoreleasePool alloc] init];
-            [[NSRunLoop currentRunLoop] run];
-            [runLoopPool drain];
-        }
-        @catch(NSException *e) { caughtException = e; }
-        if(caughtException) { 
-            NSLog(NSLocalizedString(@"Unhandled exception on %@ networking thread: %@, userInfo: %@", nil), NSStringFromClass([self class]), caughtException, [caughtException userInfo]); 
-        }
-        [exceptionPool drain];
+        NSAutoreleasePool *runLoopPool = [[NSAutoreleasePool alloc] init];
+        [[NSRunLoop currentRunLoop] run];
+        [runLoopPool drain];
     } while (YES);
 }
 


### PR DESCRIPTION
http://developer.apple.com/library/ios/#documentation/cocoa/conceptual/Exceptions/Articles/ExceptionsAndCocoaFrameworks.html#//apple_ref/doc/uid/TP40009045-SW1

Relevant Quote:
  "The Cocoa frameworks are generally not exception-safe. The general
  pattern is that exceptions are reserved for programmer error only, and
  the program catching such an exception should quit soon afterwards."

More discussion here:
http://stackoverflow.com/questions/324284/how-to-throw-an-exception-in-objective-c-cocoa

Given all this, prefer a crash on the background thread.
