### PR TITLE
Automatically use HTTP pipelining for GET and HEAD requests in AFHTTPClient

### DIFF
--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -453,6 +453,10 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {
 	NSMutableURLRequest *request = [[[NSMutableURLRequest alloc] initWithURL:url] autorelease];
     [request setHTTPMethod:method];
     [request setAllHTTPHeaderFields:self.defaultHeaders];
+
+    if ([method isEqualToString:@"GET"] || [method isEqualToString:@"HEAD"]) {
+        [request setHTTPShouldUsePipelining:YES];
+    }
 	
     if (parameters) {        
         if ([method isEqualToString:@"GET"] || [method isEqualToString:@"HEAD"] || [method isEqualToString:@"DELETE"]) {


### PR DESCRIPTION
Based on the suggestions in a WWDC session about networking, I'm starting to reconsider my original position on HTTP pipelining. There are some servers that don't support it, but for those that do, the performance benefit has been reported up to 3x speed improvement.

HTTP pipelining is already enabled by default on image requests, and we've yet to have any reports about that causing a problem.

This patch enables pipelining by default for requests using the almost-definitely-always-idempotent methods GET and HEAD.

Does this sound reasonable? Is there any strong reason why this shouldn't be done?
