### PR TITLE
Fix CocoaPods Incorrectly Importing CoreServices

### DIFF
--- a/AFNetworking.podspec
+++ b/AFNetworking.podspec
@@ -16,6 +16,7 @@ Pod::Spec.new do |s|
   s.osx.frameworks = 'CoreServices', 'SystemConfiguration'
 
   s.prefix_header_contents = <<-EOS
+#import <Availability.h>
 #if __IPHONE_OS_VERSION_MIN_REQUIRED
   #import <SystemConfiguration/SystemConfiguration.h>
   #import <MobileCoreServices/MobileCoreServices.h>


### PR DESCRIPTION
Just updated to latest master. The CocoaPods PCH changes do not work as intended. In my app, Availability.h is not yet imported so you wind up attempting to import Core Services instead of Mobile Core Services, which throws nasty references to Carbon libraries
