### PR TITLE
[AFHTTPClient init] should raise an exception

### DIFF
--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -221,6 +221,12 @@ NSArray * AFQueryStringPairsFromKeyAndValue(NSString *key, id value) {
     return [[self alloc] initWithBaseURL:url];
 }
 
+- (instancetype)init {
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                   reason:[NSString stringWithFormat:@"%@ Failed to call designated initializer. Invoke `initWithBaseURL:` instead.", NSStringFromClass([self class])]
+                                 userInfo:nil];
+}
+
 - (id)initWithBaseURL:(NSURL *)url {
     NSParameterAssert(url);
 

--- a/Tests/AFHTTPClientTests.m
+++ b/Tests/AFHTTPClientTests.m
@@ -35,6 +35,10 @@
 
 #pragma mark -
 
+- (void)testInitRaisesException {
+    expect(^{ (void)[[AFHTTPClient alloc] init]; }).to.raiseAny();
+}
+
 - (void)testDefaultHeaders {
     [self.client setDefaultHeader:@"x-some-key" value:@"SomeValue"];
     expect([self.client defaultValueForHeader:@"x-some-key"]).to.equal(@"SomeValue");


### PR DESCRIPTION
As discussed on #971, this will prevent anyone from accidentally calling init
which results in undefined behaviour.

http://developer.apple.com/library/ios/#documentation/general/conceptual/devpedia-cocoacore/MultipleInitializers.html
