### PR TITLE
Add Github's Obj-C .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Xcode
+.DS_Store
+build/
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+*.xcworkspace
+!default.xcworkspace
+xcuserdata
+profile
+*.moved-aside
+DerivedData
+.idea/


### PR DESCRIPTION
I have AFNetworking as a git submodule, and it always shows up at `(untracked content)` in `git status` because of `.DS_Store`. So this makes that go away.
