### PR TITLE
-[AFHTTPClient initWithBaseURL:] will now raise an exception with a nil URL parameter.

### DIFF
--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -237,6 +237,10 @@ static NSString * AFPropertyListStringFromParameters(NSDictionary *parameters) {
     if (!self) {
         return nil;
     }
+	
+	if (!url) {
+		[NSException raise:@"-[AFHTTPClient initWithBaseURL:] nil URL" format:@"`url` must not be nil"];
+	}
     
     // Ensure terminal slash for baseURL path, so that NSURL +URLWithString:relativeToURL: works as expected
     if ([[url path] length] > 0 && ![[url absoluteString] hasSuffix:@"/"]) {


### PR DESCRIPTION
## What it does

Modifies `-AFHTTPClient initWithBaseURL:` to raise an exception when the URL passed in is nil. This enforces what the code comments say.

Reachability causes the application to crash on iOS 6 if the baseURL is nil. Exceptions in Cocoa generally used to indicate programmer error, so this exception will help avoid others making this mistake.
## To test

Verify the example applications work as before.
