### PR TITLE
Fix threading issue with AFNetworkActivityIndicatorManager.

### DIFF
--- a/AFNetworking/AFNetworkActivityIndicatorManager.m
+++ b/AFNetworking/AFNetworkActivityIndicatorManager.m
@@ -77,8 +77,8 @@ static NSTimeInterval const kAFNetworkActivityIndicatorInvisibilityDelay = 0.25;
         // Delay hiding of activity indicator for a short interval, to avoid flickering
         if (![self isNetworkActivityIndicatorVisible]) {
             [self.activityIndicatorVisibilityTimer invalidate];
-            self.activityIndicatorVisibilityTimer = [NSTimer timerWithTimeInterval:kAFNetworkActivityIndicatorInvisibilityDelay target:self selector:@selector(updateNetworkActivityIndicatorVisibility) userInfo:nil repeats:NO];
-            [[NSRunLoop currentRunLoop] addTimer:self.activityIndicatorVisibilityTimer forMode:NSRunLoopCommonModes];
+            self.activityIndicatorVisibilityTimer = [NSTimer timerWithTimeInterval:kAFNetworkActivityIndicatorInvisibilityDelay target:self selector:@selector(updateNetworkActivityIndicatorVisibilityOnCurrentQueue) userInfo:nil repeats:NO];
+            [[NSRunLoop mainRunLoop] addTimer:self.activityIndicatorVisibilityTimer forMode:NSRunLoopCommonModes];
         } else {
             [self updateNetworkActivityIndicatorVisibility];
         }
@@ -91,8 +91,12 @@ static NSTimeInterval const kAFNetworkActivityIndicatorInvisibilityDelay = 0.25;
 
 - (void)updateNetworkActivityIndicatorVisibility {
     dispatch_async(dispatch_get_main_queue(), ^{
-        [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:[self isNetworkActivityIndicatorVisible]];
+        [self updateNetworkActivityIndicatorVisibilityOnCurrentQueue];
     });
+}
+
+- (void)updateNetworkActivityIndicatorVisibilityOnCurrentQueue {
+    [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:[self isNetworkActivityIndicatorVisible]];
 }
 
 // Not exposed, but used if activityCount is set via KVC.


### PR DESCRIPTION
AFNetworkActivityIndicatorManager still has a problem when decrementing from a background thread. The code intends to delay the hiding of the indicator to suppress flashing via a timer. The timer was added to the current run loop which, depending on the thread, will never fire.

The fix was trivial - put the timer on the mainRunLoop rather than the currentRunLoop.

I also made an additional fix to avoid an extra dispatch_async onto the main queue when responding to the timer - since the timer is already firing on the proper queue/thread.
