### PR TITLE
Avoid appending empty form data parts

### DIFF
--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -509,7 +509,9 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {
             data = [[component.value description] dataUsingEncoding:self.stringEncoding];
         }
         
-        [formData appendPartWithFormData:data name:[component.key description]];
+        if (data) {
+            [formData appendPartWithFormData:data name:[component.key description]];
+        }
     }
 
     if (block) {


### PR DESCRIPTION
AFQueryStringComponentsFromKeyAndValue() always returns at least one
component (even if its _value_ parameter is `nil`).  If a component
doesn't have any form data, there's no need for us to append an empty,
nameless part to the multipart body.

Additional improvements to consider (which are not mutually exclusive
with this change):
- Don't run this loop at all when _parameters_ is `nil`.
- Change AFQueryStringComponentsFromKeyAndValue() to return an empty
  iterable when its _value_ parameter is `nil`.

Also, remove the unused `kAFMultipartFormLineDelimiter` contant.
