### PR TITLE
Handle UIApplicationDidReceiveMemoryWarningNotification in AFImageCache

### DIFF
--- a/AFNetworking/UIImageView+AFNetworking.m
+++ b/AFNetworking/UIImageView+AFNetworking.m
@@ -159,6 +159,23 @@ static inline NSString * AFImageCacheKeyFromURLRequest(NSURLRequest *request) {
 
 @implementation AFImageCache
 
+- (id)init
+{
+    self = [super init];
+    if (self) {
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(didReceiveMemoryWarning)
+                                                     name:UIApplicationDidReceiveMemoryWarningNotification
+                                                   object:nil];
+    }
+    return self;
+}
+
+- (void)didReceiveMemoryWarning
+{
+    [self removeAllObjects];
+}
+
 - (UIImage *)cachedImageForRequest:(NSURLRequest *)request {
     switch ([request cachePolicy]) {
         case NSURLRequestReloadIgnoringCacheData:


### PR DESCRIPTION
I've modified `UIImage+AFNetworking.m` so that `AFImageCache` it now has `init` method that adds itself as an observer for `UIApplicationDidReceiveMemoryWarningNotification`, and if it receives such a low memory warning, it will purge the cache.
