### PR TITLE
Allow the cancelling of all requests on a client

### DIFF
--- a/AFNetworking/AFHTTPClient.h
+++ b/AFNetworking/AFHTTPClient.h
@@ -344,9 +344,14 @@ extern NSString * AFQueryStringFromParametersWithEncoding(NSDictionary *paramete
  Cancels all operations in the HTTP client's operation queue whose URLs match the specified HTTP method and path.
  
  @param method The HTTP method to match for the cancelled requests, such as `GET`, `POST`, `PUT`, or `DELETE`. If `nil`, all request operations with URLs matching the path will be cancelled. 
- @param url The path to match for the cancelled requests.
+ @param url The path to match for the cancelled requests. If `nil`, path will be ignored in matching request operations.
  */
 - (void)cancelAllHTTPOperationsWithMethod:(NSString *)method path:(NSString *)path;
+
+/**
+ Cancels all operations in the HTTP client's operation queue.
+ */
+- (void)cancelAllHTTPOperations;
 
 ///---------------------------------------
 /// @name Batching HTTP Request Operations

--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -552,10 +552,14 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {
             continue;
         }
         
-        if ((!method || [method isEqualToString:[[(AFHTTPRequestOperation *)operation request] HTTPMethod]]) && [path isEqualToString:[[[(AFHTTPRequestOperation *)operation request] URL] path]]) {
+        if ((!method || [method isEqualToString:[[(AFHTTPRequestOperation *)operation request] HTTPMethod]]) && (!path || [path isEqualToString:[[[(AFHTTPRequestOperation *)operation request] URL] path]])) {
             [operation cancel];
         }
     }
+}
+
+- (void)cancelAllHTTPOperations {
+    [self cancelAllHTTPOperationsWithMethod:nil path:nil];
 }
 
 - (void)enqueueBatchOfHTTPRequestOperationsWithRequests:(NSArray *)requests 


### PR DESCRIPTION
I had the need to be able to cancel every request on a client. This adds a `cancelAllHTTPOperations` and also changes `cancelAllHTTPOperationsWithMethod:path:` to ignore the path parameter if it's `nil`.
