### PR TITLE
Fix type discrepancy for upload stream delay.

### DIFF
--- a/AFNetworking/AFHTTPClient.h
+++ b/AFNetworking/AFHTTPClient.h
@@ -500,7 +500,7 @@ extern NSString * const AFNetworkingReachabilityNotificationStatusItem;
 #pragma mark -
 
 extern NSUInteger const kAFUploadStream3GSuggestedPacketSize;
-extern NSUInteger const kAFUploadStream3GSuggestedDelay;
+extern NSTimeInterval const kAFUploadStream3GSuggestedDelay;
 
 /**
  The `AFMultipartFormData` protocol defines the methods supported by the parameter in the block argument of `AFHTTPClient -multipartFormRequestWithMethod:path:parameters:constructingBodyWithBlock:`.

--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -717,7 +717,7 @@ static inline NSString * AFContentTypeForPathExtension(NSString *extension) {
 }
 
 NSUInteger const kAFUploadStream3GSuggestedPacketSize = 1024 * 16;
-NSUInteger const kAFUploadStream3GSuggestedDelay = 0.2;
+NSTimeInterval const kAFUploadStream3GSuggestedDelay = 0.2;
 
 @interface AFHTTPBodyPart : NSObject
 


### PR DESCRIPTION
The default delay for upload streams over 3G is set to `0.2` but the variable storing it is an `NSUInteger` and as such we will always get 0. This fixes that by changing the type of the `kAFUploadStream3GSuggestedDelay` variable to `NSTimeInterval` (which is also what the `delay` property of `AFMultipartBodyStream` is).
