### PR TITLE
AFN failed to get some specific pages

### DIFF
--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -251,6 +251,12 @@ NSArray * AFQueryStringPairsFromKeyAndValue(NSString *key, id value) {
     NSMutableArray *acceptLanguagesComponents = [NSMutableArray array];
     [[NSLocale preferredLanguages] enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
         float q = 1.0f - (idx * 0.1f);
+        
+        if ([(NSString*)obj compare:@"zh-Hant"] == NSOrderedSame)
+            obj = @"zh-TW";
+        else if ([(NSString*)obj compare:@"zh-Hans"] == NSOrderedSame)
+            obj = @"zh-CN";
+    
         [acceptLanguagesComponents addObject:[NSString stringWithFormat:@"%@;q=%0.1g", obj, q]];
         *stop = q <= 0.5f;
     }];


### PR DESCRIPTION
Fix the issue that AFN failed to get the page at http://rate.bot.com.tw/Pages/UIP005/Download.ashx?lang=en&fileType=1&whom=GB0030001000&date1=20130101&date2=20130505&afterOrNot=0&curcd=TWD if the system language setting is in traditional chinese or simplified chinese.
