### PR TITLE
Fix support for nested array parameters

### DIFF
--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -155,7 +155,7 @@ NSArray * AFQueryStringPairsFromKeyAndValue(NSString *key, id value) {
         }];
     } else if([value isKindOfClass:[NSArray class]]) {
         [value enumerateObjectsUsingBlock:^(id nestedValue, NSUInteger idx, BOOL *stop) {
-            [mutableQueryStringComponents addObjectsFromArray:AFQueryStringPairsFromKeyAndValue([NSString stringWithFormat:@"%@[]", key], nestedValue)];
+            [mutableQueryStringComponents addObjectsFromArray:AFQueryStringPairsFromKeyAndValue([NSString stringWithFormat:@"%@", key], nestedValue)];
         }];
     } else {
         [mutableQueryStringComponents addObject:[[AFQueryStringPair alloc] initWithField:key value:value]];


### PR DESCRIPTION
When request is sent using `AFFormURLParameterEncoding` encoding, nested arrays are including [] in their keys. Simply removing them here to allow web services to understand string arrays without additional parsing of keys.

Example:

```
NSArray *comments = [NSArray arrayWithObjects:@"123", @"456", nil]; 
```

Previous query string:

```
// [] converted to %5B and %5D respectively
comments%5B%5D=123&comments%5B%5D=456
```

Fixed query string:

```
comments=123&comments=456
```
