### PR TITLE
hasAcceptableStatusCode will return true after network failure

### DIFF
--- a/AFNetworking/AFHTTPRequestOperation.m
+++ b/AFNetworking/AFHTTPRequestOperation.m
@@ -173,7 +173,12 @@ static NSString * AFStringFromIndexSet(NSIndexSet *indexSet) {
 }
 
 - (BOOL)hasAcceptableStatusCode {
-    NSUInteger statusCode = ([self.response isKindOfClass:[NSHTTPURLResponse class]]) ? (NSUInteger)[self.response statusCode] : 0;
+	if(!self.response) {
+		// no response means network failure or such
+		return NO;
+	}
+
+    NSUInteger statusCode = ([self.response isKindOfClass:[NSHTTPURLResponse class]]) ? (NSUInteger)[self.response statusCode] : 200;
     return ![[self class] acceptableStatusCodes] || [[[self class] acceptableStatusCodes] containsIndex:statusCode];
 }
 


### PR DESCRIPTION
I just found a problem where hasAcceptableStatusCode will return true after a network failure.

Steps to reproduce:

1> disable network connectivity on device (airplane mode)

2> create network operation 

3> add operation to queue

4> use "[operation waitUntilFinished]"

5> test "[operation hasAcceptableStatusCode]"

(it will return true even though the network operation failed)
