### PR TITLE
Update to prevent crash

### DIFF
--- a/AFNetworking/AFJSONRequestOperation.m
+++ b/AFNetworking/AFJSONRequestOperation.m
@@ -76,7 +76,12 @@ static dispatch_queue_t json_request_operation_processing_queue() {
             // Workaround for a bug in NSJSONSerialization when Unicode character escape codes are used instead of the actual character
             // See http://stackoverflow.com/a/12843465/157142
             NSData *JSONData = [self.responseString dataUsingEncoding:NSUTF8StringEncoding];
-            self.responseJSON = [NSJSONSerialization JSONObjectWithData:JSONData options:self.JSONReadingOptions error:&error];
+            
+            // Check if JSONData actually exists so that a nil is not passed into [NSJSONSerialization JSONObjectWithData:options:error:]
+            // If JSONData is nil it may be due to a networking error that was already setup to be handled/reported.
+            if ( JSONData ) {
+	        self.responseJSON = [NSJSONSerialization JSONObjectWithData:JSONData options:self.JSONReadingOptions error:&error];
+            }
         }
 
         self.JSONError = error;


### PR DESCRIPTION
Check if JSONData actually exists so that a nil is not passed into [NSJSONSerialization JSONObjectWithData:options:error:]

If JSONData is nil it may be due to a networking error that was already setup to be handled/reported.
