### PR TITLE
Added SOAP content type to acceptable content types in AFXMLRequestOperation

### DIFF
--- a/AFNetworking/AFXMLRequestOperation.m
+++ b/AFNetworking/AFXMLRequestOperation.m
@@ -129,7 +129,7 @@ static dispatch_queue_t xml_request_operation_processing_queue() {
 #pragma mark - AFHTTPRequestOperation
 
 + (NSSet *)acceptableContentTypes {
-    return [NSSet setWithObjects:@"application/xml", @"text/xml", nil];
+    return [NSSet setWithObjects:@"application/xml", @"text/xml", @"application/soap+xml", nil];
 }
 
 + (BOOL)canProcessRequest:(NSURLRequest *)request {


### PR DESCRIPTION
I was doing Microsoft Dynamics CRM Authentication and my request to fetch tokens was failing because the AFNetworking didn't support 'application/soap+xml' content type. So I just added it. It's a trivial change.

Cheers,

Akbar.
