### PR TITLE
Category methods collision

### DIFF
--- a/AFNetworking/UIImageView+AFNetworking.h
+++ b/AFNetworking/UIImageView+AFNetworking.h
@@ -40,7 +40,7 @@
 
  @param url The URL used for the image request.
  */
-- (void)setImageWithURL:(NSURL *)url;
+- (void)af_setImageWithURL:(NSURL *)url;
 
 /**
  Creates and enqueues an image request operation, which asynchronously downloads the image from the specified URL. Any previous image request for the receiver will be cancelled. If the image is cached locally, the image is set immediately, otherwise the specified placeholder image will be set immediately, and then the remote image will be set once the request is finished.
@@ -50,7 +50,7 @@
 
  @discussion By default, URL requests have a cache policy of `NSURLCacheStorageAllowed` and a timeout interval of 30 seconds, and are set not handle cookies. To configure URL requests differently, use `setImageWithURLRequest:placeholderImage:success:failure:`
  */
-- (void)setImageWithURL:(NSURL *)url
+- (void)af_setImageWithURL:(NSURL *)url
        placeholderImage:(UIImage *)placeholderImage;
 
 /**
@@ -63,7 +63,7 @@
 
  @discussion If a success block is specified, it is the responsibility of the block to set the image of the image view before returning. If no success block is specified, the default behavior of setting the image with `self.image = image` is executed.
  */
-- (void)setImageWithURLRequest:(NSURLRequest *)urlRequest
+- (void)af_setImageWithURLRequest:(NSURLRequest *)urlRequest
               placeholderImage:(UIImage *)placeholderImage
                        success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, UIImage *image))success
                        failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error))failure;
@@ -71,7 +71,7 @@
 /**
  Cancels any executing image request operation for the receiver, if one exists.
  */
-- (void)cancelImageRequestOperation;
+- (void)af_cancelImageRequestOperation;
 
 @end
 

--- a/AFNetworking/UIImageView+AFNetworking.m
+++ b/AFNetworking/UIImageView+AFNetworking.m
@@ -79,20 +79,20 @@ static char kAFImageRequestOperationObjectKey;
 
 #pragma mark -
 
-- (void)setImageWithURL:(NSURL *)url {
-    [self setImageWithURL:url placeholderImage:nil];
+- (void)af_setImageWithURL:(NSURL *)url {
+    [self af_setImageWithURL:url placeholderImage:nil];
 }
 
-- (void)setImageWithURL:(NSURL *)url
+- (void)af_setImageWithURL:(NSURL *)url
        placeholderImage:(UIImage *)placeholderImage
 {
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
     [request addValue:@"image/*" forHTTPHeaderField:@"Accept"];
 
-    [self setImageWithURLRequest:request placeholderImage:placeholderImage success:nil failure:nil];
+    [self af_setImageWithURLRequest:request placeholderImage:placeholderImage success:nil failure:nil];
 }
 
-- (void)setImageWithURLRequest:(NSURLRequest *)urlRequest
+- (void)af_setImageWithURLRequest:(NSURLRequest *)urlRequest
               placeholderImage:(UIImage *)placeholderImage
                        success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, UIImage *image))success
                        failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error))failure
@@ -144,7 +144,7 @@ static char kAFImageRequestOperationObjectKey;
     }
 }
 
-- (void)cancelImageRequestOperation {
+- (void)af_cancelImageRequestOperation {
     [self.af_imageRequestOperation cancel];
     self.af_imageRequestOperation = nil;
 }

--- a/Example/Classes/Views/PostTableViewCell.m
+++ b/Example/Classes/Views/PostTableViewCell.m
@@ -54,7 +54,7 @@
 
     self.textLabel.text = _post.user.username;
     self.detailTextLabel.text = _post.text;
-    [self.imageView setImageWithURL:_post.user.avatarImageURL placeholderImage:[UIImage imageNamed:@"profile-image-placeholder"]];
+    [self.imageView af_setImageWithURL:_post.user.avatarImageURL placeholderImage:[UIImage imageNamed:@"profile-image-placeholder"]];
     
     [self setNeedsLayout];
 }


### PR DESCRIPTION
Hey, there was an interesting issue on RestKit project https://github.com/RestKit/RestKit/issues/1285

Looks like AFNetworking UIImageView category shares some method names with that of SDWebImage, which leads to weird bugs as seen above. 

https://github.com/rs/SDWebImage/blob/master/SDWebImage/UIImageView%2BWebCache.h#L53
https://github.com/AFNetworking/AFNetworking/blob/master/AFNetworking/UIImageView%2BAFNetworking.h#L43

I wonder if there should be a af_ prefix, I understand that this will lead to big backwards compatibility breakage :/

/cc @rs
