### PR TITLE
Fixes warning about using == on floats.

### DIFF
--- a/AFNetworking/AFImageRequestOperation.m
+++ b/AFNetworking/AFImageRequestOperation.m
@@ -161,9 +161,12 @@ static dispatch_queue_t image_request_operation_processing_queue() {
 }
 
 - (void)setImageScale:(CGFloat)imageScale {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wfloat-equal"
     if (imageScale == _imageScale) {
         return;
     }
+#pragma clang diagnostic pop
     
     _imageScale = imageScale;
     


### PR DESCRIPTION
If the value changes from near to 2.0 to some other near 2.0, it's fine to recalculate.

Thus, use #pragma clang diagnostic to explicitly turn off the float-equal warning.
