### PR TITLE
Add missing block parameter name preventing auto-complete to work

### DIFF
--- a/AFNetworking/AFImageRequestOperation.h
+++ b/AFNetworking/AFImageRequestOperation.h
@@ -100,13 +100,13 @@
  */
 #if __IPHONE_OS_VERSION_MIN_REQUIRED
 + (AFImageRequestOperation *)imageRequestOperationWithRequest:(NSURLRequest *)urlRequest
-                                         imageProcessingBlock:(UIImage *(^)(UIImage *))imageProcessingBlock
+                                         imageProcessingBlock:(UIImage *(^)(UIImage *image))imageProcessingBlock
                                                     cacheName:(NSString *)cacheNameOrNil
                                                       success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, UIImage *image))success
                                                       failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error))failure;
 #elif __MAC_OS_X_VERSION_MIN_REQUIRED
 + (AFImageRequestOperation *)imageRequestOperationWithRequest:(NSURLRequest *)urlRequest
-                                         imageProcessingBlock:(NSImage *(^)(NSImage *))imageProcessingBlock
+                                         imageProcessingBlock:(NSImage *(^)(NSImage *image))imageProcessingBlock
                                                     cacheName:(NSString *)cacheNameOrNil
                                                       success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSImage *image))success
                                                       failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error))failure;


### PR DESCRIPTION
When function name is auto-completed and the imageProcessingBlock stub is created, it was missing the UIImage\* parameter name.
