### PR TITLE
Set indentation settings to four spaces at the project level

### DIFF
--- a/Example/AFNetworking Mac Example.xcodeproj/project.pbxproj
+++ b/Example/AFNetworking Mac Example.xcodeproj/project.pbxproj
@@ -86,7 +86,10 @@
 				F8129BFE1591061B009BFE23 /* Frameworks */,
 				F8129BFC1591061B009BFE23 /* Products */,
 			);
+			indentWidth = 4;
 			sourceTree = "<group>";
+			tabWidth = 4;
+			usesTabs = 0;
 		};
 		F8129BFC1591061B009BFE23 /* Products */ = {
 			isa = PBXGroup;

--- a/Example/AFNetworking iOS Example.xcodeproj/project.pbxproj
+++ b/Example/AFNetworking iOS Example.xcodeproj/project.pbxproj
@@ -152,7 +152,10 @@
 				F8E469631395739D00DB05C8 /* Frameworks */,
 				F8E469611395739C00DB05C8 /* Products */,
 			);
+			indentWidth = 4;
 			sourceTree = "<group>";
+			tabWidth = 4;
+			usesTabs = 0;
 		};
 		F8E469611395739C00DB05C8 /* Products */ = {
 			isa = PBXGroup;


### PR DESCRIPTION
Since all sane people have set their Xcode indentation preference to tabs :trollface:, this will force them to use spaces instead when contributing to AFNetworking.
