### PR TITLE
Add error when building without ARC

### DIFF
--- a/AFNetworking/AFURLConnectionOperation.m
+++ b/AFNetworking/AFURLConnectionOperation.m
@@ -25,6 +25,11 @@
 #import <UIKit/UIKit.h>
 #endif
 
+#if !__has_feature(objc_arc)
+#error AFNetworking must be built with ARC.
+// You can turn on ARC for only AFNetworking files by adding -fobjc-arc to the build phase for each of its files.
+#endif
+
 typedef enum {
     AFOperationPausedState      = -1,
     AFOperationReadyState       = 1,


### PR DESCRIPTION
Test if ARC is on, and fail with an #error if not.

This is done in a source file, not a header, so it imposes no constraints on the calling code.

This may be worth adding to each source file, but I thought I'd start with a central one.
