### PR TITLE
Adding comma (,) as a percent escaped character

### DIFF
--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -81,7 +81,7 @@ static NSString * AFBase64EncodedStringFromString(NSString *string) {
 }
 
 static NSString * AFPercentEscapedQueryStringPairMemberFromStringWithEncoding(NSString *string, NSStringEncoding encoding) {
-    static NSString * const kAFCharactersToBeEscaped = @":/?&=;+!@#$()~'";
+    static NSString * const kAFCharactersToBeEscaped = @":/?&=;+!@#$()~',";
     static NSString * const kAFCharactersToLeaveUnescaped = @"[].";
 
 	return (__bridge_transfer  NSString *)CFURLCreateStringByAddingPercentEscapes(kCFAllocatorDefault, (__bridge CFStringRef)string, (__bridge CFStringRef)kAFCharactersToLeaveUnescaped, (__bridge CFStringRef)kAFCharactersToBeEscaped, CFStringConvertNSStringEncodingToEncoding(encoding));


### PR DESCRIPTION
 since it's in the reserved words per the RFC. 

Since we don't share AFPercentEscapedQueryStringPairMemberFromStringWithEncoding outside of AFNetworking, but AFOAuth1Client depends on having the _same_ escaping done, there will be another pull request there shortly
