### PR TITLE
Fixed incomplete implementation warning.

### DIFF
--- a/Example/Classes/Models/User.m
+++ b/Example/Classes/Models/User.m
@@ -26,7 +26,9 @@
 NSString * const kUserProfileImageDidLoadNotification = @"com.alamofire.user.profile-image.loaded";
 
 @interface User ()
+#if __MAC_OS_X_VERSION_MIN_REQUIRED
 + (NSOperationQueue *)sharedProfileImageRequestOperationQueue;
+#endif
 @end
 
 @implementation User {


### PR DESCRIPTION
sharedProfileImageRequestOperationQueue is declared in interface extension, but only implemented on Mac OS X. This causes an incomplete implementation warning. Added same #if around interface as surrounds impelmentation.

This only affects the example project.
