### PR TITLE
Precaution for UIImage ImageWithURLRequest

### DIFF
--- a/AFNetworking/UIImageView+AFNetworking.m
+++ b/AFNetworking/UIImageView+AFNetworking.m
@@ -99,6 +99,10 @@ static char kAFImageRequestOperationObjectKey;
                        failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error))failure
 {
     [self cancelImageRequestOperation];
+ 
+    if([urlRequest isKindOfClass:[NSURL class]]){
+        urlRequest = [NSURLRequest requestWithURL:(NSURL *)urlRequest];
+    }
     
     UIImage *cachedImage = [[[self class] af_sharedImageCache] cachedImageForRequest:urlRequest];
     if (cachedImage) {


### PR DESCRIPTION
The following code does not give a warning in xcode..Quite strange.

It took me some time to find the problem. This commit makes sure the URL is always wrapped in a NSURLRequest.

```
[myImageView setImageWithURLRequest:[NSURL URLWithString:@"http://example.com/image.png"]
                   placeholderImage:[UIImage imageNamed:@"placeholder"]
                            success:^(NSURLRequest *request, NSHTTPURLResponse *response, UIImage *image) {
                                //do something
                            } failure:^(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error) {
                                //do nothing
                            }];
```
