### PR TITLE
Changing parameter to id to allow NSArray with AFJSONParameterEncoding

### DIFF
--- a/AFNetworking/AFHTTPClient.h
+++ b/AFNetworking/AFHTTPClient.h
@@ -249,7 +249,7 @@ typedef enum {
  */
 - (NSMutableURLRequest *)requestWithMethod:(NSString *)method 
                                       path:(NSString *)path 
-                                parameters:(NSDictionary *)parameters;
+                                parameters:(id)parameters;
 
 /**
  Creates an `NSMutableURLRequest` object with the specified HTTP method and path, and constructs a `multipart/form-data` HTTP body, using the specified parameters and multipart form data block. See http://www.w3.org/TR/html4/interact/forms.html#h-17.13.4.2

--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -160,7 +160,7 @@ NSArray * AFQueryStringPairsFromKeyAndValue(NSString *key, id value) {
     return mutableQueryStringComponents;
 }
 
-static NSString * AFJSONStringFromParameters(NSDictionary *parameters) {
+static NSString * AFJSONStringFromParameters(id parameters) {
     NSError *error = nil;
     NSData *JSONData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:&error];;
     
@@ -418,7 +418,7 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {}
 
 - (NSMutableURLRequest *)requestWithMethod:(NSString *)method
                                       path:(NSString *)path
-                                parameters:(NSDictionary *)parameters
+                                parameters:(id)parameters
 {
     NSParameterAssert(method);
     


### PR DESCRIPTION
I ran into an issue where the API I was working with wanted the body of the post to be a JSON array. It seemed the only way to achieve this was to change `parameter` to `id` to accept `NSArray`. After this change I was able to post to the API with no issue, however I realize that this change might cause problems for other encodings besides `AFJSONParameterEncoding`. Is there a better way this could be achieved?

Also using `AFJSONParameterEncoding` seems to make the parameters a little overloaded, how could I add JSON to the post body and add URL parameters too? The only way I found was to add the URL parameter string to the url path, but I am sure I could be overlooking something. Is there a better way?
