### PR TITLE
Normalize objects for JSON serialization.

### DIFF
--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -160,21 +160,6 @@ NSArray * AFQueryStringPairsFromKeyAndValue(NSString *key, id value) {
     return mutableQueryStringComponents;
 }
 
-static NSString * AFJSONStringFromParameters(NSDictionary *parameters) {
-    NSError *error = nil;
-    parameters = AFJSONNormalizeObject(parameters, &error);
-    if (!parameters)
-        // Cannot be normalized.
-        return nil;
-
-    NSData *JSONData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:&error];;
-    if (!error) {
-        return [[NSString alloc] initWithData:JSONData encoding:NSUTF8StringEncoding];
-    } else {
-        return nil;
-    }
-}
-
 static BOOL AFJSONIsNormalObject(id object, NSError **error) {
 
     if ([object isKindOfClass:[NSString class]] || [object isKindOfClass:[NSNumber class]] || [object isKindOfClass:[NSNull class]])
@@ -254,6 +239,21 @@ id AFJSONNormalizeObject(id object, NSError **error) {
 
     assert(error); // An error should've been set by AFJSONIsNormalObject
     return nil;
+}
+
+static NSString * AFJSONStringFromParameters(NSDictionary *parameters) {
+    NSError *error = nil;
+    parameters = AFJSONNormalizeObject(parameters, &error);
+    if (!parameters)
+        // Cannot be normalized.
+        return nil;
+    
+    NSData *JSONData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:&error];;
+    if (!error) {
+        return [[NSString alloc] initWithData:JSONData encoding:NSUTF8StringEncoding];
+    } else {
+        return nil;
+    }
 }
 
 static NSString * AFPropertyListStringFromParameters(NSDictionary *parameters) {


### PR DESCRIPTION
- enumerable collections are converted into arrays.
- an error object explains if and why normalization isn't possible (eg. unsupported object type)
- AFNetworking really needs a way to log its errors or pass them to the application, lacking all over.

This is necessary to enable serialization of NSDictionaries that contain NSEnumerables that are not NSArrays.  It can be easily extended to enable the serialization of other types of objects that are not natively handled by NSJSONSerialization.  This is especially important when serializing from RestKit's Core Data serialized objects that use ordered sets.
