### PR TITLE
Compare NSURLRequest rather than NSURL

### DIFF
--- a/AFNetworking/UIImageView+AFNetworking.m
+++ b/AFNetworking/UIImageView+AFNetworking.m
@@ -114,7 +114,7 @@ static char kAFImageRequestOperationObjectKey;
 
         AFImageRequestOperation *requestOperation = [[AFImageRequestOperation alloc] initWithRequest:urlRequest];
         [requestOperation setCompletionBlockWithSuccess:^(AFHTTPRequestOperation *operation, id responseObject) {
-            if ([[urlRequest URL] isEqual:[[self.af_imageRequestOperation request] URL]]) {
+            if ([urlRequest isEqual:[self.af_imageRequestOperation request]]) {
                 if (success) {
                     success(operation.request, operation.response, responseObject);
                 } else {
@@ -128,7 +128,7 @@ static char kAFImageRequestOperationObjectKey;
 
             [[[self class] af_sharedImageCache] cacheImage:responseObject forRequest:urlRequest];
         } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
-            if ([[urlRequest URL] isEqual:[[self.af_imageRequestOperation request] URL]]) {
+            if ([urlRequest isEqual:[self.af_imageRequestOperation request]]) {
                 if (failure) {
                     failure(operation.request, operation.response, error);
                 }


### PR DESCRIPTION
If you inadvertently load a nil URL in UIImageView+AFNetworking, the failure block of the image request operation is bypassed because `[nil isEqual:nil] == NO`. By comparing the URL request instead of the URL, the `isEqual:` test passes and the error is properly forwarded to the failure block parameter.
