### PR TITLE
Remove _AFNETWORKING_PIN_SSL_CERTIFICATES_ definition from podspec

### DIFF
--- a/AFNetworking.podspec
+++ b/AFNetworking.podspec
@@ -18,8 +18,6 @@ Pod::Spec.new do |s|
   s.prefix_header_contents = <<-EOS
 #import <Availability.h>
 
-#define _AFNETWORKING_PIN_SSL_CERTIFICATES_
-
 #if __IPHONE_OS_VERSION_MIN_REQUIRED
   #import <SystemConfiguration/SystemConfiguration.h>
   #import <MobileCoreServices/MobileCoreServices.h>


### PR DESCRIPTION
If I understand correctly, that wasn’t intended:
https://github.com/AFNetworking/AFNetworking/issues/1027#issuecomment-18771651
