### PR TITLE
iOS 6 Warnings Fix

### DIFF
--- a/AFNetworking/AFHTTPRequestOperation.h
+++ b/AFNetworking/AFHTTPRequestOperation.h
@@ -85,12 +85,12 @@ extern NSString * AFCreateIncompleteDownloadDirectoryPath(void);
 /** 
  The callback dispatch queue on success. If `NULL` (default), the main queue is used.
  */
-@property (nonatomic) dispatch_queue_t successCallbackQueue;
+@property (nonatomic, assign) dispatch_queue_t successCallbackQueue;
 
 /** 
  The callback dispatch queue on failure. If `NULL` (default), the main queue is used.
  */
-@property (nonatomic) dispatch_queue_t failureCallbackQueue;
+@property (nonatomic, assign) dispatch_queue_t failureCallbackQueue;
 
 ///-------------------------------------------------------------
 /// @name Managing Accceptable HTTP Status Codes & Content Types


### PR DESCRIPTION
in Xcode 4.5 DP2 (iOS 6 SDK), Xcode reports 4 warnings. for these lines:

```
@property (nonatomic) dispatch_queue_t successCallbackQueue;
@property (nonatomic) dispatch_queue_t failureCallbackQueue;
```

This fix makes the properties explicitly 'assign' so that Xcode does not report these warnings.  assign attribute is automatic if not specified, so this should not affect any functionality.
