### PR TITLE
Add optional headers parameter to getPath, postPath, etc.

### DIFF
--- a/AFNetworking/AFHTTPClient.h
+++ b/AFNetworking/AFHTTPClient.h
@@ -372,6 +372,7 @@ typedef enum {
 
  @param path The path to be appended to the HTTP client's base URL and used as the request URL.
  @param parameters The parameters to be encoded and appended as the query string for the request URL.
+ @param headers (optional) Additional HTTP headers to be sent.
  @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes two arguments: the created request operation and the object created from the response data of request.
  @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes two arguments:, the created request operation and the `NSError` object describing the network or parsing error that occurred.
 
@@ -382,11 +383,18 @@ typedef enum {
         success:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
         failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure;
 
+- (void)getPath:(NSString *)path
+     parameters:(NSDictionary *)parameters
+        headers:(NSDictionary *)headers
+        success:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
+        failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure;
+
 /**
  Creates an `AFHTTPRequestOperation` with a `POST` request, and enqueues it to the HTTP client's operation queue.
 
  @param path The path to be appended to the HTTP client's base URL and used as the request URL.
  @param parameters The parameters to be encoded and set in the request HTTP body.
+ @param headers (optional) Additional HTTP headers to be sent.
  @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes two arguments: the created request operation and the object created from the response data of request.
  @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes two arguments:, the created request operation and the `NSError` object describing the network or parsing error that occurred.
 
@@ -397,11 +405,18 @@ typedef enum {
          success:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
          failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure;
 
+- (void)postPath:(NSString *)path
+      parameters:(NSDictionary *)parameters
+         headers:(NSDictionary *)headers
+         success:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
+         failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure;
+
 /**
  Creates an `AFHTTPRequestOperation` with a `PUT` request, and enqueues it to the HTTP client's operation queue.
 
  @param path The path to be appended to the HTTP client's base URL and used as the request URL.
  @param parameters The parameters to be encoded and set in the request HTTP body.
+ @param headers (optional) Additional HTTP headers to be sent.
  @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes two arguments: the created request operation and the object created from the response data of request.
  @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes two arguments:, the created request operation and the `NSError` object describing the network or parsing error that occurred.
 
@@ -412,11 +427,18 @@ typedef enum {
         success:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
         failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure;
 
+- (void)putPath:(NSString *)path
+     parameters:(NSDictionary *)parameters
+        headers:(NSDictionary *)headers
+        success:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
+        failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure;
+
 /**
  Creates an `AFHTTPRequestOperation` with a `DELETE` request, and enqueues it to the HTTP client's operation queue.
 
  @param path The path to be appended to the HTTP client's base URL and used as the request URL.
  @param parameters The parameters to be encoded and appended as the query string for the request URL.
+ @param headers (optional) Additional HTTP headers to be sent.
  @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes two arguments: the created request operation and the object created from the response data of request.
  @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes two arguments:, the created request operation and the `NSError` object describing the network or parsing error that occurred.
 
@@ -427,11 +449,18 @@ typedef enum {
            success:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
            failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure;
 
+- (void)deletePath:(NSString *)path
+        parameters:(NSDictionary *)parameters
+           headers:(NSDictionary *)headers
+           success:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
+           failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure;
+
 /**
  Creates an `AFHTTPRequestOperation` with a `PATCH` request, and enqueues it to the HTTP client's operation queue.
 
  @param path The path to be appended to the HTTP client's base URL and used as the request URL.
  @param parameters The parameters to be encoded and set in the request HTTP body.
+ @param headers (optional) Additional HTTP headers to be sent.
  @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes two arguments: the created request operation and the object created from the response data of request.
  @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes two arguments:, the created request operation and the `NSError` object describing the network or parsing error that occurred.
 
@@ -439,6 +468,12 @@ typedef enum {
  */
 - (void)patchPath:(NSString *)path
        parameters:(NSDictionary *)parameters
+          success:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
+          failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure;
+
+- (void)patchPath:(NSString *)path
+       parameters:(NSDictionary *)parameters
+          headers:(NSDictionary *)headers
           success:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
           failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure;
 @end

--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -639,6 +639,21 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {
     [self enqueueHTTPRequestOperation:operation];
 }
 
+- (void)getPath:(NSString *)path
+     parameters:(NSDictionary *)parameters
+        headers:(NSDictionary *)headers
+        success:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
+        failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure
+{
+    NSMutableURLRequest *request = [[self requestWithMethod:@"GET" path:path parameters:parameters] mutableCopy];
+    [headers enumerateKeysAndObjectsUsingBlock:^(id name, id value, BOOL *stop) {
+        [request setValue:value forHTTPHeaderField:name];
+    }];
+
+    AFHTTPRequestOperation *operation = [self HTTPRequestOperationWithRequest:request success:success failure:failure];
+    [self enqueueHTTPRequestOperation:operation];
+}
+
 - (void)postPath:(NSString *)path
       parameters:(NSDictionary *)parameters
          success:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
@@ -646,6 +661,21 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {
 {
 	NSURLRequest *request = [self requestWithMethod:@"POST" path:path parameters:parameters];
 	AFHTTPRequestOperation *operation = [self HTTPRequestOperationWithRequest:request success:success failure:failure];
+    [self enqueueHTTPRequestOperation:operation];
+}
+
+- (void)postPath:(NSString *)path
+      parameters:(NSDictionary *)parameters
+         headers:(NSDictionary *)headers
+         success:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
+         failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure
+{
+    NSMutableURLRequest *request = [[self requestWithMethod:@"POST" path:path parameters:parameters] mutableCopy];
+    [headers enumerateKeysAndObjectsUsingBlock:^(id name, id value, BOOL *stop) {
+        [request setValue:value forHTTPHeaderField:name];
+    }];
+
+    AFHTTPRequestOperation *operation = [self HTTPRequestOperationWithRequest:request success:success failure:failure];
     [self enqueueHTTPRequestOperation:operation];
 }
 
@@ -659,6 +689,21 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {
     [self enqueueHTTPRequestOperation:operation];
 }
 
+- (void)putPath:(NSString *)path
+     parameters:(NSDictionary *)parameters
+        headers:(NSDictionary *)headers
+        success:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
+        failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure
+{
+    NSMutableURLRequest *request = [[self requestWithMethod:@"PUT" path:path parameters:parameters] mutableCopy];
+    [headers enumerateKeysAndObjectsUsingBlock:^(id name, id value, BOOL *stop) {
+        [request setValue:value forHTTPHeaderField:name];
+    }];
+
+    AFHTTPRequestOperation *operation = [self HTTPRequestOperationWithRequest:request success:success failure:failure];
+    [self enqueueHTTPRequestOperation:operation];
+}
+
 - (void)deletePath:(NSString *)path
         parameters:(NSDictionary *)parameters
            success:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
@@ -669,6 +714,21 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {
     [self enqueueHTTPRequestOperation:operation];
 }
 
+- (void)deletePath:(NSString *)path
+        parameters:(NSDictionary *)parameters
+           headers:(NSDictionary *)headers
+           success:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
+           failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure
+{
+    NSMutableURLRequest *request = [[self requestWithMethod:@"DELETE" path:path parameters:parameters] mutableCopy];
+    [headers enumerateKeysAndObjectsUsingBlock:^(id name, id value, BOOL *stop) {
+        [request setValue:value forHTTPHeaderField:name];
+    }];
+
+    AFHTTPRequestOperation *operation = [self HTTPRequestOperationWithRequest:request success:success failure:failure];
+    [self enqueueHTTPRequestOperation:operation];
+}
+
 - (void)patchPath:(NSString *)path
        parameters:(NSDictionary *)parameters
           success:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
@@ -676,6 +736,21 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {
 {
     NSURLRequest *request = [self requestWithMethod:@"PATCH" path:path parameters:parameters];
 	AFHTTPRequestOperation *operation = [self HTTPRequestOperationWithRequest:request success:success failure:failure];
+    [self enqueueHTTPRequestOperation:operation];
+}
+
+- (void)patchPath:(NSString *)path
+       parameters:(NSDictionary *)parameters
+          headers:(NSDictionary *)headers
+          success:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
+          failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure
+{
+    NSMutableURLRequest *request = [[self requestWithMethod:@"PATCH" path:path parameters:parameters] mutableCopy];
+    [headers enumerateKeysAndObjectsUsingBlock:^(id name, id value, BOOL *stop) {
+        [request setValue:value forHTTPHeaderField:name];
+    }];
+
+    AFHTTPRequestOperation *operation = [self HTTPRequestOperationWithRequest:request success:success failure:failure];
     [self enqueueHTTPRequestOperation:operation];
 }
 


### PR DESCRIPTION
Hi!

Thanks very much for writing AFNetworking. :)

My app is talking to a RESTful API and oftentimes that means sending additional headers for individual requests. Headers like `If-Match` only make sense for a specific request (as opposed to all requests that an AFHTTPClient will make). I certainly could have called `setDefaultHeader:value:` before the request, then after firing off the request, call it again passing `nil` for the value to clear that default. But that lacks elegance in a big way.

I'm not the first with this need: http://stackoverflow.com/questions/12667838/setting-non-default-http-headers-with-afhttpclient the accepted answer says to make a different subclass of AFHTTPClient for each resource (yikes!!)

So, to make that answer and my app better, what this pull requests adds is variants of getPath, postPath, putPath, deletePath, and patchPath, all of which have an additional `headers:(NSDictionary *)headers` parameter after `parameters:`.

There were two ways to implement this: either adding second copies of each of the five methods, tweaking them to add headers, or making the original `headers`-less variants call the new variants, passing `nil` for `headers:`. Ordinarily I would have chosen the latter, but in this case I chose the former because the existing `getPath`, `postPath`, etc. could have easily been written to call a private `requestPath` that has a method parameter, but they're not written that way (whether as an optimization or for debugging, I don't know). In other words, I opted to match the existing tradeoffs.

Please excuse and inform me of any mistakes I've made here, this is my first time contributing to an Obj-C project :)

Cheers,
Shawn
