### PR TITLE
Issue #751 Another fix

### DIFF
--- a/AFNetworking/AFURLConnectionOperation.h
+++ b/AFNetworking/AFURLConnectionOperation.h
@@ -75,7 +75,14 @@
  - A copy of an operation will not include the `outputStream` of the original.
  - Operation copies do not include `completionBlock`. `completionBlock` often strongly captures a reference to `self`, which would otherwise have the unintuitive side-effect of pointing to the _original_ operation when copied.
  */
-@interface AFURLConnectionOperation : NSOperation <NSURLConnectionDelegate, NSCoding, NSCopying>
+@interface AFURLConnectionOperation : NSOperation <NSURLConnectionDelegate,
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_5_0
+NSURLConnectionDataDelegate,
+#endif
+#if __MAC_OS_X_VERSION_MIN_REQUIRED >= __MAC_10_8
+NSURLConnectionDataDelegate,
+#endif
+NSCoding, NSCopying>
 
 ///-------------------------------
 /// @name Accessing Run Loop Modes


### PR DESCRIPTION
When you just remove NSURLConnectionDataDelegate protocol from AFURLConnectionOperation it is hard to subclass with high OS version 

This fix add checking of the current OS version and add delegate if it available
