### PR TITLE
SSL pinning with custom Root CA

### DIFF
--- a/AFNetworking/AFURLConnectionOperation.h
+++ b/AFNetworking/AFURLConnectionOperation.h
@@ -89,6 +89,7 @@ typedef enum {
     AFSSLPinningModeNone,
     AFSSLPinningModePublicKey,
     AFSSLPinningModeCertificate,
+    AFSSLPinningModeRootCA,
 } AFURLConnectionOperationSSLPinningMode;
 #endif
 


### PR DESCRIPTION
solution for using certificates, signed with custom root CA.
based on example from https://github.com/dirkx/Security-Pinning-by-CA
