### PR TITLE
AFXMLRequestOperation missed the type application/rss+xml

### DIFF
--- a/AFNetworking/AFXMLRequestOperation.m
+++ b/AFNetworking/AFXMLRequestOperation.m
@@ -128,7 +128,7 @@ static dispatch_queue_t xml_request_operation_processing_queue() {
 #pragma mark - AFHTTPRequestOperation
 
 + (NSSet *)acceptableContentTypes {
-    return [NSSet setWithObjects:@"application/xml", @"text/xml", nil];
+    return [NSSet setWithObjects:@"application/xml", @"text/xml", @"application/rss+xml", nil];
 }
 
 + (BOOL)canProcessRequest:(NSURLRequest *)request {


### PR DESCRIPTION
This content type is usually treated the same as “application/xml” and “text/xml”.
