### PR TITLE
AFHTTPClient Registered operation classes consulted in wrong order.

### DIFF
--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -519,9 +519,9 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {
     AFHTTPRequestOperation *operation = nil;
     
     for (NSString * className in self.registeredHTTPOperationClassNames) {
-        Class op_class = NSClassFromString(className);
-        if (op_class && [op_class canProcessRequest:urlRequest]) {
-            operation = [(AFHTTPRequestOperation *)[op_class alloc] initWithRequest:urlRequest];
+        Class operationClass = NSClassFromString(className);
+        if (operationClass && [operationClass canProcessRequest:urlRequest]) {
+            operation = [(AFHTTPRequestOperation *)[operationClass alloc] initWithRequest:urlRequest];
             break;
         }
     }


### PR DESCRIPTION
The documentation states registered operation classes are consulted in the reverse order in which they are registered. New registrations are added to the beginning of the array in the `registerHTTPOperationClass:` implementation creating a LIFO array. 

Fixed using the reverseObjectEnumerator in `HTTPRequestOperationWithRequest:success:failure:` when iterating the `registeredHTTPOperationClassNames` array which produced the opposite of documented behaviour. The array was already LIFO did not need to be reversed again. fixes #794

The ordering of the array should be associated with the register implementation. The array should not have to be reverse iterated for each method that might require it. That is why I removed the use of the `reverseObjectEnumerator`
