### PR TITLE
AFHTTPRequestOperation subclasses: Minor refactoring

### DIFF
--- a/AFNetworking/AFJSONRequestOperation.m
+++ b/AFNetworking/AFJSONRequestOperation.m
@@ -48,7 +48,7 @@ static dispatch_queue_t json_request_operation_processing_queue() {
 										success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, id JSON))success
 										failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, id JSON))failure
 {
-    AFJSONRequestOperation *requestOperation = [(AFJSONRequestOperation *)[self alloc] initWithRequest:urlRequest];
+    AFJSONRequestOperation *requestOperation = [[self alloc] initWithRequest:urlRequest];
     [requestOperation setCompletionBlockWithSuccess:^(AFHTTPRequestOperation *operation, id responseObject) {
         if (success) {
             success(operation.request, operation.response, responseObject);
@@ -87,11 +87,7 @@ static dispatch_queue_t json_request_operation_processing_queue() {
 }
 
 - (NSError *)error {
-    if (_JSONError) {
-        return _JSONError;
-    } else {
-        return [super error];
-    }
+    return _JSONError ?: [super error];
 }
 
 #pragma mark - AFHTTPRequestOperation

--- a/AFNetworking/AFPropertyListRequestOperation.m
+++ b/AFNetworking/AFPropertyListRequestOperation.m
@@ -48,7 +48,7 @@ static dispatch_queue_t property_list_request_operation_processing_queue() {
 												success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, id propertyList))success
 												failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, id propertyList))failure
 {
-    AFPropertyListRequestOperation *requestOperation = [(AFPropertyListRequestOperation *)[self alloc] initWithRequest:request];
+    AFPropertyListRequestOperation *requestOperation = [[self alloc] initWithRequest:request];
     [requestOperation setCompletionBlockWithSuccess:^(AFHTTPRequestOperation *operation, id responseObject) {
         if (success) {
             success(operation.request, operation.response, responseObject);
@@ -87,17 +87,13 @@ static dispatch_queue_t property_list_request_operation_processing_queue() {
 }
 
 - (NSError *)error {
-    if (_propertyListError) {
-        return _propertyListError;
-    } else {
-        return [super error];
-    }
+    return _propertyListError ?: [super error];
 }
 
 #pragma mark - AFHTTPRequestOperation
 
 + (NSSet *)acceptableContentTypes {
-    return [NSSet setWithObjects:@"application/x-plist", nil];
+    return [NSSet setWithObject:@"application/x-plist"];
 }
 
 + (BOOL)canProcessRequest:(NSURLRequest *)request {

--- a/AFNetworking/AFXMLRequestOperation.m
+++ b/AFNetworking/AFXMLRequestOperation.m
@@ -53,7 +53,7 @@ static dispatch_queue_t xml_request_operation_processing_queue() {
 											 success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSXMLParser *XMLParser))success
 											 failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, NSXMLParser *XMLParser))failure
 {
-    AFXMLRequestOperation *requestOperation = [(AFXMLRequestOperation *)[self alloc] initWithRequest:urlRequest];
+    AFXMLRequestOperation *requestOperation = [[self alloc] initWithRequest:urlRequest];
     [requestOperation setCompletionBlockWithSuccess:^(AFHTTPRequestOperation *operation, id responseObject) {
         if (success) {
             success(operation.request, operation.response, responseObject);
@@ -111,11 +111,7 @@ static dispatch_queue_t xml_request_operation_processing_queue() {
 #endif
 
 - (NSError *)error {
-    if (_XMLError) {
-        return _XMLError;
-    } else {
-        return [super error];
-    }
+    return _XMLError ?: [super error];
 }
 
 #pragma mark - NSOperation


### PR DESCRIPTION
1. Remove unnecessary cast in factory method
2. Terser implementation of `-error`
3. Change `-setWithObjects:` to `-setWithObject:`
