### PR TITLE
Reachability code reports the network as unreachable when a connection is required but can be established automatically

### DIFF
--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -305,7 +305,11 @@ static BOOL AFURLHostIsIPAddress(NSURL *url) {
 static AFNetworkReachabilityStatus AFNetworkReachabilityStatusForFlags(SCNetworkReachabilityFlags flags) {
     BOOL isReachable = ((flags & kSCNetworkReachabilityFlagsReachable) != 0);
     BOOL needsConnection = ((flags & kSCNetworkReachabilityFlagsConnectionRequired) != 0);
-    BOOL isNetworkReachable = (isReachable && !needsConnection);
+    BOOL canConnectionAutomatically = (((flags & kSCNetworkReachabilityFlagsConnectionOnDemand ) != 0) ||
+                                       ((flags & kSCNetworkReachabilityFlagsConnectionOnTraffic) != 0));
+    BOOL canConnectWithoutUserInteraction = (canConnectionAutomatically &&
+                                             (flags & kSCNetworkReachabilityFlagsInterventionRequired) == 0);
+    BOOL isNetworkReachable = (isReachable && (!needsConnection || canConnectWithoutUserInteraction));
 
     AFNetworkReachabilityStatus status = AFNetworkReachabilityStatusUnknown;
     if (isNetworkReachable == NO) {


### PR DESCRIPTION
The current implementation of `AFNetworkReachabilityStatusForFlags(SCNetworkReachabilityFlags flags)` reports a status of `AFNetworkReachabilityStatusNotReachable` in the case whenever the `kSCNetworkReachabilityFlagsConnectionRequired` flag is set.

This is accurate in most cases, but in certain cases where the network is temporarily unavailable (for example, the device is suspended with the app running and the wifi radio is turned off) the connection can be automatically re-established by the OS without user intervention when a network call is made. This condition is reported by `SCNetworkReachabilityGetFlags(SCNetworkReachabilityRef target, SCNetworkReachabilityFlags* flags)` setting either the `kSCNetworkReachabilityFlagsConnectionOnTraffic` flag or the `kSCNetworkReachabilityFlagsConnectionOnDemand` flag along with leaving the `kSCNetworkReachabilityFlagsInterventionRequired` flag unset.

It's my opinion that in the above case where the connection can be established automatically and without user intervention that it would be appropriate for AFNetworking to report a status of `AFNetworkReachabilityStatusReachableViaWWAN` or `AFNetworkReachabilityStatusReachableViaWiFi`.

My use case for this scenario is one where I check the reachability status before running a network call and refrain from running the call if the network is reported as unavailable. In this case the network won't become available again until something else (such as a system run network task) re-establishes the connection.

My approach to this flag handling is in line with Apple's sample Reachability app: http://developer.apple.com/library/ios/#samplecode/Reachability/Listings/Classes_Reachability_m.html
