### PR TITLE
Fixed problem sending nested arrays in formData with mime attachments

### DIFF
--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -158,7 +158,8 @@ NSArray * AFQueryStringPairsFromKeyAndValue(NSString *key, id value) {
     } else if ([value isKindOfClass:[NSArray class]]) {
         NSArray *array = value;
         for (id nestedValue in array) {
-            [mutableQueryStringComponents addObjectsFromArray:AFQueryStringPairsFromKeyAndValue([NSString stringWithFormat:@"%@[]", key], nestedValue)];
+            int index = [array indexOfObject:nestedValue];
+            [mutableQueryStringComponents addObjectsFromArray:AFQueryStringPairsFromKeyAndValue([NSString stringWithFormat:@"%@[%i]", key, index], nestedValue)];
         }
     } else if ([value isKindOfClass:[NSSet class]]) {
         NSSet *set = value;


### PR DESCRIPTION
I've had problems sending a request with 

```
    multipartFormRequestWithMethod:(NSString *)method
                              path:(NSString *)path
                        parameters:(NSDictionary *)parameters
         constructingBodyWithBlock:(void (^)(id <AFMultipartFormData> formData))block
```

I have a server that expected to receive a post param this way:

```
comment_attributes[0][some_other_key] 
```

and was sending:

```
comment_attributes[][some_other_key].
```

Now it works for me but please let me know if I have to change something in another file and I'll do it.
