### PR TITLE
[Issue #591] Attempts to fix crash caused by incorrect calculation of range when reading data into buffer.

### DIFF
--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -1143,12 +1143,12 @@ typedef enum {
            intoBuffer:(uint8_t *)buffer
             maxLength:(NSUInteger)length
 {
-    NSRange range = NSMakeRange((NSUInteger)_phaseReadOffset, MIN([data length], length));
+    NSRange range = NSMakeRange((NSUInteger)_phaseReadOffset, MIN([data length] - ((NSUInteger)_phaseReadOffset), length));
     [data getBytes:buffer range:range];
     
     _phaseReadOffset += range.length;
     
-    if (range.length >= [data length]) {
+    if (((NSUInteger)_phaseReadOffset) >= [data length]) {
         [self transitionToNextPhase];
     }
     


### PR DESCRIPTION
[Issue #591] Attempts to fix crash caused by incorrect calculation of
range when reading data into buffer.

When the current buffer isn't large enough to store the data,
AFNetworking attempts to fill the current buffer with as much data as
it can holds and leaves the remaining data to the next buffer.

There is a bug when calculating the range to read from data in the next
buffer. The `_phaseReadOffset` is set correctly but the `[data length]`
is not adjusting correctly to the offset. This causes `getBytes:range:`
to complains that it attempts to get bytes that are out of range.

An attempted fix is done here by adjusting the range (Also adjust to
check against `_phaseReadOffset` instead of `range.length`.

As I am modifying some critical section, a detail review might be
required.

I am sending this pull request so as to facilitiate the review process,
but if you are already in review of the issue and the solution, you can
ignore my pull and close it. Thanks!

Detail explanation of how the solution come about can be found here:
https://github.com/AFNetworking/AFNetworking/issues/591#issuecomment-9930763
