### PR TITLE
Register error if new bodyStream cannot be created

### DIFF
--- a/AFNetworking/AFURLConnectionOperation.m
+++ b/AFNetworking/AFURLConnectionOperation.m
@@ -703,7 +703,15 @@ didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge
     if ([request.HTTPBodyStream conformsToProtocol:@protocol(NSCopying)]) {
         return [request.HTTPBodyStream copy];
     }
-    
+
+    self.error = [NSError errorWithDomain:AFNetworkingErrorDomain code:NSURLErrorCancelled userInfo:nil];
+
+    [self.outputStream close];
+
+    [self finish];
+
+    self.connection = nil;
+
     return nil;
 }
 


### PR DESCRIPTION
It looks like #819 broke #718 because the input stream created no longer implements NSCopying. This patch doesn't fix that, but it does cause the connection to close gracefully when needNewBodyStream returns nil.

According to the [NSURLConnectionDelegate docs](http://developer.apple.com/library/mac/#documentation/Foundation/Reference/NSURLConnectionDelegate_Protocol/Reference/Reference.html#//apple_ref/occ/intf/NSURLConnectionDelegate), returning nil from `needNewBodyStream` causes the connection to fail, but this does not trigger any of AFNetworking's error handling or callbacks. So this patch adds those back in.

I used `NSURLErrorCancelled` for the error, but maybe there's a more appropriate code?
