### PR TITLE
Network reachability won't be created if the host name is invalid.

### DIFF
--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -331,9 +331,11 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {}
         }
     };
     
-    SCNetworkReachabilityContext context = {0, (__bridge void *)callback, AFNetworkReachabilityRetainCallback, AFNetworkReachabilityReleaseCallback, NULL};
-    SCNetworkReachabilitySetCallback(self.networkReachability, AFNetworkReachabilityCallback, &context);
-    SCNetworkReachabilityScheduleWithRunLoop(self.networkReachability, CFRunLoopGetMain(), (CFStringRef)NSRunLoopCommonModes);
+	if (self.networkReachability) {
+		SCNetworkReachabilityContext context = {0, (__bridge void *)callback, AFNetworkReachabilityRetainCallback, AFNetworkReachabilityReleaseCallback, NULL};
+		SCNetworkReachabilitySetCallback(self.networkReachability, AFNetworkReachabilityCallback, &context);
+		SCNetworkReachabilityScheduleWithRunLoop(self.networkReachability, CFRunLoopGetMain(), (CFStringRef)NSRunLoopCommonModes);
+	}
     
     /* Network reachability monitoring does not establish a baseline for IP addresses as it does for hostnames, so if the base URL host is an IP address, the initial reachability callback is manually triggered.
      */


### PR DESCRIPTION
This prevents a crash from occuring when an invalid URL is used to
create the client, and reachability tries to set the callback target to
a non-existent object.
