### PR TITLE
-canProcessRequest isn't accurate

### DIFF
--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -509,7 +509,7 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {
     NSEnumerator *enumerator = [self.registeredHTTPOperationClassNames reverseObjectEnumerator];
     while (!operation && (className = [enumerator nextObject])) {
         Class op_class = NSClassFromString(className);
-        if (op_class && [op_class canProcessRequest:urlRequest]) {
+        if (op_class) {
             operation = [(AFHTTPRequestOperation *)[op_class alloc] initWithRequest:urlRequest];
         }
     }


### PR DESCRIPTION
Hi Mattt,

While I was working with Tumblr's API, I realized that AFHTTPClient doesn't use the earlier registered operation classes. Tumblr's API doesn't have a suffix (e.g. .json) appended thus let -canProcessRequest fail. 
IMO, I'd suggest to rename the method so it implies a probability to be able to process the request since it's not always right. It's your library and you know the best how to handle this issue. 

I hope you can fix this issue or merge my fork. 
As always, great work. I'm totally in love with it and use it in every project I can.
