### PR TITLE
Timeout property for AFHTTPClient

### DIFF
--- a/AFNetworking/AFHTTPClient.h
+++ b/AFNetworking/AFHTTPClient.h
@@ -122,6 +122,11 @@ typedef enum {
 @property (readonly, nonatomic) NSOperationQueue *operationQueue;
 
 /**
+ * Timout for requests.
+ */
+@property (nonatomic, assign) NSTimeInterval timeoutInterval;
+
+/**
  The reachability status from the device to the current `baseURL` of the `AFHTTPClient`.
 
   @warning This property requires the `SystemConfiguration` framework. Add it in the active target's "Link Binary With Library" build phase, and add `#import <SystemConfiguration/SystemConfiguration.h>` to the header prefix of the project (`Prefix.pch`).

--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -219,6 +219,7 @@ static NSString * AFPropertyListStringFromParameters(NSDictionary *parameters) {
 @synthesize registeredHTTPOperationClassNames = _registeredHTTPOperationClassNames;
 @synthesize defaultHeaders = _defaultHeaders;
 @synthesize operationQueue = _operationQueue;
+@synthesize timeoutInterval = _timeoutInterval;
 #ifdef _SYSTEMCONFIGURATION_H
 @synthesize networkReachability = _networkReachability;
 @synthesize networkReachabilityStatus = _networkReachabilityStatus;
@@ -427,6 +428,10 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {}
 	NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:url];
     [request setHTTPMethod:method];
     [request setAllHTTPHeaderFields:self.defaultHeaders];
+
+    if (self.timeoutInterval > 0) {
+        [request setTimeoutInterval:self.timeoutInterval];
+    }
 	
     if (parameters) {
         if ([method isEqualToString:@"GET"] || [method isEqualToString:@"HEAD"] || [method isEqualToString:@"DELETE"]) {


### PR DESCRIPTION
This commit adds a `timeoutInterval` property to `AFHTTPClient`. The typical use case is for servers that are sporadically slow to respond. For example, I send requests to a server that's usually fast but occasionally takes 45 seconds or longer to process a request. I don't want to keep the user hanging, thinking that the app is busy when in fact it's just stalled, waiting for a server that is taking forever to respond.

I know that this issue has been discussed before, such as pull request #133. That request was rejected for two reasons:

1) It is not clear whether iOS honors the timeout

2) A timeout can be set with AFHTTPRequestOperation instead of AFHTTPClient.

For (1), I can say that I tested the timeout behavior (iOS 6) and it works just as expected. When a GET request takes longer than the specified timeout, AFHTTPClient fails with an error: "The request timed out."

As for (2), I would argue that the suggested workaround is unintuitive. It's not at all clear -- at least, not to myself nor the other two users who supported the earlier pull request -- that a timeout on AFHTTPClient can be set via AFHTTPRequestOperation. Furthermore, having to rewrite code to use AFHTTPRequestOperation is an unnecessary inconvenience for this seemingly common use case.

Thanks for reconsidering this issue.
