### PR TITLE
Add __unused to stream delegate parameter

### DIFF
--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -1061,7 +1061,7 @@ static const NSUInteger AFMultipartBodyStreamProviderDefaultBufferLength = 4096;
 
 #pragma mark - NSStreamDelegate
 
-- (void)stream:(NSStream *)stream
+- (void)stream:(NSStream __unused *)stream
    handleEvent:(NSStreamEvent)eventCode
 {
     if (eventCode & NSStreamEventHasSpaceAvailable) {


### PR DESCRIPTION
Without this attribute, warning is generated with -Wextra.
