### PR TITLE
Making `af_imageRequestOperation` public

### DIFF
--- a/AFNetworking/UIImageView+AFNetworking.h
+++ b/AFNetworking/UIImageView+AFNetworking.h
@@ -33,6 +33,8 @@
  */
 @interface UIImageView (AFNetworking)
 
+@property (readonly, nonatomic, strong) AFImageRequestOperation *af_imageRequestOperation;
+
 /**
  Creates and enqueues an image request operation, which asynchronously downloads the image from the specified URL, and sets it the request is finished. Any previous image request for the receiver will be cancelled. If the image is cached locally, the image is set immediately, otherwise the specified placeholder image will be set immediately, and then the remote image will be set once the request is finished.
  


### PR DESCRIPTION
If the `af_imageRequestOperation` public, we can do a image download progress bar using `setDownloadProgressBlock`.
