### PR TITLE
Implement instancetype for all initialization methods

### DIFF
--- a/AFNetworking/AFHTTPClient.h
+++ b/AFNetworking/AFHTTPClient.h
@@ -148,7 +148,7 @@ typedef enum {
   
  @return The newly-initialized HTTP client
  */
-+ (AFHTTPClient *)clientWithBaseURL:(NSURL *)url;
++ (instancetype)clientWithBaseURL:(NSURL *)url;
 
 /**
  Initializes an `AFHTTPClient` object with the specified base URL.
@@ -159,7 +159,7 @@ typedef enum {
   
  @return The newly-initialized HTTP client
  */
-- (id)initWithBaseURL:(NSURL *)url;
+- (instancetype)initWithBaseURL:(NSURL *)url;
 
 ///-----------------------------------
 /// @name Managing Reachability Status

--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -205,11 +205,11 @@ NSArray * AFQueryStringPairsFromKeyAndValue(NSString *key, id value) {
 @synthesize networkReachabilityStatusBlock = _networkReachabilityStatusBlock;
 #endif
 
-+ (AFHTTPClient *)clientWithBaseURL:(NSURL *)url {
++ (instancetype)clientWithBaseURL:(NSURL *)url {
     return [[self alloc] initWithBaseURL:url];
 }
 
-- (id)initWithBaseURL:(NSURL *)url {
+- (instancetype)initWithBaseURL:(NSURL *)url {
     NSParameterAssert(url);
 
     self = [super init];

--- a/AFNetworking/AFImageRequestOperation.h
+++ b/AFNetworking/AFImageRequestOperation.h
@@ -76,11 +76,11 @@
  @return A new image request operation
  */
 #if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
-+ (AFImageRequestOperation *)imageRequestOperationWithRequest:(NSURLRequest *)urlRequest                
-                                                      success:(void (^)(UIImage *image))success;
++ (instancetype)imageRequestOperationWithRequest:(NSURLRequest *)urlRequest                
+										 success:(void (^)(UIImage *image))success;
 #elif defined(__MAC_OS_X_VERSION_MIN_REQUIRED)
-+ (AFImageRequestOperation *)imageRequestOperationWithRequest:(NSURLRequest *)urlRequest                
-                                                      success:(void (^)(NSImage *image))success;
++ (instancetype)imageRequestOperationWithRequest:(NSURLRequest *)urlRequest                
+										 success:(void (^)(NSImage *image))success;
 #endif
 
 /**
@@ -94,15 +94,15 @@
  @return A new image request operation
  */
 #if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
-+ (AFImageRequestOperation *)imageRequestOperationWithRequest:(NSURLRequest *)urlRequest
-                                         imageProcessingBlock:(UIImage *(^)(UIImage *image))imageProcessingBlock
-                                                      success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, UIImage *image))success
-                                                      failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error))failure;
++ (instancetype)imageRequestOperationWithRequest:(NSURLRequest *)urlRequest
+							imageProcessingBlock:(UIImage *(^)(UIImage *image))imageProcessingBlock
+										 success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, UIImage *image))success
+										 failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error))failure;
 #elif defined(__MAC_OS_X_VERSION_MIN_REQUIRED)
-+ (AFImageRequestOperation *)imageRequestOperationWithRequest:(NSURLRequest *)urlRequest
-                                         imageProcessingBlock:(NSImage *(^)(NSImage *image))imageProcessingBlock
-                                                      success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSImage *image))success
-                                                      failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error))failure;
++ (instancetype)imageRequestOperationWithRequest:(NSURLRequest *)urlRequest
+							imageProcessingBlock:(NSImage *(^)(NSImage *image))imageProcessingBlock
+										 success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSImage *image))success
+										 failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error))failure;
 #endif
 
 @end

--- a/AFNetworking/AFImageRequestOperation.m
+++ b/AFNetworking/AFImageRequestOperation.m
@@ -46,8 +46,8 @@ static dispatch_queue_t image_request_operation_processing_queue() {
 #endif
 
 #if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
-+ (AFImageRequestOperation *)imageRequestOperationWithRequest:(NSURLRequest *)urlRequest                
-                                                      success:(void (^)(UIImage *image))success
++ (instancetype)imageRequestOperationWithRequest:(NSURLRequest *)urlRequest                
+										 success:(void (^)(UIImage *image))success
 {
     return [self imageRequestOperationWithRequest:urlRequest imageProcessingBlock:nil success:^(NSURLRequest __unused *request, NSHTTPURLResponse __unused *response, UIImage *image) {
         if (success) {
@@ -56,8 +56,8 @@ static dispatch_queue_t image_request_operation_processing_queue() {
     } failure:nil];
 }
 #elif defined(__MAC_OS_X_VERSION_MIN_REQUIRED)
-+ (AFImageRequestOperation *)imageRequestOperationWithRequest:(NSURLRequest *)urlRequest                
-                                                      success:(void (^)(NSImage *image))success
++ (instancetype)imageRequestOperationWithRequest:(NSURLRequest *)urlRequest                
+										 success:(void (^)(NSImage *image))success
 {
     return [self imageRequestOperationWithRequest:urlRequest imageProcessingBlock:nil success:^(NSURLRequest __unused *request, NSHTTPURLResponse __unused *response, NSImage *image) {
         if (success) {
@@ -69,10 +69,10 @@ static dispatch_queue_t image_request_operation_processing_queue() {
 
 
 #if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
-+ (AFImageRequestOperation *)imageRequestOperationWithRequest:(NSURLRequest *)urlRequest
-                                         imageProcessingBlock:(UIImage *(^)(UIImage *))imageProcessingBlock
-                                                      success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, UIImage *image))success
-                                                      failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error))failure
++ (instancetype)imageRequestOperationWithRequest:(NSURLRequest *)urlRequest
+							imageProcessingBlock:(UIImage *(^)(UIImage *))imageProcessingBlock
+										 success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, UIImage *image))success
+										 failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error))failure
 {
     AFImageRequestOperation *requestOperation = [[AFImageRequestOperation alloc] initWithRequest:urlRequest];
     [requestOperation setCompletionBlockWithSuccess:^(AFHTTPRequestOperation *operation, id responseObject) {
@@ -100,10 +100,10 @@ static dispatch_queue_t image_request_operation_processing_queue() {
     return requestOperation;
 }
 #elif defined(__MAC_OS_X_VERSION_MIN_REQUIRED)
-+ (AFImageRequestOperation *)imageRequestOperationWithRequest:(NSURLRequest *)urlRequest
-                                         imageProcessingBlock:(NSImage *(^)(NSImage *))imageProcessingBlock
-                                                      success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSImage *image))success
-                                                      failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error))failure
++ (instancetype)imageRequestOperationWithRequest:(NSURLRequest *)urlRequest
+							imageProcessingBlock:(NSImage *(^)(NSImage *))imageProcessingBlock
+										 success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSImage *image))success
+										 failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error))failure
 {
     AFImageRequestOperation *requestOperation = [[AFImageRequestOperation alloc] initWithRequest:urlRequest];
     [requestOperation setCompletionBlockWithSuccess:^(AFHTTPRequestOperation *operation, id responseObject) {
@@ -131,7 +131,7 @@ static dispatch_queue_t image_request_operation_processing_queue() {
 }
 #endif
 
-- (id)initWithRequest:(NSURLRequest *)urlRequest {
+- (instancetype)initWithRequest:(NSURLRequest *)urlRequest {
     self = [super initWithRequest:urlRequest];
     if (!self) {
         return nil;

--- a/AFNetworking/AFJSONRequestOperation.h
+++ b/AFNetworking/AFJSONRequestOperation.h
@@ -64,8 +64,8 @@
   
  @return A new JSON request operation
  */
-+ (AFJSONRequestOperation *)JSONRequestOperationWithRequest:(NSURLRequest *)urlRequest
-                                                    success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, id JSON))success 
-                                                    failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, id JSON))failure;
++ (instancetype)JSONRequestOperationWithRequest:(NSURLRequest *)urlRequest
+										success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, id JSON))success
+										failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, id JSON))failure;
 
 @end

--- a/AFNetworking/AFJSONRequestOperation.m
+++ b/AFNetworking/AFJSONRequestOperation.m
@@ -41,9 +41,9 @@ static dispatch_queue_t json_request_operation_processing_queue() {
 @synthesize JSONReadingOptions = _JSONReadingOptions;
 @synthesize JSONError = _JSONError;
 
-+ (AFJSONRequestOperation *)JSONRequestOperationWithRequest:(NSURLRequest *)urlRequest
-                                                    success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, id JSON))success 
-                                                    failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, id JSON))failure
++ (instancetype)JSONRequestOperationWithRequest:(NSURLRequest *)urlRequest
+										success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, id JSON))success
+										failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, id JSON))failure
 {
     AFJSONRequestOperation *requestOperation = [[self alloc] initWithRequest:urlRequest];
     [requestOperation setCompletionBlockWithSuccess:^(AFHTTPRequestOperation *operation, id responseObject) {

--- a/AFNetworking/AFNetworkActivityIndicatorManager.h
+++ b/AFNetworking/AFNetworkActivityIndicatorManager.h
@@ -58,7 +58,7 @@
  
  @return The systemwide network activity indicator manager.
  */
-+ (AFNetworkActivityIndicatorManager *)sharedManager;
++ (instancetype)sharedManager;
 
 /**
  Increments the number of active network requests. If this number was zero before incrementing, this will start animating the status bar network activity indicator.

--- a/AFNetworking/AFNetworkActivityIndicatorManager.m
+++ b/AFNetworking/AFNetworkActivityIndicatorManager.m
@@ -42,7 +42,7 @@ static NSTimeInterval const kAFNetworkActivityIndicatorInvisibilityDelay = 0.17;
 @synthesize enabled = _enabled;
 @dynamic networkActivityIndicatorVisible;
 
-+ (AFNetworkActivityIndicatorManager *)sharedManager {
++ (instancetype)sharedManager {
     static AFNetworkActivityIndicatorManager *_sharedManager = nil;
     static dispatch_once_t oncePredicate;
     dispatch_once(&oncePredicate, ^{

--- a/AFNetworking/AFPropertyListRequestOperation.h
+++ b/AFNetworking/AFPropertyListRequestOperation.h
@@ -61,8 +61,8 @@
  
  @return A new property list request operation
  */
-+ (AFPropertyListRequestOperation *)propertyListRequestOperationWithRequest:(NSURLRequest *)urlRequest
-                                                                    success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, id propertyList))success
-                                                                    failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, id propertyList))failure;
++ (instancetype)propertyListRequestOperationWithRequest:(NSURLRequest *)urlRequest
+												success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, id propertyList))success
+												failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, id propertyList))failure;
 
 @end

--- a/AFNetworking/AFPropertyListRequestOperation.m
+++ b/AFNetworking/AFPropertyListRequestOperation.m
@@ -43,9 +43,9 @@ static dispatch_queue_t property_list_request_operation_processing_queue() {
 @synthesize propertyListFormat = _propertyListFormat;
 @synthesize propertyListError = _propertyListError;
 
-+ (AFPropertyListRequestOperation *)propertyListRequestOperationWithRequest:(NSURLRequest *)request
-                                                                    success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, id propertyList))success
-                                                                    failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, id propertyList))failure
++ (instancetype)propertyListRequestOperationWithRequest:(NSURLRequest *)request
+												success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, id propertyList))success
+												failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, id propertyList))failure
 {
     AFPropertyListRequestOperation *requestOperation = [[self alloc] initWithRequest:request];
     [requestOperation setCompletionBlockWithSuccess:^(AFHTTPRequestOperation *operation, id responseObject) {
@@ -61,7 +61,7 @@ static dispatch_queue_t property_list_request_operation_processing_queue() {
     return requestOperation;
 }
 
-- (id)initWithRequest:(NSURLRequest *)urlRequest {
+- (instancetype)initWithRequest:(NSURLRequest *)urlRequest {
     self = [super initWithRequest:urlRequest];
     if (!self) {
         return nil;

--- a/AFNetworking/AFURLConnectionOperation.h
+++ b/AFNetworking/AFURLConnectionOperation.h
@@ -153,7 +153,7 @@
  
  @discussion This is the designated initializer.
  */
-- (id)initWithRequest:(NSURLRequest *)urlRequest;
+- (instancetype)initWithRequest:(NSURLRequest *)urlRequest;
 
 ///----------------------------------
 /// @name Pausing / Resuming Requests

--- a/AFNetworking/AFURLConnectionOperation.m
+++ b/AFNetworking/AFURLConnectionOperation.m
@@ -173,7 +173,7 @@ static inline BOOL AFStateTransitionIsValid(AFOperationState fromState, AFOperat
     return _networkRequestThread;
 }
 
-- (id)initWithRequest:(NSURLRequest *)urlRequest {
+- (instancetype)initWithRequest:(NSURLRequest *)urlRequest {
     self = [super init];
     if (!self) {
 		return nil;

--- a/AFNetworking/AFXMLRequestOperation.h
+++ b/AFNetworking/AFXMLRequestOperation.h
@@ -66,9 +66,9 @@
  
  @return A new XML request operation
  */
-+ (AFXMLRequestOperation *)XMLParserRequestOperationWithRequest:(NSURLRequest *)urlRequest
-                                                        success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSXMLParser *XMLParser))success
-                                                        failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, NSXMLParser *XMLParser))failure;
++ (instancetype)XMLParserRequestOperationWithRequest:(NSURLRequest *)urlRequest
+											 success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSXMLParser *XMLParser))success
+											 failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, NSXMLParser *XMLParser))failure;
 
 
 #ifdef __MAC_OS_X_VERSION_MIN_REQUIRED
@@ -81,9 +81,9 @@
  
  @return A new XML request operation
  */
-+ (AFXMLRequestOperation *)XMLDocumentRequestOperationWithRequest:(NSURLRequest *)urlRequest
-                                                          success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSXMLDocument *document))success
-                                                          failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, NSXMLDocument *document))failure;
++ (instancetype)XMLDocumentRequestOperationWithRequest:(NSURLRequest *)urlRequest
+											   success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSXMLDocument *document))success
+											   failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, NSXMLDocument *document))failure;
 #endif
 
 @end

--- a/AFNetworking/AFXMLRequestOperation.m
+++ b/AFNetworking/AFXMLRequestOperation.m
@@ -48,9 +48,9 @@ static dispatch_queue_t xml_request_operation_processing_queue() {
 #endif
 @synthesize XMLError = _XMLError;
 
-+ (AFXMLRequestOperation *)XMLParserRequestOperationWithRequest:(NSURLRequest *)urlRequest
-                                                        success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSXMLParser *XMLParser))success
-                                                        failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, NSXMLParser *XMLParser))failure
++ (instancetype)XMLParserRequestOperationWithRequest:(NSURLRequest *)urlRequest
+											 success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSXMLParser *XMLParser))success
+											 failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, NSXMLParser *XMLParser))failure
 {
     AFXMLRequestOperation *requestOperation = [[self alloc] initWithRequest:urlRequest];
     [requestOperation setCompletionBlockWithSuccess:^(AFHTTPRequestOperation *operation, id responseObject) {
@@ -67,9 +67,9 @@ static dispatch_queue_t xml_request_operation_processing_queue() {
 }
 
 #ifdef __MAC_OS_X_VERSION_MIN_REQUIRED
-+ (AFXMLRequestOperation *)XMLDocumentRequestOperationWithRequest:(NSURLRequest *)urlRequest
-                                                          success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSXMLDocument *document))success
-                                                          failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, NSXMLDocument *document))failure
++ (instancetype)XMLDocumentRequestOperationWithRequest:(NSURLRequest *)urlRequest
+											   success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSXMLDocument *document))success
+											   failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, NSXMLDocument *document))failure
 {
     AFXMLRequestOperation *requestOperation = [[self alloc] initWithRequest:urlRequest];
     [requestOperation setCompletionBlockWithSuccess:^(AFHTTPRequestOperation *operation, __unused id responseObject) {


### PR DESCRIPTION
To overcome issues such as #695, instancetype is used for all initialization method return types.
