### PR TITLE
Add pragma declarations to suppress retain cycle warnings in Xcode 4.6DP

### DIFF
--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -566,6 +566,8 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {}
     
     for (AFHTTPRequestOperation *operation in operations) {
         AFCompletionBlock originalCompletionBlock = [operation.completionBlock copy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-retain-cycles"
         operation.completionBlock = ^{
             dispatch_queue_t queue = operation.successCallbackQueue ?: dispatch_get_main_queue();
             dispatch_group_async(dispatchGroup, queue, ^{
@@ -587,6 +589,7 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {}
                 dispatch_group_leave(dispatchGroup);
             });
         };
+#pragma clang diagnostic pop
         
         dispatch_group_enter(dispatchGroup);
         [batchedOperation addDependency:operation];

--- a/AFNetworking/AFImageRequestOperation.m
+++ b/AFNetworking/AFImageRequestOperation.m
@@ -81,10 +81,12 @@ static dispatch_queue_t image_request_operation_processing_queue() {
             if (imageProcessingBlock) {
                 dispatch_async(image_request_operation_processing_queue(), ^(void) {
                     UIImage *processedImage = imageProcessingBlock(image);
-
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-retain-cycles"
                     dispatch_async(requestOperation.successCallbackQueue ?: dispatch_get_main_queue(), ^(void) {
                         success(operation.request, operation.response, processedImage);
                     });
+#pragma clang diagnostic pop
                 });
             } else {
                 success(operation.request, operation.response, image);


### PR DESCRIPTION
Suppresses the warnings
