### PR TITLE
UIImageView's image not set when given a success block

### DIFF
--- a/AFNetworking/UIImageView+AFNetworking.m
+++ b/AFNetworking/UIImageView+AFNetworking.m
@@ -117,7 +117,9 @@ static char kAFImageRequestOperationObjectKey;
             if ([urlRequest isEqual:[self.af_imageRequestOperation request]]) {
                 if (success) {
                     success(operation.request, operation.response, responseObject);
-                } else if (responseObject) {
+                }
+
+                if (responseObject) {
                     self.image = responseObject;
                 }
 


### PR DESCRIPTION
Calling `setImageWithURLRequest:placeholderImage:success:failure:` with a success block does not set the image.

The image will not appear the first time, but it will work anytime after that because the image is set from cache.
