### PR TITLE
Automatically dispatch callbacks to the calling queue

### DIFF
--- a/AFNetworking/AFHTTPRequestOperation.m
+++ b/AFNetworking/AFHTTPRequestOperation.m
@@ -209,6 +209,13 @@ static NSString * AFStringFromIndexSet(NSIndexSet *indexSet) {
 - (void)setCompletionBlockWithSuccess:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
                               failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure
 {
+    if (!self.successCallbackQueue) {
+        self.successCallbackQueue = dispatch_get_current_queue();
+    }
+    if (!self.failureCallbackQueue) {
+        self.failureCallbackQueue = dispatch_get_current_queue();
+    }
+    
     self.completionBlock = ^ {
         if ([self isCancelled]) {
             return;

--- a/AFNetworking/AFImageRequestOperation.m
+++ b/AFNetworking/AFImageRequestOperation.m
@@ -205,6 +205,13 @@ static dispatch_queue_t image_request_operation_processing_queue() {
 - (void)setCompletionBlockWithSuccess:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
                               failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure
 {
+    if (!self.successCallbackQueue) {
+      self.successCallbackQueue = dispatch_get_current_queue();
+    }
+    if (!self.failureCallbackQueue) {
+      self.failureCallbackQueue = dispatch_get_current_queue();
+    }
+    
     self.completionBlock = ^ {
         if ([self isCancelled]) {
             return;

--- a/AFNetworking/AFJSONRequestOperation.m
+++ b/AFNetworking/AFJSONRequestOperation.m
@@ -102,6 +102,13 @@ static dispatch_queue_t json_request_operation_processing_queue() {
 - (void)setCompletionBlockWithSuccess:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
                               failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure
 {
+    if (!self.successCallbackQueue) {
+      self.successCallbackQueue = dispatch_get_current_queue();
+    }
+    if (!self.failureCallbackQueue) {
+      self.failureCallbackQueue = dispatch_get_current_queue();
+    }
+    
     self.completionBlock = ^ {
         if ([self isCancelled]) {
             return;

--- a/AFNetworking/AFPropertyListRequestOperation.m
+++ b/AFNetworking/AFPropertyListRequestOperation.m
@@ -111,6 +111,13 @@ static dispatch_queue_t property_list_request_operation_processing_queue() {
 - (void)setCompletionBlockWithSuccess:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
                               failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure
 {
+    if (!self.successCallbackQueue) {
+      self.successCallbackQueue = dispatch_get_current_queue();
+    }
+    if (!self.failureCallbackQueue) {
+      self.failureCallbackQueue = dispatch_get_current_queue();
+    }
+    
     self.completionBlock = ^ {
         if ([self isCancelled]) {
             return;

--- a/AFNetworking/AFXMLRequestOperation.m
+++ b/AFNetworking/AFXMLRequestOperation.m
@@ -149,6 +149,13 @@ static dispatch_queue_t xml_request_operation_processing_queue() {
 - (void)setCompletionBlockWithSuccess:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
                               failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure
 {
+    if (!self.successCallbackQueue) {
+      self.successCallbackQueue = dispatch_get_current_queue();
+    }
+    if (!self.failureCallbackQueue) {
+      self.failureCallbackQueue = dispatch_get_current_queue();
+    }
+
     self.completionBlock = ^ {
         if ([self isCancelled]) {
             return;


### PR DESCRIPTION
GREETINGS.

This patch changes the default dispatch queue on which AFNetworking calls your success and failure blocks. 

Currently, AFNetworking calls you back on the main queue unless you specifically request otherwise using `successCallbackQueue` and `failureCallbackQueue`. This patch changes AFNetworking so it assumes that the queue _calling_ the `setCompletionBlockWithSuccess:failure:` selector is the intended callback queue. Because all paths lead to `setCompletionBlockWithSuccess:failure:`, this patch also changes the behavior of the more commonly-used APIs, such as the lovable `getPath:parameters:success:failure:`.

This allows `AFHTTPRequestOperation`, its subclasses, and the get/post/put/delete/patch methods on `AFHTTPClient`, to be used safely from long-lived background queues, such as an `NSOperation` performing a multi-request action.

In (I posit) 90% of use cases, it will end up dispatching on the main queue anyway, exactly as it worked previously. However, I believe this implementation better fits with what one expects when using blocks. The (beautiful) illusion blocks create for the developer is that code is happening later, but in nearly (or very nearly) the same context. This helps preserve that illusion in the (admittedly rarer) cases where you call AFNetworking from a non-main queue.

I tested this patch in the two example applications, and I've been using it in a private application I'm developing for a client.

I fully expect some discussion (or an outright close!) of this pull request. I also recognize that it may be appropriate to add this same functionality in `AFHTTPClient`'s `enqueueBatchOfHTTPRequestOperations:progressBlock:completionBlock:`. I am totally willing to do this and squash it if people like the spirit of the patch.

P.S. I am a huge fan of AFNetworking and recommend it to anyone who asks.
