### PR TITLE
Allow enabling self-signed SSL certificates at runtime

### DIFF
--- a/AFNetworking/AFHTTPClient.h
+++ b/AFNetworking/AFHTTPClient.h
@@ -253,6 +253,12 @@ typedef enum {
  */
 - (void)setDefaultCredential:(NSURLCredential *)credential;
 
+/**
+ Whether the URL connection should allows invalid SSL certificates (such as self-signed certificates) when connecting to an SSL-enabled server.
+ `NO` by default.
+ */
+@property (nonatomic, assign) BOOL allowInvalidSSLCertificate;
+
 ///-------------------------------
 /// @name Creating Request Objects
 ///-------------------------------

--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -206,6 +206,7 @@ NSArray * AFQueryStringPairsFromKeyAndValue(NSString *key, id value) {
 @synthesize registeredHTTPOperationClassNames = _registeredHTTPOperationClassNames;
 @synthesize defaultHeaders = _defaultHeaders;
 @synthesize defaultCredential = _defaultCredential;
+@synthesize allowInvalidSSLCertificate = _allowInvalidSSLCertificate;
 @synthesize operationQueue = _operationQueue;
 #ifdef _SYSTEMCONFIGURATION_H
 @synthesize networkReachability = _networkReachability;
@@ -533,6 +534,7 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {
     [operation setCompletionBlockWithSuccess:success failure:failure];
 
     operation.credential = self.defaultCredential;
+	operation.allowInvalidSSLCertificate = self.allowInvalidSSLCertificate;
 
     return operation;
 }

--- a/AFNetworking/AFURLConnectionOperation.h
+++ b/AFNetworking/AFURLConnectionOperation.h
@@ -150,6 +150,12 @@ NSCoding, NSCopying>
  */
 @property (nonatomic, strong) NSURLCredential *credential;
 
+/**
+ Whether the URL connection should allows invalid SSL certificates (such as self-signed certificates) when connecting to an SSL-enabled server.
+ `NO` by default.
+ */
+@property (nonatomic, assign) BOOL allowInvalidSSLCertificate;
+
 ///------------------------
 /// @name Accessing Streams
 ///------------------------

--- a/AFNetworking/AFURLConnectionOperation.m
+++ b/AFNetworking/AFURLConnectionOperation.m
@@ -145,6 +145,7 @@ static inline BOOL AFStateTransitionIsValid(AFOperationState fromState, AFOperat
 @dynamic inputStream;
 @synthesize outputStream = _outputStream;
 @synthesize credential = _credential;
+@synthesize allowInvalidSSLCertificate = _allowInvalidSSLCertificate;
 @synthesize shouldUseCredentialStorage = _shouldUseCredentialStorage;
 @synthesize userInfo = _userInfo;
 @synthesize backgroundTaskIdentifier = _backgroundTaskIdentifier;
@@ -524,10 +525,11 @@ willSendRequestForAuthenticationChallenge:(NSURLAuthenticationChallenge *)challe
 canAuthenticateAgainstProtectionSpace:(NSURLProtectionSpace *)protectionSpace
 {
 #ifdef _AFNETWORKING_ALLOW_INVALID_SSL_CERTIFICATES_
-    if ([protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust]) {
+    _allowInvalidSSLCertificate = YES;
+#endif
+	if (_allowInvalidSSLCertificate && [protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust]) {
         return YES;
     }
-#endif
 
     if (self.authenticationAgainstProtectionSpace) {
         return self.authenticationAgainstProtectionSpace(connection, protectionSpace);
@@ -542,11 +544,12 @@ canAuthenticateAgainstProtectionSpace:(NSURLProtectionSpace *)protectionSpace
 didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge
 {
 #ifdef _AFNETWORKING_ALLOW_INVALID_SSL_CERTIFICATES_
-    if ([challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust]) {
+    _allowInvalidSSLCertificate = YES;
+#endif
+	if (_allowInvalidSSLCertificate && [challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust]) {
         [challenge.sender useCredential:[NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust] forAuthenticationChallenge:challenge];
         return;
     }
-#endif
 
     if (self.authenticationChallenge) {
         self.authenticationChallenge(connection, challenge);


### PR DESCRIPTION
Currently, the ability to use self-signed SSL certificates is enabled through a preprocessor macro. This means the app can't decide at runtime whether to allow these certificates. This pull requests adds a property to AFHTTPClient called allowInvalidSSLCertificate, which when set to YES allows invalid SSL certificates. To maintain backwards compatibility, the existing preprocessor macro is honoured.

Although obviously not a good idea to enable in a public build of an app, during testing we choose which server to use at runtime and we need to authenticate against a server that uses a self-signed certificate. This greatly helps with our ability to work against this server.
