### PR TITLE
An empty (as in " ") JSON response calls the error block

### DIFF
--- a/AFNetworking/AFJSONRequestOperation.m
+++ b/AFNetworking/AFJSONRequestOperation.m
@@ -64,7 +64,8 @@ static dispatch_queue_t json_request_operation_processing_queue() {
     if (!_responseJSON && [self.responseData length] > 0 && [self isFinished] && !self.JSONError) {
         NSError *error = nil;
 
-        if ([self.responseData length] == 0) {
+        NSString* trimmedResponseString = [self.responseString stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+        if ([self.responseData length] == 0 || [trimmedResponseString length] == 0) {
             self.responseJSON = nil;
         } else {
             self.responseJSON = [NSJSONSerialization JSONObjectWithData:self.responseData options:self.JSONReadingOptions error:&error];


### PR DESCRIPTION
This issue is similar to http://stackoverflow.com/questions/12044880/afnetworking-failure-block-running-when-returning-with-200-and-no-content and arises with Rails as backend http://stackoverflow.com/questions/12407328/rails-head-ok-interpreted-as-ajaxerror

I added a check if the trimmed responseString is empty
