### PR TITLE
Fix an issue where canceling a request would not do so because there is no internet connection

### DIFF
--- a/AFNetworking/AFJSONRequestOperation.m
+++ b/AFNetworking/AFJSONRequestOperation.m
@@ -110,6 +110,9 @@ static dispatch_queue_t json_request_operation_processing_queue() {
         if (self.error) {
             if (failure) {
                 dispatch_async(self.failureCallbackQueue ? self.failureCallbackQueue : dispatch_get_main_queue(), ^{
+                    if ([self isCancelled]) {
+                        return;
+                    }
                     failure(self, self.error);
                 });
             }
@@ -120,12 +123,20 @@ static dispatch_queue_t json_request_operation_processing_queue() {
                 if (self.JSONError) {
                     if (failure) {
                         dispatch_async(self.failureCallbackQueue ? self.failureCallbackQueue : dispatch_get_main_queue(), ^{
+                            if ([self isCancelled]) {
+                                return;
+                            }
+
                             failure(self, self.error);
                         });
                     }
                 } else {
                     if (success) {
                         dispatch_async(self.successCallbackQueue ? self.successCallbackQueue : dispatch_get_main_queue(), ^{
+                            if ([self isCancelled]) {
+                                return;
+                            }
+
                             success(self, JSON);
                         });
                     }                    

--- a/AFNetworking/AFURLConnectionOperation.m
+++ b/AFNetworking/AFURLConnectionOperation.m
@@ -435,7 +435,7 @@ static inline BOOL AFStateTransitionIsValid(AFOperationState fromState, AFOperat
 
 - (void)cancel {
     [self.lock lock];
-    if (![self isFinished] && ![self isCancelled]) {
+    if (/*![self isFinished] && */![self isCancelled]) {
         [self willChangeValueForKey:@"isCancelled"];
         _cancelled = YES;
         [super cancel];


### PR DESCRIPTION
Causing the block to be called even though the you explicitly say you wanted to cancel the request.
