### PR TITLE
Update the Podfile.lock to reference the new specfile hash

### DIFF
--- a/Tests/Podfile.lock
+++ b/Tests/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - AFHTTPRequestOperationLogger (0.10.0):
     - AFNetworking (>= 0.9.0)
-  - AFNetworking (1.2.1)
+  - AFNetworking (1.3.0)
   - Expecta (0.2.1)
   - OCMock (2.1.1)
 
@@ -17,8 +17,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   AFHTTPRequestOperationLogger: 34ba125cb9eeb77a3b67aaaca105720ba3a0798c
-  AFNetworking: d1ba5908b233189e424e101721acef7905b58efb
+  AFNetworking: e528f20d06b1b818c3571266fb5efa20031a8ace
   Expecta: d46fb1bd78c90a83da0158b9b1e108de106e369f
   OCMock: 79212e5e328378af5cfd6edb5feacfd6c49cd8a3
 
-COCOAPODS: 0.20.1
+COCOAPODS: 0.20.2


### PR DESCRIPTION
Otherwise the tests will fail, and you get the error:

```
[!] Required version (AFNetworking (from `../`)) not found for `AFNetworking`.
Available versions: 1.3.0
```

When the spec file is changed, pod update needs to be run
