### PR TITLE
Replaces no-longer-required ugliness in weakSelf pattern.

### DIFF
--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -343,9 +343,9 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {
         return;
     }
 
-    __weak __typeof(&*self)weakSelf = self;
+    __weak __typeof(self)weakSelf = self;
     AFNetworkReachabilityStatusBlock callback = ^(AFNetworkReachabilityStatus status) {
-        __strong __typeof(&*weakSelf)strongSelf = weakSelf;
+        __strong __typeof(self)strongSelf = weakSelf;
         if (!strongSelf) {
             return;
         }

--- a/AFNetworking/AFURLConnectionOperation.m
+++ b/AFNetworking/AFURLConnectionOperation.m
@@ -239,9 +239,9 @@ static inline BOOL AFStateTransitionIsValid(AFOperationState fromState, AFOperat
     if (!block) {
         [super setCompletionBlock:nil];
     } else {
-        __weak __typeof(&*self)weakSelf = self;
+        __weak __typeof(self)weakSelf = self;
         [super setCompletionBlock:^ {
-            __strong __typeof(&*weakSelf)strongSelf = weakSelf;
+            __strong __typeof(self)strongSelf = weakSelf;
 
             block();
             [strongSelf setCompletionBlock:nil];
@@ -280,9 +280,9 @@ static inline BOOL AFStateTransitionIsValid(AFOperationState fromState, AFOperat
     [self.lock lock];
     if (!self.backgroundTaskIdentifier) {
         UIApplication *application = [UIApplication sharedApplication];
-        __weak __typeof(&*self)weakSelf = self;
+        __weak __typeof(self)weakSelf = self;
         self.backgroundTaskIdentifier = [application beginBackgroundTaskWithExpirationHandler:^{
-            __strong __typeof(&*weakSelf)strongSelf = weakSelf;
+            __strong __typeof(self)strongSelf = weakSelf;
 
             if (handler) {
                 handler();


### PR DESCRIPTION
- With Xcode 4.4 and later , you can now skip the &\* operator on __weak __typeof.
- Also, I've switched __strong __typeof(weakSelf) to __strong __typeof(self); __typeof being a compile time operation, it does not cause self to be captured.
