### PR TITLE
Proposal for some `UIImageView (AFNetworking)` changes

### DIFF
--- a/AFNetworking/UIImageView+AFNetworking.m
+++ b/AFNetworking/UIImageView+AFNetworking.m
@@ -110,13 +110,23 @@ static char kAFImageRequestOperationObjectKey;
     UIImage *cachedImage = [[[self class] af_sharedImageCache] cachedImageForRequest:urlRequest];
     self.image = cachedImage ?: placeholderImage;
     
+    if (cachedImage) {
+        if (success) {
+            success(nil, nil, cachedImage);
+        } else {
+            self.image = cachedImage;
+        }
+    }
+    
     AFImageRequestOperation *requestOperation = [[AFImageRequestOperation alloc] initWithRequest:urlRequest];
     [requestOperation setCompletionBlockWithSuccess:^(AFHTTPRequestOperation *operation, id responseObject) {
         if ([urlRequest isEqual:[self.af_imageRequestOperation request]]) {
-            self.image = responseObject;
-            
-            if (success) {
-                success(operation.request, operation.response, responseObject);
+            if (![responseObject isEqual:cachedImage]) {
+                if (success) {
+                    success(operation.request, operation.response, responseObject);
+                } else {
+                    self.image = responseObject;
+                }
             }
             
             if (self.af_imageRequestOperation == operation) {


### PR DESCRIPTION
Here I some changes I would like to propose to `UIImageView (AFNetworking)` which I think are reasonable:
- `-[UIImage setImageWithURL:placeholderImage:]` now tries to find a previous cached `NSHTTPURLResponse` and sends the value of the HTTP `Last-Modified` Header in the `If-Modified-Since` HTTP Header of the new request. The NSURL loading system doesn't do this on its own and that way, we allow the server to respond with a plain and lightweight `304` response code. The NSURL loading system will then automatically pick up the cached response on its own. Almost no network traffic is being generated in that case.
- `-[AFImageCache cachedImageForRequest:]` now tries to find a cached image in the shared `NSURLCache`.
- I changed the behavior of `-[UIImageView setImageWithURLRequest:placeholderImage:success:failure:]` in the following way:
  - By sending this message to an `UIImageView`, the developer basically tell the image view to set the corresponding image as soon as the data is available. **The default behavior, for me, would therefore be to set the image even if the user passes in a success block.** Having to manage weak and strong reference for the image view is a pain in the neck if you want to set the image in the success callback.
  - By adopting this new behavior (`setting the image as soon as it is available`) and the improved image caching by utilizing 
    `NSURLCache` calling `-[UIImageView setImageWithURLRequest:placeholderImage:success:failure:]` will now try to first set the cached image from the memory cache. If it isn't found, it tries to find the cached image on disk thanks to `NSURLCache`. If that image is still not available, the placeholder image is being used.
    - `-[UIImageView setImageWithURLRequest:placeholderImage:success:failure:]` now always sends a request to the server. I think this is justified because we are sending the `If-Modified-Since` header. If the web server is smart enough to send back a `304` almost no traffic is being generated. The previous implementation had a small down site: If an image changed on the server side during the applications lifetime, the change would only be picked up if the `AFImageCache` has been evicted. This might get pretty frustrating for the actual user of the application if he expects an image to change but it doesn't.
