### PR TITLE
Add attribute unavailable to the `init` and `new` headers of AFHTTPClient.

### DIFF
--- a/AFNetworking/AFHTTPClient.h
+++ b/AFNetworking/AFHTTPClient.h
@@ -176,6 +176,16 @@ typedef enum {
  */
 - (id)initWithBaseURL:(NSURL *)url;
 
+/**
+ Disabled. Invoke the designated initializer `initWithBaseURL:` instead.
+ */
+-(id) init __attribute__((unavailable("Invoke the designated initializer `initWithBaseURL:` instead.")));
+
+/**
+ Disabled. Invoke the designated initializer `initWithBaseURL:` instead.
+ */
++(id) new __attribute__((unavailable("Invoke the designated initializer `initWithBaseURL:` instead.")));
+
 ///-----------------------------------
 /// @name Managing Reachability Status
 ///-----------------------------------

--- a/Tests/AFHTTPClientTests.m
+++ b/Tests/AFHTTPClientTests.m
@@ -35,8 +35,8 @@
 
 #pragma mark -
 
-- (void)testInitRaisesException {
-    expect(^{ (void)[[AFHTTPClient alloc] init]; }).to.raiseAny();
+- (void)testNewRaisesException {
+    expect(^{ (void)[AFHTTPClient performSelector:(@selector(new))]; }).to.raiseAny();
 }
 
 - (void)testDefaultHeaders {


### PR DESCRIPTION
I didn't remove the `init` implementation with @throws in case anyone is calling it in a non conventional way.
