### PR TITLE
Adding If-Modified-Since HTTP Header when available.

### DIFF
--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -520,7 +520,7 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {
         NSCachedURLResponse *cachedURLResponse = [[NSURLCache sharedURLCache] cachedResponseForRequest:urlRequest];
         NSHTTPURLResponse *response = (NSHTTPURLResponse *)cachedURLResponse.response;
         
-        NSString *lastModifiedString = response.allHeaderFields[@"last-modified"];
+        NSString *lastModifiedString = [response.allHeaderFields objectForKey:@"last-modified"];
         if (lastModifiedString) {
             NSMutableURLRequest *mutableURLRequest = urlRequest.copy;
             [mutableURLRequest setValue:lastModifiedString forHTTPHeaderField:@"If-Modified-Since"];


### PR DESCRIPTION
I changed `-[AFHTTPClient HTTPRequestOperationWithRequest:success:failure:]` to include an `If-Modified-Since` HTTP header value in the `urlRequest` in case a cached response contains a `Last-Modified` HTTP header value as described in [14.25 If-Modified-Since](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html) or [here](http://nshipster.com/nsurlcache/).
