### PR TITLE
Suppress compiler warnings for unused variable when building without assertions

### DIFF
--- a/AFNetworking/AFURLConnectionOperation.m
+++ b/AFNetworking/AFURLConnectionOperation.m
@@ -616,7 +616,10 @@ willSendRequestForAuthenticationChallenge:(NSURLAuthenticationChallenge *)challe
                     [[challenge sender] useCredential:credential forAuthenticationChallenge:challenge];
                 } else {
                     SecTrustResultType result = 0;
-                    OSStatus status = SecTrustEvaluate(serverTrust, &result);
+
+                    // Add __unused__ attribute to suppress the warning when building with NS_BLOCK_ASSERTIONS=1
+                    OSStatus __attribute__((__unused__)) status = SecTrustEvaluate(serverTrust, &result);
+
                     NSAssert(status == errSecSuccess, @"SecTrustEvaluate error: %ld", (long int)status);
                     
                     if (result == kSecTrustResultUnspecified || result == kSecTrustResultProceed) {


### PR DESCRIPTION
When building with NS_BLOCK_ASSERTIONS=1, the NSAssert() evaluated to void, causing the status variable to get marked as unused. I added the unused attribute to variable declaration to avoid this warning.
