### PR TITLE
Network activity indicator manager changes

### DIFF
--- a/AFNetworking/AFNetworkActivityIndicatorManager.m
+++ b/AFNetworking/AFNetworkActivityIndicatorManager.m
@@ -114,7 +114,9 @@ static NSTimeInterval const kAFNetworkActivityIndicatorInvisibilityDelay = 0.17;
 		_activityCount++;
 	}
     [self didChangeValueForKey:@"activityCount"];
-    [self updateNetworkActivityIndicatorVisibilityDelayed];
+    if (_activityCount == 1) {
+        [self updateNetworkActivityIndicatorVisibilityDelayed];
+    }
 }
 
 - (void)decrementActivityCount {
@@ -126,7 +128,9 @@ static NSTimeInterval const kAFNetworkActivityIndicatorInvisibilityDelay = 0.17;
 		_activityCount--;
 	}
     [self didChangeValueForKey:@"activityCount"];
-    [self updateNetworkActivityIndicatorVisibilityDelayed];
+    if (_activityCount == 0) {
+        [self updateNetworkActivityIndicatorVisibilityDelayed];
+    }
 }
 
 @end


### PR DESCRIPTION
Current implementation allow negative values for the activity counter, that could broke indicator updates. For example, if manager enabled between request lifecycle, it would prevent invocation of the incremental action, so decrement action will set counter to -1. First commit addresses that issue. I also noticed that manager calls indicator status change for every increment/decrement action, second commit changes that. And I wonder is it necessary to make synchronisation locks for the counter changes? I believe that write to atomic non-retained property should be atomic operation. Thank you!
