### PR TITLE
unwanted string conversion when the response charset is not set

### DIFF
--- a/AFNetworking/AFJSONRequestOperation.m
+++ b/AFNetworking/AFJSONRequestOperation.m
@@ -75,8 +75,8 @@ static dispatch_queue_t json_request_operation_processing_queue() {
         } else {
             // Workaround for a bug in NSJSONSerialization when Unicode character escape codes are used instead of the actual character
             // See http://stackoverflow.com/a/12843465/157142
-            NSData *JSONData = [self.responseString dataUsingEncoding:self.responseStringEncoding];
-            self.responseJSON = [NSJSONSerialization JSONObjectWithData:JSONData options:self.JSONReadingOptions error:&error];
+            self.responseJSON = [NSJSONSerialization JSONObjectWithData:self.responseData
+                                                                options:self.JSONReadingOptions error:&error];
         }
 
         self.JSONError = error;


### PR DESCRIPTION
First the response data is decoded in "ISO-8859-1" in the "responseString" property getter. Then it is re-encoded in UTF-8 since responseStringEncoding properties default value is NSUTF8StringEncoding
