### PR TITLE
Using self.error instead of self.JSONError in AFJSONRequestOperation.

### DIFF
--- a/AFNetworking/AFJSONRequestOperation.m
+++ b/AFNetworking/AFJSONRequestOperation.m
@@ -120,7 +120,7 @@ static dispatch_queue_t json_request_operation_processing_queue() {
             dispatch_async(json_request_operation_processing_queue(), ^{
                 id JSON = self.responseJSON;
 
-                if (self.JSONError) {
+                if (self.error) {
                     if (failure) {
                         dispatch_async(self.failureCallbackQueue ?: dispatch_get_main_queue(), ^{
                             failure(self, self.error);


### PR DESCRIPTION
I recently encountered an API returning `null` as a json object. Since `null` is not a valid JSON object, `-[AFJSONRequestOperation responseJSON]` will generate a `JSONError`. Since a `null` response should have resulted in a success callback for my special case, I looked for an easy way to suppress this error. So I swizzled `-[AFJSONRequestOperation error]` and discarded the error.

Since `-[AFJSONRequestOperation setCompletionBlockWithSuccess:failure:]` was using `self.JSONError` in one place, I would need to swizzle a private selector for this method to work which I don't feel comfortable with. Since `self.error` is already being passed into the failure handler and `self.error` picks up the `JSONError`, no harm is done by changing `self.JSONError` to `self.error`.
