### PR TITLE
Improved Image Loading Performance By Inflating Image In Background

### DIFF
--- a/AFNetworking/AFImageRequestOperation.h
+++ b/AFNetworking/AFImageRequestOperation.h
@@ -65,6 +65,11 @@
  The scale factor used when interpreting the image data to construct `responseImage`. Specifying a scale factor of 1.0 results in an image whose size matches the pixel-based dimensions of the image. Applying a different scale factor changes the size of the image as reported by the size property. This is set to the value of scale of the main screen by default, which automatically scales images for retina displays, for instance.
  */
 @property (nonatomic, assign) CGFloat imageScale;
+
+/**
+ Whether to automatically inflate response image data for compressed formats (such as PNG or JPEG). Enabling this can significantly improve drawing performance on iOS when used with `setCompletionBlockWithSuccess:failure:`, as it allows a bitmap representation to be constructed in the background rather than on the main thread. `YES` by default.
+ */
+@property (nonatomic, assign) BOOL automaticallyInflatesResponseImage;
 #endif
 
 /**


### PR DESCRIPTION
Following a hot tip from a couple developers at WWDC, I attempted to narrow the performance gap for image loading. 

Currently, there is a noticeable stutter on some devices when settings images, because compressed image formats (such as PNG) are decompressed and set on the main thread in the callback.

In preliminary testing, this patch improves performance significantly—removing the aforementioned stutter completely. It does so in a couple of ways:
- Creating an inflated / decompressed image in the `responseImage` getter, which is normally accessed in the background during the `completionBlock`
- Staying close to the metal when allocating `CGImageRef` (i.e. using `CGImageCreateWithPNGDataProvider` or `CGImageCreateWithJPEGDataProvider` depending on the response headers of the operation).

I'm really excited by the initial success of this, but want to make sure I got everything right before merging this in (my Quartz-jitsu is a little rusty).

Any feedback? /cc @steipete @blakewatters @0xced
