### PR TITLE
Using __unsafe_unretained for getting invocation arguments.

### DIFF
--- a/Tests/AFHTTPClientTests.m
+++ b/Tests/AFHTTPClientTests.m
@@ -271,7 +271,10 @@
     __block NSArray *operations = nil;
     id mockClient = [OCMockObject partialMockForObject:self.client];
     void (^theBlock)(NSInvocation *) = ^(NSInvocation *invocation) {
-        [invocation getArgument:&operations atIndex:2];
+        __unsafe_unretained id argument = nil;
+        [invocation getArgument:&argument atIndex:2];
+        
+        operations = argument;
     };
     [[[mockClient stub] andDo:theBlock] enqueueBatchOfHTTPRequestOperations:[OCMArg any] progressBlock:nil completionBlock:nil];
     [mockClient enqueueBatchOfHTTPRequestOperationsWithRequests:@[ firstRequest, secondRequest ] progressBlock:nil completionBlock:nil];
@@ -294,12 +297,18 @@
     
     __block NSArray *operations = nil;
     [[[mockOperationQueue stub] andDo:^(NSInvocation *invocation) {
-        [invocation getArgument:&operations atIndex:2];
+        __unsafe_unretained id argument = nil;
+        [invocation getArgument:&argument atIndex:2];
+        
+        operations = argument;
     }] addOperations:OCMOCK_ANY waitUntilFinished:NO];
     
     __block NSBlockOperation *batchedOperation = nil;
     [[[mockOperationQueue stub] andDo:^(NSInvocation *invocation) {
-        [invocation getArgument:&batchedOperation atIndex:2];
+        __unsafe_unretained id argument = nil;
+        [invocation getArgument:&argument atIndex:2];
+        
+        batchedOperation = argument;
     }] addOperation:OCMOCK_ANY];
     [mockClient enqueueBatchOfHTTPRequestOperations:@[ firstOperation, secondOperation ] progressBlock:NULL completionBlock:NULL];
     

--- a/Tests/Podfile.lock
+++ b/Tests/Podfile.lock
@@ -17,7 +17,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   AFHTTPRequestOperationLogger: 34ba125cb9eeb77a3b67aaaca105720ba3a0798c
-  AFNetworking: 02a1b682b3c3fa39afd22e725ab8f4a65cb157b6
+  AFNetworking: d1ba5908b233189e424e101721acef7905b58efb
   Expecta: d46fb1bd78c90a83da0158b9b1e108de106e369f
   OCMock: 79212e5e328378af5cfd6edb5feacfd6c49cd8a3
 


### PR DESCRIPTION
I'm not a 100% sure on this one. Since one of the tests failed for osx, I took a look and found that we were using -[NSInvocation getArgument:atIndex:] with a **strong** argument pointer. We are under arc and what I have experienced so far is that id pointers are by default autoreleased. Since NSInvocation is expecting a void \* for the argument, I would bet that this introduces some memory corruption which causes the test to fail. Anyway, I'm storing the argument in an __unsafe_unretained variable now and assigning it later to the strong variable which seems to fix the issue. Does anyone have more knowledge regarding this, probably @0xced?
