### PR TITLE
Added the ability to specify the key to be used when caching images

### DIFF
--- a/AFNetworking/UIImageView+AFNetworking.h
+++ b/AFNetworking/UIImageView+AFNetworking.h
@@ -43,6 +43,12 @@
 - (void)setImageWithURL:(NSURL *)url;
 
 /**
+  @param cacheKey allows you to specify the key to be used by AFImageCache. If `nil`, AFImageCache uses the url as the key.
+ */
+- (void)setImageWithURL:(NSURL *)url
+               cacheKey:(NSString *)key;
+
+/**
  Creates and enqueues an image request operation, which asynchronously downloads the image from the specified URL. Any previous image request for the receiver will be cancelled. If the image is cached locally, the image is set immediately, otherwise the specified placeholder image will be set immediately, and then the remote image will be set once the request is finished.
 
  By default, URL requests have a cache policy of `NSURLCacheStorageAllowed` and a timeout interval of 30 seconds, and are set not handle cookies. To configure URL requests differently, use `setImageWithURLRequest:placeholderImage:success:failure:`
@@ -52,6 +58,13 @@
  */
 - (void)setImageWithURL:(NSURL *)url
        placeholderImage:(UIImage *)placeholderImage;
+
+/**
+  @param cacheKey allows you to specify the key to be used by AFImageCache. If `nil`, AFImageCache uses the url as the key.
+ */
+- (void)setImageWithURL:(NSURL *)url
+       placeholderImage:(UIImage *)placeholderImage
+               cacheKey:(NSString *)key;
 
 /**
  Creates and enqueues an image request operation, which asynchronously downloads the image with the specified URL request object. Any previous image request for the receiver will be cancelled. If the image is cached locally, the image is set immediately, otherwise the specified placeholder image will be set immediately, and then the remote image will be set once the request is finished.
@@ -67,6 +80,15 @@
               placeholderImage:(UIImage *)placeholderImage
                        success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, UIImage *image))success
                        failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error))failure;
+
+/**
+  @param cacheKey allows you to specify the key to be used by AFImageCache. If `nil`, AFImageCache uses the url as the key.
+ */
+- (void)setImageWithURLRequest:(NSURLRequest *)urlRequest
+              placeholderImage:(UIImage *)placeholderImage
+                      cacheKey:(NSString *)key
+                       success:(void (^)(NSURLRequest *, NSHTTPURLResponse *, UIImage *))success
+                       failure:(void (^)(NSURLRequest *, NSHTTPURLResponse *, NSError *))failure;
 
 /**
  Cancels any executing image request operation for the receiver, if one exists.


### PR DESCRIPTION
I've added the ability to specify the key that AFImageCache should use. I did this because while my base URL doesn't change, the parameters on the end of my URL do; even though the image itself doesn't change. Because AFImageCache uses url.absoluteString as a key, I end up with several versions of the same image all stored under a slightly different key.

The ability to specify an AFImageCache key also gives objects the flexibility to cache images using their unique id, or some other unique key based on the objects specific needs.
