### PR TITLE
Optional download and upload progress queue

### DIFF
--- a/AFNetworking/AFURLConnectionOperation.h
+++ b/AFNetworking/AFURLConnectionOperation.h
@@ -164,6 +164,20 @@
 @property (nonatomic, strong) NSOutputStream *outputStream;
 
 ///---------------------------------------------
+/// @name Progress Callback queues
+///---------------------------------------------
+
+/**
+ The callback dispatch queue on download progress. If `NULL` (default), the main queue is used.
+ */
+@property (nonatomic, assign) dispatch_queue_t downloadCallbackQueue;
+
+/**
+ The callback dispatch queue on upload progress. If `NULL` (default), the main queue is used.
+ */
+@property (nonatomic, assign) dispatch_queue_t uploadCallbackQueue;
+
+///---------------------------------------------
 /// @name Managing Request Operation Information
 ///---------------------------------------------
 


### PR DESCRIPTION
Yesterday I was writing an app that need the behaviour of download of a certain file to be totally outside the main queue and I needed to dispatch the process of the operation to an certain queue. Trying to do that I found out that the download and upload progress block were always dispatched to the main queue. 

So based on that I have implemented on the `AFURLConnectionOperation` the same behaviour we have on the `AFHTTPRequestOperation` that you have the option to pass custom queues for the failure and success block I have implemented the same behaviour for the upload and download progress block.
