### PR TITLE
Set the AFHTTPClient's networkReachability after the reachability callback

### DIFF
--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -367,10 +367,10 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {
     self.networkReachability = SCNetworkReachabilityCreateWithName(kCFAllocatorDefault, [[self.baseURL host] UTF8String]);
     
     AFNetworkReachabilityStatusBlock callback = ^(AFNetworkReachabilityStatus status){
-        self.networkReachabilityStatus = status;
         if (self.networkReachabilityStatusBlock) {
             self.networkReachabilityStatusBlock(status);
         }
+        self.networkReachabilityStatus = status;
     };
     
     SCNetworkReachabilityContext context = {0, callback, AFNetworkReachabilityRetainCallback, AFNetworkReachabilityReleaseCallback, NULL};


### PR DESCRIPTION
This allows folks to check in their reachability callback what the reachability is changing _from_ by accessing the `self.networkReachabilityStatus` property.
