### PR TITLE
NSNull parameters are encoded as "<null>" when using multipart form data

### DIFF
--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -473,6 +473,8 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {}
             NSData *data = nil;
             if ([pair.value isKindOfClass:[NSData class]]) {
                 data = pair.value;
+            } else if ([pair.value isKindOfClass:[NSNull class]]) {
+                data = [NSData data];
             } else {
                 data = [[pair.value description] dataUsingEncoding:self.stringEncoding];
             }


### PR DESCRIPTION
`NSNull` values in the parameter dictionary are encoded as `"<null>"` when using multipart form data as parameter encoding.

For example, consider the following code (where `[MyHTTPClient sharedClient]` is a singleton instance of `AFHTTPClient`):

```

NSDictionary *params = @{
    @"test" : [NSNull null]
};

NSMutableURLRequest *request = [[MyHTTPClient sharedClient] multipartFormRequestWithMethod:@"POST" path:@"/test" parameters:params
    constructingBodyWithBlock:^(id<AFMultipartFormData> formData) {
        // ...
    }
];

AFHTTPRequestOperation *operation = [[MyHTTPClient sharedClient] HTTPRequestOperationWithRequest:request
    success:^(AFHTTPRequestOperation *operation, id json) {
        // ...
    }
    failure:^(AFHTTPRequestOperation *operation, NSError *error) {
        // ...
    }
];

[[MyHTTPClient sharedClient] enqueueHTTPRequestOperation:operation];
```

The relevant part in the produced multipart request looks like this:

```
Content-Disposition: form-data; name="test"

<null>
```

Expected: Empty body (since there is no explicit notion of "null" in multipart/form-data AFAIK.
