### PR TITLE
Update AFNetworking/AFHTTPClient.h

### DIFF
--- a/AFNetworking/AFHTTPClient.h
+++ b/AFNetworking/AFHTTPClient.h
@@ -505,7 +505,7 @@ extern NSString * const AFNetworkingReachabilityNotificationStatusItem;
 /**
  The `AFMultipartFormData` protocol defines the methods supported by the parameter in the block argument of `-multipartFormRequestWithMethod:path:parameters:constructingBodyWithBlock:`.
  */
-@protocol AFMultipartFormData
+@protocol AFMultipartFormData <NSObject>
 
 /**
  Appends HTTP headers, followed by the encoded data and the multipart form boundary.


### PR DESCRIPTION
AFMultipartFormData protocol should incorporate NSObject protocol.

 - To prevent compiler errors when performing methods like performSelector: on an instance that conforms to AFMultipartFormData protocol
 - An instance of AFMultipartFormData class inherits from NSObject which conforms to NSObject protocol.
