### PR TITLE
Remove AFNetworking source references from test project, cocoapods is used

### DIFF
--- a/Tests/AFNetworking Tests.xcodeproj/project.pbxproj
+++ b/Tests/AFNetworking Tests.xcodeproj/project.pbxproj
@@ -64,25 +64,6 @@
 		25C4EC2E173D7DC40083E116 /* CFNetwork.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CFNetwork.framework; path = System/Library/Frameworks/CFNetwork.framework; sourceTree = SDKROOT; };
 		25C4EC30173D7DCA0083E116 /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = System/Library/Frameworks/MobileCoreServices.framework; sourceTree = SDKROOT; };
 		25C4EC32173D7DD20083E116 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
-		25DE5FFB173EB13C00422571 /* AFHTTPClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFHTTPClient.h; sourceTree = "<group>"; };
-		25DE5FFC173EB13C00422571 /* AFHTTPClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFHTTPClient.m; sourceTree = "<group>"; };
-		25DE5FFD173EB13C00422571 /* AFHTTPRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFHTTPRequestOperation.h; sourceTree = "<group>"; };
-		25DE5FFE173EB13C00422571 /* AFHTTPRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFHTTPRequestOperation.m; sourceTree = "<group>"; };
-		25DE5FFF173EB13C00422571 /* AFImageRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFImageRequestOperation.h; sourceTree = "<group>"; };
-		25DE6000173EB13C00422571 /* AFImageRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFImageRequestOperation.m; sourceTree = "<group>"; };
-		25DE6001173EB13C00422571 /* AFJSONRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFJSONRequestOperation.h; sourceTree = "<group>"; };
-		25DE6002173EB13C00422571 /* AFJSONRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFJSONRequestOperation.m; sourceTree = "<group>"; };
-		25DE6003173EB13C00422571 /* AFNetworkActivityIndicatorManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFNetworkActivityIndicatorManager.h; sourceTree = "<group>"; };
-		25DE6004173EB13C00422571 /* AFNetworkActivityIndicatorManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFNetworkActivityIndicatorManager.m; sourceTree = "<group>"; };
-		25DE6005173EB13C00422571 /* AFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFNetworking.h; sourceTree = "<group>"; };
-		25DE6006173EB13C00422571 /* AFPropertyListRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFPropertyListRequestOperation.h; sourceTree = "<group>"; };
-		25DE6007173EB13C00422571 /* AFPropertyListRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFPropertyListRequestOperation.m; sourceTree = "<group>"; };
-		25DE6008173EB13C00422571 /* AFURLConnectionOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFURLConnectionOperation.h; sourceTree = "<group>"; };
-		25DE6009173EB13C00422571 /* AFURLConnectionOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFURLConnectionOperation.m; sourceTree = "<group>"; };
-		25DE600A173EB13C00422571 /* AFXMLRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFXMLRequestOperation.h; sourceTree = "<group>"; };
-		25DE600B173EB13C00422571 /* AFXMLRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFXMLRequestOperation.m; sourceTree = "<group>"; };
-		25DE600C173EB13C00422571 /* UIImageView+AFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImageView+AFNetworking.h"; sourceTree = "<group>"; };
-		25DE600D173EB13C00422571 /* UIImageView+AFNetworking.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImageView+AFNetworking.m"; sourceTree = "<group>"; };
 		29A9CE2017456336002360C8 /* AFJSONRequestOperationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFJSONRequestOperationTests.m; sourceTree = "<group>"; };
 		2B6D24F8E1B74E10A269E8B3 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		55E73C267F33406A9F92476C /* libPods-ios.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ios.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -133,7 +114,6 @@
 				25801549173EB4B40026AA6E /* Pods-ios.xcconfig */,
 				2580154A173EB4B40026AA6E /* Pods-osx.xcconfig */,
 				25801548173EB3B00026AA6E /* Tests */,
-				2544EC37173BE382004117E8 /* AFNetworking */,
 				25A753091747FC7E00F04F2F /* Resources */,
 				2544EC34173BE382004117E8 /* Frameworks */,
 				2544EC33173BE382004117E8 /* Products */,
@@ -167,33 +147,6 @@
 				2B6D24F8E1B74E10A269E8B3 /* libPods.a */,
 			);
 			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		2544EC37173BE382004117E8 /* AFNetworking */ = {
-			isa = PBXGroup;
-			children = (
-				25DE5FFB173EB13C00422571 /* AFHTTPClient.h */,
-				25DE5FFC173EB13C00422571 /* AFHTTPClient.m */,
-				25DE5FFD173EB13C00422571 /* AFHTTPRequestOperation.h */,
-				25DE5FFE173EB13C00422571 /* AFHTTPRequestOperation.m */,
-				25DE5FFF173EB13C00422571 /* AFImageRequestOperation.h */,
-				25DE6000173EB13C00422571 /* AFImageRequestOperation.m */,
-				25DE6001173EB13C00422571 /* AFJSONRequestOperation.h */,
-				25DE6002173EB13C00422571 /* AFJSONRequestOperation.m */,
-				25DE6003173EB13C00422571 /* AFNetworkActivityIndicatorManager.h */,
-				25DE6004173EB13C00422571 /* AFNetworkActivityIndicatorManager.m */,
-				25DE6005173EB13C00422571 /* AFNetworking.h */,
-				25DE6006173EB13C00422571 /* AFPropertyListRequestOperation.h */,
-				25DE6007173EB13C00422571 /* AFPropertyListRequestOperation.m */,
-				25DE6008173EB13C00422571 /* AFURLConnectionOperation.h */,
-				25DE6009173EB13C00422571 /* AFURLConnectionOperation.m */,
-				25DE600A173EB13C00422571 /* AFXMLRequestOperation.h */,
-				25DE600B173EB13C00422571 /* AFXMLRequestOperation.m */,
-				25DE600C173EB13C00422571 /* UIImageView+AFNetworking.h */,
-				25DE600D173EB13C00422571 /* UIImageView+AFNetworking.m */,
-			);
-			name = AFNetworking;
-			path = ../AFNetworking;
 			sourceTree = "<group>";
 		};
 		2544EC82173BFAA8004117E8 /* Other Frameworks */ = {


### PR DESCRIPTION
These files are redundant and left-behind from how things used to be done

`pod 'AFNetworking', :path => '../'` is now used.
