### PR TITLE
[BUGFIX] Avoid common output stream setup errors, including runloop scheduling

### DIFF
--- a/AFNetworking/AFURLConnectionOperation.m
+++ b/AFNetworking/AFURLConnectionOperation.m
@@ -253,6 +253,10 @@ static inline BOOL AFStateTransitionIsValid(AFOperationState fromState, AFOperat
 }
 
 - (void)setOutputStream:(NSOutputStream *)outputStream {
+    if (outputStream == _outputStream) {
+        return;
+    }
+    
     [self willChangeValueForKey:@"outputStream"];
     [outputStream retain];
     
@@ -262,11 +266,6 @@ static inline BOOL AFStateTransitionIsValid(AFOperationState fromState, AFOperat
     }
     _outputStream = outputStream;
     [self didChangeValueForKey:@"outputStream"];
-    
-    NSRunLoop *runLoop = [NSRunLoop currentRunLoop];
-    for (NSString *runLoopMode in self.runLoopModes) {
-        [self.outputStream scheduleInRunLoop:runLoop forMode:runLoopMode];
-    }
 }
 
 #if __IPHONE_OS_VERSION_MIN_REQUIRED


### PR DESCRIPTION
This commit fixes two bugs with setting the output stream on an URLConnectionOperation, one common and one not:
- The less common bug is setting `outputStream` to the same value twice. If this is done then the value of `outputStream` should not be triggered as updated, and there's also a very good chance that the stream should not be closed, either. If this fix isn't appropriate I can back it out.
- The more common (and dangerous) bug is runloop scheduling. Output streams _may_ be scheduled in multiple runloops according to the documentation. This can create contention between active runloops for performing operations with the stream. Even worse, if the operation is created on (and the `outputStream` is set on) the main thread, this may block main thread activity ESPECIALLY with networks that have high latency or dropped packets (such as Edge or 3G) resulting in a SIGKILL from the OS. Could also cause (possibly severe and hard to diagnose) crashes if an operation were created and scheduled in, say, a callback of another operation.

This fix should resolve some of the "3G crash" issues people seem to experience.
