### PR TITLE
Removing setting Accept-Encoding by default.

### DIFF
--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -251,9 +251,6 @@ static NSString * AFPropertyListStringFromParameters(NSDictionary *parameters) {
     self.registeredHTTPOperationClassNames = [NSMutableArray array];
     
 	self.defaultHeaders = [NSMutableDictionary dictionary];
-    
-	// Accept-Encoding HTTP Header; see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.3
-	[self setDefaultHeader:@"Accept-Encoding" value:@"gzip"];
 	
 	// Accept-Language HTTP Header; see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.4
 	NSString *preferredLanguageCodes = [[NSLocale preferredLanguages] componentsJoinedByString:@", "];


### PR DESCRIPTION
Hi Mattt,

Was wondering if it would be possible to get this change into AFNetworking.

I think it is a bit better behavior since the encodings aren't implemented in userland and it seems the system should set it to what it supports.

It also adds a workaround to a bug we (think) we found in NSURLConnection where in ios5.1 it won't call the connection:willSendRequest delegate method which is what PonyDebugger relies on when it times connections.

We wrote about the workaround in our [readme](https://github.com/square/PonyDebugger#known-issues--improvements), but it would be awesome if AFNetworking could help out with this because I think most of our users are on AFNetworking.

NSURLConnection will set this to the supported formats which is a
superset of gzip. (at least in 5.1 it set deflate as well)
