### PR TITLE
Fixes warning: default label in switch which covers all enumeration valu...

### DIFF
--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -1160,19 +1160,7 @@ typedef enum {
         return YES;
     }
 
-    switch (self.inputStream.streamStatus) {
-        case NSStreamStatusNotOpen:
-        case NSStreamStatusOpening:
-        case NSStreamStatusOpen:
-        case NSStreamStatusReading:
-        case NSStreamStatusWriting:
-            return YES;
-        case NSStreamStatusAtEnd:
-        case NSStreamStatusClosed:
-        case NSStreamStatusError:
-        default:
-            return NO;
-    }
+    return self.inputStream.streamStatus < NSStreamStatusAtEnd;
 }
 
 - (NSInteger)read:(uint8_t *)buffer


### PR DESCRIPTION
...es [-Wcovered-switch-default].

Also simplifies the code.  Less lines and ensures there is always a return value from the method.  No need for switch or default case.

You didn't put the pragma around all the cases you reverted Matt.  So here is another little patch that I think makes the code better and fixes the warning.
