### PR TITLE
Some minor stuff

### DIFF
--- a/AFNetworking/AFURLConnectionOperation.m
+++ b/AFNetworking/AFURLConnectionOperation.m
@@ -208,7 +208,7 @@ static inline BOOL AFStateTransitionIsValid(AFOperationState fromState, AFOperat
         
         for (NSData *data in pinnedCertificates) {
             SecCertificateRef allowedCertificate = SecCertificateCreateWithData(NULL, (__bridge CFDataRef)data);
-            NSCParameterAssert(allowedCertificate);
+            NSParameterAssert(allowedCertificate);
             
             SecCertificateRef allowedCertificates[] = {allowedCertificate};
             CFArrayRef certificates = CFArrayCreate(NULL, (const void **)allowedCertificates, 1, NULL);
@@ -223,7 +223,7 @@ static inline BOOL AFStateTransitionIsValid(AFOperationState fromState, AFOperat
             NSAssert(status == errSecSuccess, @"SecTrustEvaluate error: %ld", (long int)status);
             
             SecKeyRef allowedPublicKey = SecTrustCopyPublicKey(allowedTrust);            
-            NSCParameterAssert(allowedPublicKey);
+            NSParameterAssert(allowedPublicKey);
             [publicKeys addObject:(__bridge_transfer id)allowedPublicKey];
             
             CFRelease(allowedTrust);


### PR DESCRIPTION
By taking a look over the current SSL pinning feature, I figured than
- `Security.framework` doesn't define `noErr` but rather `errSecSuccess` as `OSStatus` and it's good practice to use the frameworks defined status codes in case they might eventually change in the future.
- `+[NSURLConnectionOperation pinnedPublicKeys]` was using `NSCParameterAssert` instead of `NSParameterAssert` which I think is wrong here because its an objc method implementation.
