### PR TITLE
Fixed compiler error in AFHTTPRequestOperation; #417

### DIFF
--- a/AFNetworking/AFHTTPRequestOperation.m
+++ b/AFNetworking/AFHTTPRequestOperation.m
@@ -56,7 +56,7 @@ NSSet * AFContentTypesFromHTTPHeader(NSString *string) {
 
 static void AFSwizzleClassMethodWithClassAndSelectorUsingBlock(Class klass, SEL selector, void *block) {
     Method originalMethod = class_getClassMethod(klass, selector);
-    IMP implementation = imp_implementationWithBlock(block);
+    IMP implementation = imp_implementationWithBlock((__bridge id)(block));
     class_replaceMethod(objc_getMetaClass([NSStringFromClass(klass) UTF8String]), selector, implementation, method_getTypeEncoding(originalMethod));
 }
 


### PR DESCRIPTION
Casting (void *) block to (__bridge id).  Required as of Xcode 4.4
