### PR TITLE
Fixed sign conversion warning.

### DIFF
--- a/AFNetworking/AFHTTPRequestOperation.m
+++ b/AFNetworking/AFHTTPRequestOperation.m
@@ -188,7 +188,7 @@ NSString * AFCreateIncompleteDownloadDirectoryPath(void) {
 }
 
 - (BOOL)hasAcceptableStatusCode {
-    return ![[self class] acceptableStatusCodes] || [[[self class] acceptableStatusCodes] containsIndex:[self.response statusCode]];
+    return ![[self class] acceptableStatusCodes] || [[[self class] acceptableStatusCodes] containsIndex:(NSUInteger)[self.response statusCode]];
 }
 
 - (BOOL)hasAcceptableContentType {


### PR DESCRIPTION
containsIndex takes a NSUInteger, not a NSInteger. When CLANG_WARN_IMPLICIT_SIGN_CONVERSION is set, this generates a warning.

This is easily fixed with a typecast.
