### PR TITLE
Fix the duplicated `AFJSONDecode()` calling that cause message sending t...

### DIFF
--- a/AFNetworking/AFJSONRequestOperation.m
+++ b/AFNetworking/AFJSONRequestOperation.m
@@ -66,7 +66,7 @@ static dispatch_queue_t json_request_operation_processing_queue() {
 }
 
 - (id)responseJSON {
-    if (!_responseJSON && [self.responseData length] > 0 && [self isFinished]) {
+    if (!_responseJSON && [self.responseData length] > 0 && [self isFinished] && !self.JSONError) {
         NSError *error = nil;
 
         if ([self.responseData length] == 0) {


### PR DESCRIPTION
...o deallocated `NSError` object

After a long time debug, I found the reason for the problem my previous pull request that want to fix is that `AFJSONDecode()` was called twice for single `AFJSONRequestOperation` when failing to parse the JSON data. If JSON is parsed successfully, this will not happen.

Details see comments in code blew.

**AFJSONRequestOperation.m**

```
- (void)setCompletionBlockWithSuccess:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure
{
    self.completionBlock = ^ {
        if ([self isCancelled]) {
            return;
        }

        if (self.error) {
            if (failure) {
                dispatch_async(self.failureCallbackQueue ? self.failureCallbackQueue : dispatch_get_main_queue(), ^{
                    failure(self, self.error);
                });
            }
        } else {
            dispatch_async(json_request_operation_processing_queue(), ^{
            /** =============================
            `responseJSON` first call
             ============================= */
              id JSON = self.responseJSON;

                if (self.JSONError) {
                    if (failure) {
                        dispatch_async(self.failureCallbackQueue ? self.failureCallbackQueue : dispatch_get_main_queue(), ^{
                        /** =============================
                        `responseJSON` second call, PART I
                         ============================= */
                          failure(self, self.error);
                        });
                    }
                } else {
                    if (success) {
                        dispatch_async(self.successCallbackQueue ? self.successCallbackQueue : dispatch_get_main_queue(), ^{
                            success(self, JSON);
                        });
                    }                    
                }
            });
        }
    };    
}
```

```
+ (AFJSONRequestOperation *)JSONRequestOperationWithRequest:(NSURLRequest *)urlRequest success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, id JSON))success failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, id JSON))failure
{
    AFJSONRequestOperation *requestOperation = [[[self alloc] initWithRequest:urlRequest] autorelease];
    [requestOperation setCompletionBlockWithSuccess:^(AFHTTPRequestOperation *operation, id responseObject) {
        if (success) {
            success(operation.request, operation.response, responseObject);     }
    } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
        if (failure) {
            /** =============================
            `responseJSON` second call, PART II
             ============================= */
            failure(operation.request, operation.response, error, [(AFJSONRequestOperation *)operation responseJSON]);
        }
    }];

    return requestOperation;
}
```

```
- (id)responseJSON {
    /**  =============================
    even if it failed to parse JSON the first time, this condition here still allow the method to 
        be call the second time, and the previously generated `error` will be deallocated, 
    however the deallocated one is already sent to the failure block
     ============================= */
    if (!_responseJSON && [self.responseData length] > 0 && [self isFinished]) {
        /**  =============================
        `error` object pointer here used for getting the error from the decode function 
        is always newly allocated on the heap.
        ============================= */
        NSError *error = nil;

        if ([self.responseData length] == 0) {
            self.responseJSON = nil;
        } else {
            self.responseJSON = AFJSONDecode(self.responseData, &error);
        }

        self.JSONError = error;
    }

    return _responseJSON;
}
```

So the fix here is that if `AFJSONRequestOperation` find itself fail to parse the JSON data the first time, then do nothing for the following time.

This issue can be easily re-produced when parsing invalid JSON data under ARC with AFNetworking as a standalone Non-ARC static library.
