### PR TITLE
Avoid warning on implicit 64 to 32 conversion in AFHTTPClient.m

### DIFF
--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -1154,7 +1154,7 @@ typedef enum {
            intoBuffer:(uint8_t *)buffer
             maxLength:(NSUInteger)length
 {
-    NSRange range = NSMakeRange(_phaseReadOffset, MIN([data length], length));
+    NSRange range = NSMakeRange((NSUInteger)_phaseReadOffset, MIN([data length], length));
     [data getBytes:buffer range:range];
     
     _phaseReadOffset += range.length;


### PR DESCRIPTION
When using the -Wshorten-64-to-32 flag making an NSRange from the AFHTTPBodyPart _phaseReadOffset ivar causes an implicit conversion warning (or error if using -Werror).

This is a simple cast to silence the warning. I'm not entirely confident this is the best way to do this since _phaseReadOffset could conceivably be larger than NSUIntegerMax.

I'll gladly revisit it and update the pull request if this fix is deemed unsatisfactory.
