### PR TITLE
fix for AFHTTPClient not being released

### DIFF
--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -335,11 +335,17 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {}
     }
     
     self.networkReachability = SCNetworkReachabilityCreateWithName(kCFAllocatorDefault, [[self.baseURL host] UTF8String]);
-    
+
+    __weak AFHTTPClient *weakSelf = self;
     AFNetworkReachabilityStatusBlock callback = ^(AFNetworkReachabilityStatus status){
-        self.networkReachabilityStatus = status;
-        if (self.networkReachabilityStatusBlock) {
-            self.networkReachabilityStatusBlock(status);
+        __strong AFHTTPClient *strongSelf = weakSelf;
+        if (!strongSelf) {
+            // the weak ref is gone, depart this block
+            return;
+        }
+        strongSelf.networkReachabilityStatus = status;
+        if (strongSelf.networkReachabilityStatusBlock) {
+            strongSelf.networkReachabilityStatusBlock(status);
         }
     };
     


### PR DESCRIPTION
We ran into AFHTTPClient not being released like in AFNetworking issue #581. This fixes it for us with the weakself/strongself pattern (note __strong is explicit to show what's going on).
