### PR TITLE
add accept header for setImageWithURL

### DIFF
--- a/AFNetworking/UIImageView+AFNetworking.m
+++ b/AFNetworking/UIImageView+AFNetworking.m
@@ -89,7 +89,7 @@ static char kAFImageRequestOperationObjectKey;
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url cachePolicy:NSURLRequestUseProtocolCachePolicy timeoutInterval:30.0];
     [request setHTTPShouldHandleCookies:NO];
     [request setHTTPShouldUsePipelining:YES];
-    
+    [request addValue:@"image/*" forHTTPHeaderField:@"Accept"];
     [self setImageWithURLRequest:request placeholderImage:placeholderImage success:nil failure:nil];
 }
 


### PR DESCRIPTION
Currently the accepts header gets sets as Accept */\* for setImageWithURL

Since this is for an image request, would it be ok to set the header to Accept image/\* as the accept header
