### PR TITLE
Possible bugfix

### DIFF
--- a/AFNetworking/AFImageRequestOperation.m
+++ b/AFNetworking/AFImageRequestOperation.m
@@ -113,7 +113,9 @@ static dispatch_queue_t image_request_operation_processing_queue() {
                 dispatch_async(image_request_operation_processing_queue(), ^(void) {
                     NSImage *processedImage = imageProcessingBlock(image);
 
-                    dispatch_async(dispatch_get_main_queue(), ^(void) {
+                    dispatch_async(requestOperation.successCallbackQueue?
+                                   requestOperation.successCallbackQueue:
+                                   dispatch_get_main_queue(), ^(void) {
                         success(operation.request, operation.response, processedImage);
                     });
                 });


### PR DESCRIPTION
I've found that image downloading may contain some kind of bug. There is a possibility to provide image post-processing block which is called to modify image after downloading. After applying this block, success block is called in main queue and it's hardcoded. However, there is a possibility to set a separate queue for success block calling and I think it definitely should be taken into account while calling success block after image post processing is done.
What do you think?
