### PR TITLE
Small correction to SSL Pinning documentation

### DIFF
--- a/AFNetworking/AFURLConnectionOperation.h
+++ b/AFNetworking/AFURLConnectionOperation.h
@@ -315,7 +315,7 @@ NSCoding, NSCopying>
 ///----------------
 
 /**
- ## Network Reachability
+ ## SSL Pinning Options
 
  The following constants are provided by `AFURLConnectionOperation` as possible SSL Pinning options.
 


### PR DESCRIPTION
Noticed a section misnamed in the new SSL pinning docs...

Also on a side note, why not use NS_OPTIONS there instead of just a plain ole enum?
