### PR TITLE
Fix timeout on multipart form requests with data that is a multiple of the buffer size

### DIFF
--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -1105,6 +1105,9 @@ typedef enum {
 }
 
 - (BOOL)hasBytesAvailable {
+    if(_phase == AFFinalBoundaryPhase) {
+    	return YES;
+    }
     switch (self.inputStream.streamStatus) {
         case NSStreamStatusNotOpen:
         case NSStreamStatusOpening:


### PR DESCRIPTION
If AFMultipartFormFinalBoundary (34 bytes) doesn't fit into the buffer after finishing the body it isn't finished because the stream is closed. This patches hasAvailableBytes so that read is called again to finish the boundary and then transition to the end state.

To repro try creating data which is just under a multiple of 32768 bytes, since that is the buffer size and sending a multipart form request with something like: https://gist.github.com/4323786

For me this request times out (status code 408) since the final boundary is never completed.
