### PR TITLE
fix for unescaped brackets in params values

### DIFF
--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -80,11 +80,13 @@ static NSString * AFBase64EncodedStringFromString(NSString *string) {
     return [[NSString alloc] initWithData:mutableData encoding:NSASCIIStringEncoding];
 }
 
-static NSString * AFPercentEscapedQueryStringPairMemberFromStringWithEncoding(NSString *string, NSStringEncoding encoding) {
+static NSString * AFPercentEscapedQueryStringPairMemberFromStringWithEncoding(NSString *string, NSStringEncoding encoding, BOOL isValue) {
     static NSString * const kAFCharactersToBeEscaped = @":/?&=;+!@#$()~',*";
-    static NSString * const kAFCharactersToLeaveUnescaped = @"[].";
-
-	return (__bridge_transfer  NSString *)CFURLCreateStringByAddingPercentEscapes(kCFAllocatorDefault, (__bridge CFStringRef)string, (__bridge CFStringRef)kAFCharactersToLeaveUnescaped, (__bridge CFStringRef)kAFCharactersToBeEscaped, CFStringConvertNSStringEncodingToEncoding(encoding));
+    static NSString * const kAFParamNameCharactersToLeaveUnescaped = @"[].";
+    static NSString * const kAFParamValueCharactersToLeaveUnescaped = @"";
+	
+	NSString *unescaped = isValue ? kAFParamValueCharactersToLeaveUnescaped : kAFParamNameCharactersToLeaveUnescaped;
+	return (__bridge_transfer  NSString *)CFURLCreateStringByAddingPercentEscapes(kCFAllocatorDefault, (__bridge CFStringRef)string, (__bridge CFStringRef)unescaped, (__bridge CFStringRef)kAFCharactersToBeEscaped, CFStringConvertNSStringEncodingToEncoding(encoding));
 }
 
 #pragma mark -
@@ -116,9 +118,9 @@ static NSString * AFPercentEscapedQueryStringPairMemberFromStringWithEncoding(NS
 
 - (NSString *)URLEncodedStringValueWithEncoding:(NSStringEncoding)stringEncoding {
     if (!self.value || [self.value isEqual:[NSNull null]]) {
-        return AFPercentEscapedQueryStringPairMemberFromStringWithEncoding([self.field description], stringEncoding);
+        return AFPercentEscapedQueryStringPairMemberFromStringWithEncoding([self.field description], stringEncoding, NO);
     } else {
-        return [NSString stringWithFormat:@"%@=%@", AFPercentEscapedQueryStringPairMemberFromStringWithEncoding([self.field description], stringEncoding), AFPercentEscapedQueryStringPairMemberFromStringWithEncoding([self.value description], stringEncoding)];
+        return [NSString stringWithFormat:@"%@=%@", AFPercentEscapedQueryStringPairMemberFromStringWithEncoding([self.field description], stringEncoding, NO), AFPercentEscapedQueryStringPairMemberFromStringWithEncoding([self.value description], stringEncoding, YES)];
     }
 }
 


### PR DESCRIPTION
Hey,

The default HTTP escaping code on the AFHTTPClient is explicitly skipping square brackets on the query string from being escaped.
I'm assuming this is to support rails' "arrays in HTTP params" feature, but is nonetheless a violation of RFC 3986 that can cause some HTTP servers to improperly parse the query string (namely our IIS servers don't seem too happy with these queries).

So far, this patch only addresses the issue in params values, mainly for backward compatibility with aforementioned rails convention.
However, reading RFC 3986 in more details, it seems that square brackets are never allowed as part of a query string, and as such should always be escaped. Cf http://www.ietf.org/rfc/rfc3986.txt that claims:

> A host identified by an Internet Protocol literal address, version 6 [RFC3513] or later, is distinguished by enclosing the IP literal within square brackets ("[" and "]").  This is the only place where square bracket characters are allowed in the URI syntax.

I'd be more than happy to patch AFNetworking to be compliant with that part, but making the patch would require a bit more work (probably moving away from C functions for URL encoding), and I'd like to be sure this behavior would be fine with upstream before starting any work on it.
As it is, this patch shouldn't break anything, just fix improperly escaped query values.
