### PR TITLE
Fix for reachability release issue #529

### DIFF
--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -366,6 +366,7 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {}
     if (_networkReachability) {
         SCNetworkReachabilityUnscheduleFromRunLoop(_networkReachability, CFRunLoopGetMain(), (CFStringRef)NSRunLoopCommonModes);
         CFRelease(_networkReachability);
+        _networkReachability = NULL;
     }
 }
 


### PR DESCRIPTION
Sets the reachability reference to NULL after CFRelease.
