### PR TITLE
ImageView+AFNetworking category support for OSX

### DIFF
--- a/AFNetworking/AFNetworking.h
+++ b/AFNetworking/AFNetworking.h
@@ -35,10 +35,11 @@
 #import "AFHTTPClient.h"
 
 #import "AFImageRequestOperation.h"
+#import "UIImageView+AFNetworking.h"
 
 #if __IPHONE_OS_VERSION_MIN_REQUIRED
 #import "AFNetworkActivityIndicatorManager.h"
-#import "UIImageView+AFNetworking.h"
 #endif
+
 
 #endif /* _AFNETWORKING_ */

--- a/AFNetworking/UIImageView+AFNetworking.h
+++ b/AFNetworking/UIImageView+AFNetworking.h
@@ -26,7 +26,20 @@
 #import <Availability.h>
 
 #if __IPHONE_OS_VERSION_MIN_REQUIRED
+
 #import <UIKit/UIKit.h>
+
+#else
+
+#import <AppKit/AppKit.h>
+#ifndef UIImage
+#define UIImage NSImage
+#endif
+#ifndef UIImageView
+#define UIImageView NSImageView
+#endif
+
+#endif
 
 /**
  This category adds methods to the UIKit framework's `UIImageView` class. The methods in this category provide support for loading remote images asynchronously from a URL.
@@ -72,5 +85,3 @@
 - (void)cancelImageRequestOperation;
 
 @end
-
-#endif

--- a/AFNetworking/UIImageView+AFNetworking.m
+++ b/AFNetworking/UIImageView+AFNetworking.m
@@ -23,7 +23,6 @@
 #import <Foundation/Foundation.h>
 #import <objc/runtime.h>
 
-#if __IPHONE_OS_VERSION_MIN_REQUIRED
 #import "UIImageView+AFNetworking.h"
 
 @interface AFImageCache : NSCache
@@ -179,5 +178,3 @@ static inline NSString * AFImageCacheKeyFromURLRequest(NSURLRequest *request) {
 }
 
 @end
-
-#endif


### PR DESCRIPTION
This patch consists in replacing UIImageView by NSImageView if AFNetworking is user in an OSX app.

`- (void)setImageWithURL:placeholderImage:` and `- (void)setImageWithURLRequest:placeholderImage:success:failure:` were tested successfully. They should be the only two critical methods for this modification, but further tests are welcomed.
