### PR TITLE
fix: current code wasn't able to parse JSON responses with encoding other than UTF-8, UTF-16, UTF-32

### DIFF
--- a/AFNetworking/AFJSONRequestOperation.m
+++ b/AFNetworking/AFJSONRequestOperation.m
@@ -73,6 +73,8 @@ static dispatch_queue_t json_request_operation_processing_queue() {
         if ([self.responseData length] == 0 || [self.responseString isEqualToString:@" "]) {
             self.responseJSON = nil;
         } else {
+            // Workaround for a bug in NSJSONSerialization when Unicode character escape codes are used instead of the actual character
+            // See http://stackoverflow.com/a/12843465/157142
             NSData *JSONData = [self.responseString dataUsingEncoding:NSUTF8StringEncoding];
             self.responseJSON = [NSJSONSerialization JSONObjectWithData:JSONData options:self.JSONReadingOptions error:&error];
         }


### PR DESCRIPTION
First, thanks for the great library :-)
I think i found a bug in parsing JSON responses using the response encoding.
Afaik this is done in 2 steps, first parsing the responseString into a unicode using the response encoding.
Second parsing the JSON out of the responseString unicode.
According to the Apple spec (https://developer.apple.com/library/mac/#documentation/Foundation/Reference/NSJSONSerialization_Class/Reference/Reference.html), data given to [NSJSONSerialization JSONObjectWithData:..] must be encoded with one of UTF-8, UTF-16LE, UTF-16BE, UTF-32LE, UTF-32BE.
Anything else won't work afaik.
The current code is using the response encoding for building the NSData from the responseString, so parsing JSON from an URI which uses an encoding other than the 5 listed above will fail (e.g. ISO-8859-1).
The responseString is already a unicode, so I think hardcoding the encoding here to UTF-8 won't harm anything and fixes problems when the response encoding is not one of the by NSJSONSerialization supported ones.
