### PR TITLE
Adds flexibility to the "Authorization: token..." header.

### DIFF
--- a/AFNetworking/AFHTTPClient.h
+++ b/AFNetworking/AFHTTPClient.h
@@ -50,6 +50,15 @@ typedef enum {
 #endif
 
 /**
+ Specifies the format used for the Authorization header when using a token
+ */
+typedef enum {
+	AFNetworkAuthorizationTokenFormatUnkown     = -1,
+    AFNetworkAuthorizationTokenFormatDefault    = 0,  // "Authorization: token token=\"xxx\""
+    AFNetworkAuthorizationTokenFormatSlim     = 1,	  // "Authorization: token xxx"
+} AFNetworkAuthorizationTokenFormat;
+
+/**
  Specifies the method used to encode parameters into request body. 
  */
 typedef enum {
@@ -262,6 +271,8 @@ extern NSString * AFQueryStringFromParametersWithEncoding(NSDictionary *paramete
  @param token The authentication token
  */
 - (void)setAuthorizationHeaderWithToken:(NSString *)token;
+
+- (void)setAuthorizationHeaderWithToken:(NSString *)token valueFormat:(AFNetworkAuthorizationTokenFormat)format;
 
 /**
  Clears any existing value for the "Authorization" HTTP header.

--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -450,7 +450,21 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {
 }
 
 - (void)setAuthorizationHeaderWithToken:(NSString *)token {
-    [self setDefaultHeader:@"Authorization" value:[NSString stringWithFormat:@"Token token=\"%@\"", token]];
+	[self setAuthorizationHeaderWithToken:token valueFormat:AFNetworkAuthorizationTokenFormatDefault];
+}
+
+- (void)setAuthorizationHeaderWithToken:(NSString *)token valueFormat:(AFNetworkAuthorizationTokenFormat)format
+{
+	switch (format) {
+		case AFNetworkAuthorizationTokenFormatDefault:
+			[self setDefaultHeader:@"Authorization" value:[NSString stringWithFormat:@"Token token=\"%@\"", token]];
+			break;
+		case AFNetworkAuthorizationTokenFormatSlim:
+			[self setDefaultHeader:@"Authorization" value:[NSString stringWithFormat:@"Token %@", token]];
+			return;
+		default:
+			return;
+	}
 }
 
 - (void)clearAuthorizationHeader {


### PR DESCRIPTION
I'm not 100% sure if there's a "proper" way to format this header, but I ran into a situation where the formatting applied by AFNetwork didn't work with my service, as it expected "Authorization: token [token]".

This thread (https://github.com/technoweenie/faraday/issues/127) suggests that the standard is loosely defined, so I've added mechanism for supporting multiple token formats.

Now supports the following
    "Authorization: token token=\"xxx\""
    "Authorization: token xxx"
