### PR TITLE
Wrap Framework imports with #ifdef __OBJC__ to prevent compile errors

### DIFF
--- a/AFNetworking.podspec
+++ b/AFNetworking.podspec
@@ -17,12 +17,14 @@ Pod::Spec.new do |s|
 
   s.prefix_header_contents = <<-EOS
 #import <Availability.h>
-#if __IPHONE_OS_VERSION_MIN_REQUIRED
-  #import <SystemConfiguration/SystemConfiguration.h>
-  #import <MobileCoreServices/MobileCoreServices.h>
-#else
-  #import <SystemConfiguration/SystemConfiguration.h>
-  #import <CoreServices/CoreServices.h>
+#ifdef __OBJC__
+    #if __IPHONE_OS_VERSION_MIN_REQUIRED
+          #import <SystemConfiguration/SystemConfiguration.h>
+          #import <MobileCoreServices/MobileCoreServices.h>
+    #else
+          #import <SystemConfiguration/SystemConfiguration.h>
+          #import <CoreServices/CoreServices.h>
+    #endif
 #endif
 EOS
 end


### PR DESCRIPTION
I believe that the precompiled header imports needs to be wrapped with the included #ifdef.   Otherwise I get a nice smattering of compile errors.   I am not sure whether this pull request should be here or in the Cocoapods Specs repo.   If so I will open there.
