### PR TITLE
Fix an issue where _skippedCharacterSet would get dealloc'd early

### DIFF
--- a/AFNetworking/AFHTTPRequestOperation.m
+++ b/AFNetworking/AFHTTPRequestOperation.m
@@ -29,7 +29,7 @@ NSSet * AFContentTypesFromHTTPHeader(NSString *string) {
     static NSCharacterSet *_skippedCharacterSet = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        _skippedCharacterSet = [NSCharacterSet characterSetWithCharactersInString:@" ,"];
+        _skippedCharacterSet = [[NSCharacterSet characterSetWithCharactersInString:@" ,"] retain];
     });
     
     if (!string) {


### PR DESCRIPTION
Found a bug where `_skippedCharacterSet` would point to bad memory.

Since `_skippedCharacterSet` is a static variable and lives forever, we need to add a `retain` call to it so that it doesn't get autoreleased.
