### PR TITLE
Get acceptableStatusCodes via instance method

### DIFF
--- a/AFNetworking/AFHTTPRequestOperation.m
+++ b/AFNetworking/AFHTTPRequestOperation.m
@@ -148,7 +148,7 @@ NSString * AFCreateIncompleteDownloadDirectoryPath(void) {
     if (self.response && !self.HTTPError) {
         if (![self hasAcceptableStatusCode]) {
             NSMutableDictionary *userInfo = [NSMutableDictionary dictionary];
-            [userInfo setValue:[NSString stringWithFormat:NSLocalizedString(@"Expected status code in (%@), got %d", nil), AFStringFromIndexSet([[self class] acceptableStatusCodes]), [self.response statusCode]] forKey:NSLocalizedDescriptionKey];
+            [userInfo setValue:[NSString stringWithFormat:NSLocalizedString(@"Expected status code in (%@), got %d", nil), AFStringFromIndexSet([self acceptableStatusCodes]), [self.response statusCode]] forKey:NSLocalizedDescriptionKey];
             [userInfo setValue:[self.request URL] forKey:NSURLErrorFailingURLErrorKey];
             
             self.HTTPError = [[[NSError alloc] initWithDomain:AFNetworkingErrorDomain code:NSURLErrorBadServerResponse userInfo:userInfo] autorelease];
@@ -186,8 +186,13 @@ NSString * AFCreateIncompleteDownloadDirectoryPath(void) {
     [super pause];
 }
 
+- (NSIndexSet *)acceptableStatusCodes {
+    return [[self class] acceptableStatusCodes];
+}
+
 - (BOOL)hasAcceptableStatusCode {
-    return ![[self class] acceptableStatusCodes] || [[[self class] acceptableStatusCodes] containsIndex:[self.response statusCode]];
+    NSIndexSet *acceptableStatusCodes = [self acceptableStatusCodes];
+    return !acceptableStatusCodes || [acceptableStatusCodes containsIndex:[self.response statusCode]];
 }
 
 - (BOOL)hasAcceptableContentType {


### PR DESCRIPTION
Instead of calling the class method acceptableStatusCodes directly, this calls an instance method acceptableStatusCodes that calls the class method.

This:
- improves readability
- replaces a redundant call to acceptableStatusCodes
- allows developers to subclass AFHTTPRequestOperation and make the subclass support per-instance acceptableStatusCodes
