### PR TITLE
Fixed NSJSONSerialization crash on escaped UTF8 characters

### DIFF
--- a/AFNetworking/AFJSONRequestOperation.m
+++ b/AFNetworking/AFJSONRequestOperation.m
@@ -67,7 +67,8 @@ static dispatch_queue_t json_request_operation_processing_queue() {
         if ([self.responseData length] == 0) {
             self.responseJSON = nil;
         } else {
-            self.responseJSON = [NSJSONSerialization JSONObjectWithData:self.responseData options:self.JSONReadingOptions error:&error];
+            NSData *jsonData = [self.responseString dataUsingEncoding:NSUTF8StringEncoding];
+            self.responseJSON = [NSJSONSerialization JSONObjectWithData:jsonData options:self.JSONReadingOptions error:&error];
         }
         
         self.JSONError = error;


### PR DESCRIPTION
Using a JSON REST service I experienced some `NSJSONSerialization` crashed, it goes crazy while creating a `CFString`. A [StackOverflow post](http://stackoverflow.com/questions/12842481/nsjsonserialization-results-in-exc-bad-access) pointed me in the direction that `NSJSONSerialization` might crash on escaped UTF8 characters and on some other specific cases.

I was able to work around this `NSJSONSerialization`-issue by using the responseString instead of the responseData. It seems that the escaped characters are handles correctly then.

Of course this is an issue that Apple should fix, but for the time being I think it's nice to make sure the response is parsed correctly.

Let me know if there is anything that you want to see improved before you can pull this in!
