### PR TITLE
DELETE paramaters encoding location

### DIFF
--- a/AFNetworking/AFHTTPClient.h
+++ b/AFNetworking/AFHTTPClient.h
@@ -149,6 +149,11 @@ extern NSString * AFQueryStringFromParametersWithEncoding(NSDictionary *paramete
 @property (nonatomic, assign) AFHTTPClientParameterEncoding parameterEncoding;
 
 /**
+ This specifies where the paramaters for a DELETE request are encoded, YES for in the URL and NO for in the HTTP Request Body. Is Yes by default to support backwords compatability.
+ */
+@property (nonatomic, assign) BOOL deleteParamsEncodedInURL;
+
+/**
  The operation queue which manages operations enqueued by the HTTP client.
  */
 @property (readonly, nonatomic, retain) NSOperationQueue *operationQueue;

--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -237,6 +237,7 @@ static NSString * AFPropertyListStringFromParameters(NSDictionary *parameters) {
 @synthesize baseURL = _baseURL;
 @synthesize stringEncoding = _stringEncoding;
 @synthesize parameterEncoding = _parameterEncoding;
+@synthesize deleteParamsEncodedInURL = _deleteParamsEncodedInURL;
 @synthesize registeredHTTPOperationClassNames = _registeredHTTPOperationClassNames;
 @synthesize defaultHeaders = _defaultHeaders;
 @synthesize operationQueue = _operationQueue;
@@ -260,7 +261,8 @@ static NSString * AFPropertyListStringFromParameters(NSDictionary *parameters) {
     
     self.stringEncoding = NSUTF8StringEncoding;
     self.parameterEncoding = AFFormURLParameterEncoding;
-	
+	self.deleteParamsEncodedInURL = YES;
+    
     self.registeredHTTPOperationClassNames = [NSMutableArray array];
     
 	self.defaultHeaders = [NSMutableDictionary dictionary];
@@ -459,7 +461,7 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {
     }
 	
     if (parameters) {        
-        if ([method isEqualToString:@"GET"] || [method isEqualToString:@"HEAD"]) {
+        if ([method isEqualToString:@"GET"] || [method isEqualToString:@"HEAD"] || (self.deleteParamsEncodedInURL && [method isEqualToString:@"DELETE"])) {
             url = [NSURL URLWithString:[[url absoluteString] stringByAppendingFormat:[path rangeOfString:@"?"].location == NSNotFound ? @"?%@" : @"&%@", AFQueryStringFromParametersWithEncoding(parameters, self.stringEncoding)]];
             [request setURL:url];
         } else {


### PR DESCRIPTION
These changes allow for the DELETE parameters to be encoded in the HTTP request body instead of the URL. This is how the documentation for the class describes the deletePath:parameters:success:failure: and with the property added it does not break existing code that relies on the params in the URL. This also creates compatibility with the Code Igniter RESTful implementation.

Feel free to edit the names or comments.
