### PR TITLE
Changes to provide controlled access to UIImage+AFNetworking's cache

### DIFF
--- a/AFNetworking/UIImageView+AFNetworking.h
+++ b/AFNetworking/UIImageView+AFNetworking.h
@@ -88,10 +88,16 @@ typedef AFNetworkingShouldAcceptImage (^AFNetworkingShouldAcceptImageBlock)(NSDa
  @discussion The block should return `AFNetworkingShouldAcceptImageYES` to both accept and cache the image (pending the usual cache policy test), `AFNetworkingShouldAcceptImageNO` to neither accept nor cache the image (your error handler will be called instead of your success handler and no image substitution will be performed), or `AFNetworkingShouldAcceptImageYESButDoNotCache` to return the image but never cache it, irrespective of the caching policy. The error object may be set for passing to your error handler in the case of `AFNetworkingShouldAcceptImageNO`. Note that this block may be called multiple times per image (this is because the test is run for the NSURLConnection cache and also for the internal AFImage cache).
  
  @param validationBlock The block that is executed to determine whether to cache
- 
  */
 + (void)setAFNetworkingShouldAcceptImageBlock:(AFNetworkingShouldAcceptImageBlock)validationBlock;
 
+/**
+ Clear the image from the cache (if any) for the given URL request
+ 
+ @param request The NSURLRequest who's cache should be cleared
+ */
+
++ (void)clearAFNetworkingImageCacheForRequest:(NSURLRequest *)request;
 
 @end
 

--- a/AFNetworking/UIImageView+AFNetworking.m
+++ b/AFNetworking/UIImageView+AFNetworking.m
@@ -57,6 +57,11 @@ static char kAFImageRequestOperationObjectKey;
     [self af_sharedImageCache].validationBlock = validationBlock;
 }
 
++ (void)clearAFNetworkingImageCacheForRequest:(NSURLRequest *)request
+{
+    [[self af_sharedImageCache] cacheImage:nil forRequest:request];
+}
+
 - (AFHTTPRequestOperation *)af_imageRequestOperation {
     return (AFHTTPRequestOperation *)objc_getAssociatedObject(self, &kAFImageRequestOperationObjectKey);
 }
@@ -215,6 +220,8 @@ static inline NSString * AFImageCacheKeyFromURLRequest(NSURLRequest *request) {
 {
     if (image && request) {
         [self setObject:image forKey:AFImageCacheKeyFromURLRequest(request)];
+    } else if (request) {
+        [self removeObjectForKey:AFImageCacheKeyFromURLRequest(request)];
     }
 }
 


### PR DESCRIPTION
While I agree with hiding the cache implementation in general, there are some circumstances where exposing minimal access is required:
1. A way to clear cache entries when they are known to be stale;
2. A way to triage which images are stored in the cache.

An example of (1) is after uploading a new user profile image which is delivered by a fixed endpoint. For this change I opted for a simple clearing of the cache (unlike NSURLCache where you can clear individual entries with `storeCachedResponse:forRequest:`).

Two example of (2) are:

a. restricting the size of images you want to cache;
b. preventing partial/corrupted images from being placed in the cache.

For me, (b) was the driver of the change since the lovely AT&T network was truncating some downloads and NSURLConnection was treating it as a successful download. Here is how I use the api added in this change to prevent that in my case:

``` objective-c
    [UIImageView setAFNetworkingShouldAcceptImageBlock:^AFNetworkingShouldAcceptImage(NSData *originalData, NSURLRequest *originalRequest, NSError *__autoreleasing *error) {
        if ([[originalRequest.URL pathExtension] isEqualToString:@"jpg"])
            return dataIsValidJPEG(originalData) ? AFNetworkingShouldAcceptImageYES : AFNetworkingShouldAcceptImageNO;

        return AFNetworkingShouldAcceptImageYES;
    }];
```

I have included both changes in a single pull request since they are both related to exposing a limited API for the private cache.
