### PR TITLE
AFImageRequestOperation tweaks

### DIFF
--- a/AFNetworking/AFImageRequestOperation.m
+++ b/AFNetworking/AFImageRequestOperation.m
@@ -106,7 +106,7 @@ static dispatch_queue_t image_request_operation_processing_queue() {
 										 success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSImage *image))success
 										 failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error))failure
 {
-    AFImageRequestOperation *requestOperation = [[AFImageRequestOperation alloc] initWithRequest:urlRequest];
+    AFImageRequestOperation *requestOperation = [[self alloc] initWithRequest:urlRequest];
     [requestOperation setCompletionBlockWithSuccess:^(AFHTTPRequestOperation *operation, id responseObject) {
         if (success) {
             NSImage *image = responseObject;


### PR DESCRIPTION
This pull request fixes a couple of issues I was having when using AFImageRequestOperation.
- One of the servers my app tried to connect to was returning JPEG images with a content type of `image/jpg`. While technically incorrect, this caused the operation to fail, which isn't desirable behaviour. Unfortunately the server isn't one I control, otherwise I'd have made the change on the server side.
- While attempting to subclass `AFImageRequestOperation` to include the invalid type, I noticed that `imageRequestOperationWithRequest:imageProcessingBlock:success:failure:` always returned AFImageRequestOperation instances, rather than instances of the current class (like the other request operation classes).
