### PR TITLE
Let NSJSON parse top-level objects.

### DIFF
--- a/AFNetworking/AFJSONUtilities.m
+++ b/AFNetworking/AFJSONUtilities.m
@@ -200,7 +200,7 @@ id AFJSONDecode(NSData *data, NSError **error) {
         invocation.selector = _NSJSONSerializationSelector;
 
         [invocation setArgument:&data atIndex:2]; // arguments 0 and 1 are self and _cmd respectively, automatically set by NSInvocation
-        NSUInteger readOptions = 0;
+        NSUInteger readOptions = NSJSONReadingAllowFragments;
         [invocation setArgument:&readOptions atIndex:3];
         if (error != NULL) {
             [invocation setArgument:&error atIndex:4];


### PR DESCRIPTION
I've got an API returning 'true' and 'null' JSON responses. It seems better
to be liberal in what we accept.

If this approach is problematic could we have a way of setting the options?
