### PR TITLE
Set the name of the network thread

### DIFF
--- a/AFNetworking/AFURLConnectionOperation.m
+++ b/AFNetworking/AFURLConnectionOperation.m
@@ -159,7 +159,7 @@ static inline BOOL AFStateTransitionIsValid(AFOperationState fromState, AFOperat
 + (void) __attribute__((noreturn)) networkRequestThreadEntryPoint:(id)__unused object {
     do {
         @autoreleasepool {
-            [NSThread currentThread].name = @"AFNetworking";
+            [[NSThread currentThread] setName:@"AFNetworking"];
             [[NSRunLoop currentRunLoop] run];
         }
     } while (YES);


### PR DESCRIPTION
This makes debugging a lot nicer.

![before](https://f.cloud.github.com/assets/58493/295197/125f1bb2-9466-11e2-9aff-7d87a29bc4bd.png)
![after](https://f.cloud.github.com/assets/58493/295198/14cd0774-9466-11e2-8c63-6fed2fe15d8c.png)
