### PR TITLE
Declare use of the NSURLConnectionDelegate protocol.

### DIFF
--- a/AFNetworking/AFURLConnectionOperation.h
+++ b/AFNetworking/AFURLConnectionOperation.h
@@ -75,7 +75,7 @@ extern NSString * const AFNetworkingOperationDidFinishNotification;
  
  @warning Attempting to load a `file://` URL in iOS 4 may result in an `NSInvalidArgumentException`, caused by the connection returning `NSURLResponse` rather than `NSHTTPURLResponse`, which is the behavior as of iOS 5.
  */
-@interface AFURLConnectionOperation : NSOperation
+@interface AFURLConnectionOperation : NSOperation <NSURLConnectionDelegate>
 
 ///-------------------------------
 /// @name Accessing Run Loop Modes


### PR DESCRIPTION
This allows subclasses to formally override NSURLConnectionDelegate
methods.
