### PR TITLE
Raise error if unable to decode response string

### DIFF
--- a/AFNetworking/AFJSONRequestOperation.m
+++ b/AFNetworking/AFJSONRequestOperation.m
@@ -76,7 +76,15 @@ static dispatch_queue_t json_request_operation_processing_queue() {
             // Workaround for a bug in NSJSONSerialization when Unicode character escape codes are used instead of the actual character
             // See http://stackoverflow.com/a/12843465/157142
             NSData *JSONData = [self.responseString dataUsingEncoding:NSUTF8StringEncoding];
-            self.responseJSON = [NSJSONSerialization JSONObjectWithData:JSONData options:self.JSONReadingOptions error:&error];
+
+            if (JSONData) {
+                self.responseJSON = [NSJSONSerialization JSONObjectWithData:JSONData options:self.JSONReadingOptions error:&error];
+            } else {
+                //Could not decode response string
+                error = [[NSError alloc]initWithDomain:AFNetworkingErrorDomain
+                                                  code:NSURLErrorCannotDecodeContentData
+                                              userInfo:@{NSLocalizedDescriptionKey : [NSString stringWithFormat:@"Could not decode:\n%@",self.responseString]}];
+            }
         }
 
         self.JSONError = error;


### PR DESCRIPTION
https://github.com/AFNetworking/AFNetworking/pull/876 fixes a character encoding crash by hard-coding the encoding to `NSUTF8StringEncoding`, but assumes `dataUsingEncoding:` will succeed. This patch checks for a non-nil return value to prevent the crash in `JSONObjectWithData:options:error:`. If the `NSData` is nil, it sets `self.JSONError` to an error including the response string.
