### PR TITLE
Added method to use placeholder view instead of placeholder image with s...

### DIFF
--- a/AFNetworking/UIImageView+AFNetworking.h
+++ b/AFNetworking/UIImageView+AFNetworking.h
@@ -43,6 +43,30 @@
 - (void)setImageWithURL:(NSURL *)url;
 
 /**
+ Creates and enqueues an image request operation, which asynchronously downloads the image from the specified URL. Any previous image request for the receiver will be cancelled. If the image is cached locally, the image is set immediately, otherwise the specified placeholder view will be added immediately, and then the remote image will be set once the request is finished.
+ 
+ @param url The URL used for the image request.
+ @param placeholderView The placeholder view to be set initially, until the image request finishes. If `nil`, the image view will not add a placeholder view.
+ 
+ @discussion By default, URL requests have a cache policy of `NSURLCacheStorageAllowed` and a timeout interval of 30 seconds, and are set not handle cookies. To configure URL requests differently, use `setImageWithURLRequest:placeholderImage:success:failure:`
+ */
+- (void)setImageWithURL:(NSURL *)url
+        placeholderView:(UIView *)placeholderView;
+
+/**
+ Creates and enqueues an image request operation, which asynchronously downloads the image with the specified URL request object. Any previous image request for the receiver will be cancelled. If the image is cached locally, the image is set immediately, otherwise the specified placeholder view will be set immediately, and then the remote image will be set once the request is finished.
+ 
+ @param urlRequest The URL request used for the image request.
+ @param placeholderView The placeholder view to be set initially, until the image request finishes. If `nil`, the image view will not add a placeholder view.
+ @param success A block to be executed when the image request operation finishes successfully, with a status code in the 2xx range, and with an acceptable content type (e.g. `image/png`). This block has no return value and takes three arguments: the request sent from the client, the response received from the server, and the image created from the response data of request. If the image was returned from cache, the request and response parameters will be `nil`.
+ @param failure A block object to be executed when the image request operation finishes unsuccessfully, or that finishes successfully. This block has no return value and takes three arguments: the request sent from the client, the response received from the server, and the error object describing the network or parsing error that occurred.
+ */
+- (void)setImageWithURLRequest:(NSURLRequest *)urlRequest
+               placeholderView: (UIView *) placeholderView
+                       success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, UIImage *image))success
+                       failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error))failure;
+
+/**
  Creates and enqueues an image request operation, which asynchronously downloads the image from the specified URL. Any previous image request for the receiver will be cancelled. If the image is cached locally, the image is set immediately, otherwise the specified placeholder image will be set immediately, and then the remote image will be set once the request is finished.
  
  @param url The URL used for the image request.


### PR DESCRIPTION
...etImageWithURL:placeholderView: and setImageWithURLRequest:placeholderView:success:failure: methods for using a placeholder view with start callback startPlaceholderWithImageView:
