### PR TITLE
Add support for COCOAPODS macro

### DIFF
--- a/AFNetworking/AFHTTPClient.h
+++ b/AFNetworking/AFHTTPClient.h
@@ -25,6 +25,14 @@
 
 #import <Availability.h>
 
+#ifndef HAS_SYSTEMCONFIGURATION_H
+#define HAS_SYSTEMCONFIGURATION_H _SYSTEMCONFIGURATION_H || COCOAPODS
+#endif
+
+#ifndef HAS_UTTYPE
+#define HAS_UTTYPE __UTTYPE__ || COCOAPODS
+#endif
+
 /**
  `AFHTTPClient` captures the common patterns of communicating with an web application over HTTP. It encapsulates information like base URL, authorization credentials, and HTTP headers, and uses them to construct and manage the execution of HTTP request operations.
 
@@ -73,7 +81,7 @@
  - NSCoding cannot serialize / deserialize block properties, so an archive of an HTTP client will not include any reachability callback block that may be set.
  */
 
-#ifdef _SYSTEMCONFIGURATION_H
+#ifdef HAS_SYSTEMCONFIGURATION_H
 typedef enum {
     AFNetworkReachabilityStatusUnknown          = -1,
     AFNetworkReachabilityStatusNotReachable     = 0,
@@ -84,7 +92,7 @@ typedef enum {
 #warning SystemConfiguration framework not found in project, or not included in precompiled header. Network reachability functionality will not be available.
 #endif
 
-#ifndef __UTTYPE__
+#ifndef HAS_UTTYPE
 #if __IPHONE_OS_VERSION_MIN_REQUIRED
 #warning MobileCoreServices framework not found in project, or not included in precompiled header. Automatic MIME type detection when uploading files in multipart requests will not be available.
 #else
@@ -134,7 +142,7 @@ typedef enum {
 
  @warning This property requires the `SystemConfiguration` framework. Add it in the active target's "Link Binary With Library" build phase, and add `#import <SystemConfiguration/SystemConfiguration.h>` to the header prefix of the project (`Prefix.pch`).
  */
-#ifdef _SYSTEMCONFIGURATION_H
+#ifdef HAS_SYSTEMCONFIGURATION_H
 @property (readonly, nonatomic, assign) AFNetworkReachabilityStatus networkReachabilityStatus;
 #endif
 
@@ -180,7 +188,7 @@ typedef enum {
 
  @warning This method requires the `SystemConfiguration` framework. Add it in the active target's "Link Binary With Library" build phase, and add `#import <SystemConfiguration/SystemConfiguration.h>` to the header prefix of the project (`Prefix.pch`).
  */
-#ifdef _SYSTEMCONFIGURATION_H
+#ifdef HAS_SYSTEMCONFIGURATION_H
 - (void)setReachabilityStatusChangeBlock:(void (^)(AFNetworkReachabilityStatus status))block;
 #endif
 
@@ -527,7 +535,7 @@ extern NSString * AFQueryStringFromParametersWithEncoding(NSDictionary *paramete
 
  @warning In order for network reachability to be monitored, include the `SystemConfiguration` framework in the active target's "Link Binary With Library" build phase, and add `#import <SystemConfiguration/SystemConfiguration.h>` to the header prefix of the project (`Prefix.pch`).
  */
-#ifdef _SYSTEMCONFIGURATION_H
+#ifdef HAS_SYSTEMCONFIGURATION_H
 extern NSString * const AFNetworkingReachabilityDidChangeNotification;
 extern NSString * const AFNetworkingReachabilityNotificationStatusItem;
 #endif

--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -27,7 +27,7 @@
 
 #import <Availability.h>
 
-#ifdef _SYSTEMCONFIGURATION_H
+#ifdef HAS_SYSTEMCONFIGURATION_H
 #import <netinet/in.h>
 #import <netinet6/in6.h>
 #import <arpa/inet.h>
@@ -39,7 +39,7 @@
 #import <UIKit/UIKit.h>
 #endif
 
-#ifdef _SYSTEMCONFIGURATION_H
+#ifdef HAS_SYSTEMCONFIGURATION_H
 NSString * const AFNetworkingReachabilityDidChangeNotification = @"com.alamofire.networking.reachability.change";
 NSString * const AFNetworkingReachabilityNotificationStatusItem = @"AFNetworkingReachabilityNotificationStatusItem";
 
@@ -187,13 +187,13 @@ NSArray * AFQueryStringPairsFromKeyAndValue(NSString *key, id value) {
 @property (readwrite, nonatomic, strong) NSMutableDictionary *defaultHeaders;
 @property (readwrite, nonatomic, strong) NSURLCredential *defaultCredential;
 @property (readwrite, nonatomic, strong) NSOperationQueue *operationQueue;
-#ifdef _SYSTEMCONFIGURATION_H
+#ifdef HAS_SYSTEMCONFIGURATION_H
 @property (readwrite, nonatomic, assign) AFNetworkReachabilityRef networkReachability;
 @property (readwrite, nonatomic, assign) AFNetworkReachabilityStatus networkReachabilityStatus;
 @property (readwrite, nonatomic, copy) AFNetworkReachabilityStatusBlock networkReachabilityStatusBlock;
 #endif
 
-#ifdef _SYSTEMCONFIGURATION_H
+#ifdef HAS_SYSTEMCONFIGURATION_H
 - (void)startMonitoringNetworkReachability;
 - (void)stopMonitoringNetworkReachability;
 #endif
@@ -207,7 +207,7 @@ NSArray * AFQueryStringPairsFromKeyAndValue(NSString *key, id value) {
 @synthesize defaultHeaders = _defaultHeaders;
 @synthesize defaultCredential = _defaultCredential;
 @synthesize operationQueue = _operationQueue;
-#ifdef _SYSTEMCONFIGURATION_H
+#ifdef HAS_SYSTEMCONFIGURATION_H
 @synthesize networkReachability = _networkReachability;
 @synthesize networkReachabilityStatus = _networkReachabilityStatus;
 @synthesize networkReachabilityStatusBlock = _networkReachabilityStatusBlock;
@@ -255,7 +255,7 @@ NSArray * AFQueryStringPairsFromKeyAndValue(NSString *key, id value) {
     [self setDefaultHeader:@"User-Agent" value:[NSString stringWithFormat:@"%@/%@ (Mac OS X %@)", [[[NSBundle mainBundle] infoDictionary] objectForKey:(NSString *)kCFBundleExecutableKey] ?: [[[NSBundle mainBundle] infoDictionary] objectForKey:(NSString *)kCFBundleIdentifierKey], [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"] ?: [[[NSBundle mainBundle] infoDictionary] objectForKey:(NSString *)kCFBundleVersionKey], [[NSProcessInfo processInfo] operatingSystemVersionString]]];
 #endif
 
-#ifdef _SYSTEMCONFIGURATION_H
+#ifdef HAS_SYSTEMCONFIGURATION_H
     self.networkReachabilityStatus = AFNetworkReachabilityStatusUnknown;
     [self startMonitoringNetworkReachability];
 #endif
@@ -267,7 +267,7 @@ NSArray * AFQueryStringPairsFromKeyAndValue(NSString *key, id value) {
 }
 
 - (void)dealloc {
-#ifdef _SYSTEMCONFIGURATION_H
+#ifdef HAS_SYSTEMCONFIGURATION_H
     [self stopMonitoringNetworkReachability];
 #endif
 }
@@ -278,7 +278,7 @@ NSArray * AFQueryStringPairsFromKeyAndValue(NSString *key, id value) {
 
 #pragma mark -
 
-#ifdef _SYSTEMCONFIGURATION_H
+#ifdef HAS_SYSTEMCONFIGURATION_H
 static BOOL AFURLHostIsIPAddress(NSURL *url) {
     struct sockaddr_in sa_in;
     struct sockaddr_in6 sa_in6;
@@ -711,7 +711,7 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {
     HTTPClient.parameterEncoding = self.parameterEncoding;
     HTTPClient.registeredHTTPOperationClassNames = [self.registeredHTTPOperationClassNames copyWithZone:zone];
     HTTPClient.defaultHeaders = [self.defaultHeaders copyWithZone:zone];
-#ifdef _SYSTEMCONFIGURATION_H
+#ifdef HAS_SYSTEMCONFIGURATION_H
     HTTPClient.networkReachabilityStatusBlock = self.networkReachabilityStatusBlock;
 #endif
     return HTTPClient;
@@ -740,7 +740,7 @@ static inline NSString * AFMultipartFormFinalBoundary() {
 }
 
 static inline NSString * AFContentTypeForPathExtension(NSString *extension) {
-#ifdef __UTTYPE__
+#ifdef HAS_UTTYPE
     NSString *UTI = (__bridge_transfer NSString *)UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, (__bridge CFStringRef)extension, NULL);
     NSString *contentType = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)UTI, kUTTagClassMIMEType);
     if (!contentType) {


### PR DESCRIPTION
This pull request relies on a committed but not yet released feature of CocoaPods described in CocoaPods/CocoaPods#903.

I'm opening the pull because I'm looking for feedback. It is designed to suppress the warnings related to the conditional compilation of the System Configure / Core Services logic as discussed in #614.

/c @blakewatters 
