### PR TITLE
Fix content type for extension from returning null

### DIFF
--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -742,7 +742,12 @@ static inline NSString * AFMultipartFormFinalBoundary() {
 static inline NSString * AFContentTypeForPathExtension(NSString *extension) {
 #ifdef __UTTYPE__
     NSString *UTI = (__bridge_transfer NSString *)UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, (__bridge CFStringRef)extension, NULL);
-    return (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)UTI, kUTTagClassMIMEType);
+    NSString *contentType = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)UTI, kUTTagClassMIMEType);
+    if (!contentType) {
+        return @"application/octet-stream";
+    } else {
+        return contentType;
+    }
 #else
     return @"application/octet-stream";
 #endif


### PR DESCRIPTION
AFContentTypeForPathExtension can currently return null for certain file extensions (like .md), which can cause uploads to fail. This makes sure it always falls back to application/octet-stream if it can't find a better type.
