### PR TITLE
Feature file download operation

### DIFF
--- a/AFNetworking.xcworkspace/contents.xcworkspacedata
+++ b/AFNetworking.xcworkspace/contents.xcworkspacedata
@@ -5,6 +5,12 @@
       location = "group:AFNetworking"
       name = "AFNetworking">
       <FileRef
+         location = "group:AFFileDownloadOperation.h">
+      </FileRef>
+      <FileRef
+         location = "group:AFFileDownloadOperation.m">
+      </FileRef>
+      <FileRef
          location = "group:AFHTTPClient.h">
       </FileRef>
       <FileRef

--- a/AFNetworking/AFFileDownloadOperation.h
+++ b/AFNetworking/AFFileDownloadOperation.h
@@ -1,3 +1,10 @@
+//
+//  AFFileDownloadOperation.h
+//  AFNetworking
+//
+//  Created by Vincent Roy Chevalier on 2013-02-28.
+//
+
 #import <Foundation/Foundation.h>
 
 #import "AFHTTPRequestOperation.h"

--- a/AFNetworking/AFFileDownloadOperation.m
+++ b/AFNetworking/AFFileDownloadOperation.m
@@ -1,3 +1,12 @@
+//
+//  AFFileDownloadOperation.m
+//  AFNetworking
+//
+//  Created by Vincent Roy Chevalier on 2013-02-28.
+//
+
+#import <Foundation/Foundation.h>
+
 #import "AFFileDownloadOperation.h"
 
 @implementation AFFileDownloadOperation
@@ -5,9 +14,9 @@
 @synthesize destinationFilePath = _destinationFilePath;
 
 - (id)initWithRequest:(NSURLRequest *)urlRequest destinationFilePath:(NSString *)filePath {
-    self = [super )initWithRequest:urlRequest];
+    self = [super initWithRequest:urlRequest];
     if (!self) {
-  	  return nil;
+        return nil;
     }
     
     _destinationFilePath = filePath;
@@ -18,17 +27,8 @@
 }
 
 - (void)connectionDidFinishLoading:(NSURLConnection __unused *)connection {
-    self.responseData = [NSData dataWithContentsOfFile:_destinationFilePath options:NSDataReadingMappedIfSafe error:nil];
-
-    [self.outputStream close];
-
-    [self finish];
-
-    self.connection = nil;
-}
-
-- (void)dealloc {
-    _destinationFilePath = nil;
+    [self.outputStream setProperty:[NSData dataWithContentsOfFile:_destinationFilePath options:NSDataReadingMappedIfSafe error:nil] forKey:NSStreamDataWrittenToMemoryStreamKey];
+    [super connectionDidFinishLoading:connection];
 }
 
 @end


### PR DESCRIPTION
New class AFFileDownloadOperation. Subclass of AFHTTPRequestOperation. It fixes major memory allocation problem by switching NSOutputStream from Memory to Disk with + outputStreamToFileAtPath:append:. Problem has been encountered by developing an app that manage files without restriction on size. Memory allocations were way too heavy.
