### PR TITLE
Skip query string parameters when matching request absolute URL and operation absolute URL.

### DIFF
--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -553,8 +553,13 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {
             continue;
         }
 
+	NSString *operationURL = [[[(AFHTTPRequestOperation *)operation request] URL] absoluteString];
+	NSString *operationWithNoParams = [operationURL componentsSeparatedByString:@"?"][0];
+		
+	NSString *URLStringWithNoParams = [URLStringToMatched componentsSeparatedByString:@"?"][0];
+		
         BOOL hasMatchingMethod = !method || [method isEqualToString:[[(AFHTTPRequestOperation *)operation request] HTTPMethod]];
-        BOOL hasMatchingURL = [[[[(AFHTTPRequestOperation *)operation request] URL] absoluteString] isEqualToString:URLStringToMatched];
+	BOOL hasMatchingURL = [operationWithNoParams isEqualToString:URLStringWithNoParams];
 
         if (hasMatchingMethod && hasMatchingURL) {
             [operation cancel];


### PR DESCRIPTION
In certain cases, the current request method's absolute URL may contain query string parameters that don't match those that may exist in the operation's absolute URL.

It may be beneficial to either directly trim query string parmeters from the string comparison or provide a new method that allows for this.
