### PR TITLE
Update network activity indicator only if requests have a non nil URL

### DIFF
--- a/AFNetworking/AFNetworkActivityIndicatorManager.m
+++ b/AFNetworking/AFNetworkActivityIndicatorManager.m
@@ -62,8 +62,8 @@ static NSTimeInterval const kAFNetworkActivityIndicatorInvisibilityDelay = 0.17;
         return nil;
     }
 
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(incrementActivityCount) name:AFNetworkingOperationDidStartNotification object:nil];
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(decrementActivityCount) name:AFNetworkingOperationDidFinishNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(networkingOperationDidStart:) name:AFNetworkingOperationDidStartNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(networkingOperationDidFinish:) name:AFNetworkingOperationDidFinishNotification object:nil];
 
     return self;
 }
@@ -124,6 +124,20 @@ static NSTimeInterval const kAFNetworkActivityIndicatorInvisibilityDelay = 0.17;
 	}
     [self didChangeValueForKey:@"activityCount"];
     [self updateNetworkActivityIndicatorVisibilityDelayed];
+}
+
+- (void)networkingOperationDidStart:(NSNotification *)notification {
+    AFURLConnectionOperation *connectionOperation = [notification object];
+    if (connectionOperation.request.URL) {
+        [self incrementActivityCount];
+    }
+}
+
+- (void)networkingOperationDidFinish:(NSNotification *)notification {
+    AFURLConnectionOperation *connectionOperation = [notification object];
+    if (connectionOperation.request.URL) {
+        [self decrementActivityCount];
+    }
 }
 
 @end


### PR DESCRIPTION
If requests have a nil URL (try commenting the line `_avatarImageURLString = [attributes valueForKeyPath:@"avatar_image.url"];` in `User.m`) the network activity indicator will activate although there is no network activity at all.
