### PR TITLE
Add imageProcessingBlock:cacheName: variants

### DIFF
--- a/AFNetworking/UIImageView+AFNetworking.h
+++ b/AFNetworking/UIImageView+AFNetworking.h
@@ -42,6 +42,10 @@
  */
 - (void)setImageWithURL:(NSURL *)url;
 
+- (void)setImageWithURL:(NSURL *)url
+   imageProcessingBlock:(UIImage *(^)(UIImage *image))imageProcessingBlock
+              cacheName:(NSString *)cacheNameOrNil;
+
 /**
  Creates and enqueues an image request operation, which asynchronously downloads the image from the specified URL. If the image is cached locally, the image is set immediately. Otherwise, the specified placeholder image will be set immediately, and then the remote image will be set once the request is finished.
  
@@ -52,6 +56,11 @@
 */
 - (void)setImageWithURL:(NSURL *)url 
        placeholderImage:(UIImage *)placeholderImage;
+
+- (void)setImageWithURL:(NSURL *)url 
+       placeholderImage:(UIImage *)placeholderImage
+   imageProcessingBlock:(UIImage *(^)(UIImage *image))imageProcessingBlock
+              cacheName:(NSString *)cacheNameOrNil;
 
 /**
  Creates and enqueues an image request operation, which asynchronously downloads the image with the specified url request object. If the image is cached locally, the image is set immediately. Otherwise, the specified placeholder image will be set immediately, and then the remote image will be set once the request is finished.
@@ -65,6 +74,13 @@
 */
 - (void)setImageWithURLRequest:(NSURLRequest *)urlRequest 
               placeholderImage:(UIImage *)placeholderImage 
+                       success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, UIImage *image))success
+                       failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error))failure;
+
+- (void)setImageWithURLRequest:(NSURLRequest *)urlRequest 
+              placeholderImage:(UIImage *)placeholderImage
+          imageProcessingBlock:(UIImage *(^)(UIImage *image))imageProcessingBlock
+                     cacheName:(NSString *)cacheNameOrNil
                        success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, UIImage *image))success
                        failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error))failure;
 


### PR DESCRIPTION
This way, it is possible to process the image in the background (ex.: resize, tint) before setting it as the image property of the image view.
