### PR TITLE
Support for the image/pjpeg MIME type

### DIFF
--- a/AFNetworking/AFImageRequestOperation.h
+++ b/AFNetworking/AFImageRequestOperation.h
@@ -40,6 +40,7 @@
  
  - `image/tiff`
  - `image/jpeg`
+ - `image/pjpeg`
  - `image/gif`
  - `image/png`
  - `image/ico`

--- a/AFNetworking/AFImageRequestOperation.m
+++ b/AFNetworking/AFImageRequestOperation.m
@@ -184,7 +184,7 @@ static dispatch_queue_t image_request_operation_processing_queue() {
 #pragma mark - AFHTTPRequestOperation
 
 + (NSSet *)acceptableContentTypes {
-    return [NSSet setWithObjects:@"image/tiff", @"image/jpeg", @"image/gif", @"image/png", @"image/ico", @"image/x-icon", @"image/bmp", @"image/x-bmp", @"image/x-xbitmap", @"image/x-win-bitmap", nil];
+    return [NSSet setWithObjects:@"image/tiff", @"image/jpeg", @"image/pjpeg", @"image/gif", @"image/png", @"image/ico", @"image/x-icon", @"image/bmp", @"image/x-bmp", @"image/x-xbitmap", @"image/x-win-bitmap", nil];
 }
 
 + (BOOL)canProcessRequest:(NSURLRequest *)request {


### PR DESCRIPTION
Simple change to AFImageRequestOperation so it accepts the image/pjpeg MIME type as a valid image type.

As far as I know, image/pjpeg is used by Internet Explorer only, for progressive JPEG pictures. It might not be part of the MIME standard. Progressive JPEGs are supported by UIImage at least under iOS 6 and 5.
