### PR TITLE
Fall back to ISO-8859-1 when generating responseString

### DIFF
--- a/AFNetworking/AFURLConnectionOperation.m
+++ b/AFNetworking/AFURLConnectionOperation.m
@@ -333,8 +333,14 @@ static inline BOOL AFStateTransitionIsValid(AFOperationState fromState, AFOperat
                 stringEncoding = CFStringConvertEncodingToNSStringEncoding(IANAEncoding);
             }
         }
-        
+
+        /*
+         When no explicit charset parameter is provided by the sender, media subtypes of the "text" type are defined to have a default charset value of "ISO-8859-1" when received via HTTP (RFC 2616)
+         */
         self.responseString = [[NSString alloc] initWithData:self.responseData encoding:stringEncoding];
+        if (!_responseString) {
+            self.responseString = [[NSString alloc] initWithData:self.responseData encoding:NSISOLatin1StringEncoding];
+        }
     }
     [self.lock unlock];
     


### PR DESCRIPTION
As specified by RFC 2616:

> When no explicit charset parameter is provided by the sender, media subtypes of the "text" type are defined to have a default charset value of "ISO-8859-1" when received via HTTP

Right now, AFNetworking defaults to UTF-8 if no encoding is specified in the response headers.

With this changes, if the resulting string is nil (NSData couldn't be converted to NSString using that encoding) it falls back to ISO-8859-1 and tries again
