### PR TITLE
don't use __weak for completionBlocks. (Issue #414)

### DIFF
--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -570,7 +570,7 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {
     for (AFHTTPRequestOperation *operation in operations) {
         AFCompletionBlock originalCompletionBlock = [operation.completionBlock copy];
         operation.completionBlock = ^{
-            dispatch_queue_t queue = operation.successCallbackQueue ? operation.successCallbackQueue : dispatch_get_main_queue();
+            dispatch_queue_t queue = operation.successCallbackQueue ?: dispatch_get_main_queue();
             dispatch_group_async(dispatchGroup, queue, ^{
                 if (originalCompletionBlock) {
                     originalCompletionBlock();

--- a/AFNetworking/AFHTTPRequestOperation.m
+++ b/AFNetworking/AFHTTPRequestOperation.m
@@ -222,26 +222,29 @@ NSString * AFCreateIncompleteDownloadDirectoryPath(void) {
 - (void)setCompletionBlockWithSuccess:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
                               failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure
 {
-    __weak AFHTTPRequestOperation *weakSelf = self;
+    // completion block is manually nilled out in AFURLConnectionOperation to break the retain cycle.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-retain-cycles"
     self.completionBlock = ^ {
-        if ([weakSelf isCancelled]) {
+        if ([self isCancelled]) {
             return;
         }
         
-        if (weakSelf.error) {
+        if (self.error) {
             if (failure) {
-                dispatch_async(weakSelf.failureCallbackQueue ? weakSelf.failureCallbackQueue : dispatch_get_main_queue(), ^{
-                    failure(weakSelf, weakSelf.error);
+                dispatch_async(self.failureCallbackQueue ?: dispatch_get_main_queue(), ^{
+                    failure(self, self.error);
                 });
             }
         } else {
             if (success) {
-                dispatch_async(weakSelf.successCallbackQueue ? weakSelf.successCallbackQueue : dispatch_get_main_queue(), ^{
-                    success(weakSelf, weakSelf.responseData);
+                dispatch_async(self.successCallbackQueue ?: dispatch_get_main_queue(), ^{
+                    success(self, self.responseData);
                 });
             }
         }
     };
+#pragma clang diagnostic pop
 }
 
 - (void)setResponseFilePath:(NSString *)responseFilePath {

--- a/AFNetworking/AFJSONRequestOperation.m
+++ b/AFNetworking/AFJSONRequestOperation.m
@@ -96,38 +96,40 @@ static dispatch_queue_t json_request_operation_processing_queue() {
 - (void)setCompletionBlockWithSuccess:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
                               failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure
 {
-    __weak AFJSONRequestOperation *weakSelf = self;
-    self.completionBlock = ^ {
-        if ([weakSelf isCancelled]) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-retain-cycles"
+   self.completionBlock = ^ {
+        if ([self isCancelled]) {
             return;
         }
         
-        if (weakSelf.error) {
+        if (self.error) {
             if (failure) {
-                dispatch_async(weakSelf.failureCallbackQueue ? weakSelf.failureCallbackQueue : dispatch_get_main_queue(), ^{
-                    failure(weakSelf, weakSelf.error);
+                dispatch_async(self.failureCallbackQueue ?: dispatch_get_main_queue(), ^{
+                    failure(self, self.error);
                 });
             }
         } else {
             dispatch_async(json_request_operation_processing_queue(), ^{
-                id JSON = weakSelf.responseJSON;
+                id JSON = self.responseJSON;
                 
                 if (self.JSONError) {
                     if (failure) {
-                        dispatch_async(weakSelf.failureCallbackQueue ? weakSelf.failureCallbackQueue : dispatch_get_main_queue(), ^{
-                            failure(weakSelf, weakSelf.error);
+                        dispatch_async(self.failureCallbackQueue ?: dispatch_get_main_queue(), ^{
+                            failure(self, self.error);
                         });
                     }
                 } else {
                     if (success) {
-                        dispatch_async(weakSelf.successCallbackQueue ? weakSelf.successCallbackQueue : dispatch_get_main_queue(), ^{
-                            success(weakSelf, JSON);
+                        dispatch_async(self.successCallbackQueue ?: dispatch_get_main_queue(), ^{
+                            success(self, JSON);
                         });
                     }                    
                 }
             });
         }
-    };    
+    };
+#pragma clang diagnostic pop
 }
 
 @end

--- a/AFNetworking/AFPropertyListRequestOperation.m
+++ b/AFNetworking/AFPropertyListRequestOperation.m
@@ -106,38 +106,40 @@ static dispatch_queue_t property_list_request_operation_processing_queue() {
 - (void)setCompletionBlockWithSuccess:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
                               failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure
 {
-    __weak AFPropertyListRequestOperation *weakSelf = self;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-retain-cycles"
     self.completionBlock = ^ {
-        if ([weakSelf isCancelled]) {
+        if ([self isCancelled]) {
             return;
         }
         
-        if (weakSelf.error) {
+        if (self.error) {
             if (failure) {
-                dispatch_async(weakSelf.failureCallbackQueue ? weakSelf.failureCallbackQueue : dispatch_get_main_queue(), ^{
-                    failure(weakSelf, weakSelf.error);
+                dispatch_async(self.failureCallbackQueue ?: dispatch_get_main_queue(), ^{
+                    failure(self, self.error);
                 });
             }
         } else {
             dispatch_async(property_list_request_operation_processing_queue(), ^(void) {
-                id propertyList = weakSelf.responsePropertyList;
+                id propertyList = self.responsePropertyList;
                 
                 if (self.propertyListError) {
                     if (failure) {
-                        dispatch_async(weakSelf.failureCallbackQueue ? weakSelf.failureCallbackQueue : dispatch_get_main_queue(), ^{
-                            failure(weakSelf, weakSelf.error);
+                        dispatch_async(self.failureCallbackQueue ?: dispatch_get_main_queue(), ^{
+                            failure(self, self.error);
                         });
                     }
                 } else {
                     if (success) {
-                        dispatch_async(weakSelf.successCallbackQueue ? weakSelf.successCallbackQueue : dispatch_get_main_queue(), ^{
-                            success(weakSelf, propertyList);
+                        dispatch_async(self.successCallbackQueue ?: dispatch_get_main_queue(), ^{
+                            success(self, propertyList);
                         });
                     } 
                 }
             });
         }
-    };    
+    };
+#pragma clang diagnostic pop
 }
 
 @end

--- a/AFNetworking/AFXMLRequestOperation.m
+++ b/AFNetworking/AFXMLRequestOperation.m
@@ -138,30 +138,32 @@ static dispatch_queue_t xml_request_operation_processing_queue() {
 - (void)setCompletionBlockWithSuccess:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
                               failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure
 {
-    __weak AFXMLRequestOperation *weakSelf = self;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-retain-cycles"
     self.completionBlock = ^ {
-        if ([weakSelf isCancelled]) {
+        if ([self isCancelled]) {
             return;
         }
         
         dispatch_async(xml_request_operation_processing_queue(), ^(void) {
-            NSXMLParser *XMLParser = weakSelf.responseXMLParser;
+            NSXMLParser *XMLParser = self.responseXMLParser;
             
             if (self.error) {
                 if (failure) {
-                    dispatch_async(weakSelf.failureCallbackQueue ? weakSelf.failureCallbackQueue : dispatch_get_main_queue(), ^{
-                        failure(weakSelf, weakSelf.error);
+                    dispatch_async(self.failureCallbackQueue ?: dispatch_get_main_queue(), ^{
+                        failure(self, self.error);
                     });
                 }
             } else {
                 if (success) {
-                    dispatch_async(weakSelf.successCallbackQueue ? weakSelf.successCallbackQueue : dispatch_get_main_queue(), ^{
-                        success(weakSelf, XMLParser);
+                    dispatch_async(self.successCallbackQueue ?: dispatch_get_main_queue(), ^{
+                        success(self, XMLParser);
                     });
                 } 
             }
         });
-    };    
+    };
+#pragma clang diagnostic pop
 }
 
 @end


### PR DESCRIPTION
We nil out the completionBlock manually in AFURLConnectionOperation. Using __weak here potentially doesn't call the set completion blocks.
Restores iOS4 compatibility. Also shortens inline ifs with a ternary conditional(?:).
