### PR TITLE
Faster calculation of the count of finished operations in a queue.

### DIFF
--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -585,8 +585,6 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {
         dispatch_release(dispatchGroup);
     }];
     
-    NSPredicate *finishedOperationPredicate = [NSPredicate predicateWithFormat:@"isFinished == YES"];
-    
     for (AFHTTPRequestOperation *operation in operations) {
         AFCompletionBlock originalCompletionBlock = [[operation.completionBlock copy] autorelease];
         operation.completionBlock = ^{
@@ -597,7 +595,13 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {
                 }
                 
                 if (progressBlock) {
-                    progressBlock([[operations filteredArrayUsingPredicate:finishedOperationPredicate] count], [operations count]);
+                    NSInteger finishedOperationCount = 0;
+                    for (AFHTTPRequestOperation *o in operations) {
+                        if (o.isFinished) {
+                            finishedOperationCount++;
+                        }
+                    }                    
+                    progressBlock(finishedOperationCount, [operations count]);
                 }
                 
                 dispatch_group_leave(dispatchGroup);


### PR DESCRIPTION
This works around a performance issue with NSPredicate that arises when canceling queues with a large number of operations. Since the progress blocks are generally executed on the main thread, the UI can be blocked for several seconds when large queues are cancelled. Fast Enumeration performs much better, completing in roughly .0004s for ~1700 operations vs .0090s when using filteredArrayUsingPredicate.
