### PR TITLE
initWithBaseURL should treat URL as directory

### DIFF
--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -254,6 +254,9 @@ static NSString * AFPropertyListStringFromParameters(NSDictionary *parameters) {
         return nil;
     }
     
+    if ( [[url path] length] > 0 && ![[url absoluteString] hasSuffix: @"/"] ) {
+        url = [url URLByAppendingPathComponent: @""];
+    }
     self.baseURL = url;
     
     self.stringEncoding = NSUTF8StringEncoding;


### PR DESCRIPTION
Fixes #446. If the URL passed into initWithBaseURL is a file URL rather than a directory URL we will fix it.

Without this fix, if you provide "http://myhost/api" as a baseURL and try to get "path", AFNetworking will get http://myhost/path instead of http://myhost/api/path. With the fix, we'll change http://myhost/api to http://myhost/api/.
