### PR TITLE
Allow fallback to generic image loading if PNG/JPEG-specific loads fail

### DIFF
--- a/AFNetworking/AFImageRequestOperation.m
+++ b/AFNetworking/AFImageRequestOperation.m
@@ -49,7 +49,7 @@ static UIImage * AFInflatedImageFromResponseWithDataAtScale(NSHTTPURLResponse *r
         return nil;
     }
 
-    CGImageRef imageRef;
+    CGImageRef imageRef = nil;
 
     CGDataProviderRef dataProvider = CGDataProviderCreateWithCFData((__bridge CFDataRef)data);
 
@@ -58,7 +58,9 @@ static UIImage * AFInflatedImageFromResponseWithDataAtScale(NSHTTPURLResponse *r
         imageRef = CGImageCreateWithPNGDataProvider(dataProvider,  NULL, true, kCGRenderingIntentDefault);
     } else if ([contentTypes containsObject:@"image/jpeg"]) {
         imageRef = CGImageCreateWithJPEGDataProvider(dataProvider, NULL, true, kCGRenderingIntentDefault);
-    } else {
+    }
+    
+    if (!imageRef) {
         UIImage *image = AFImageWithDataAtScale(data, scale);
         if (image.images) {
             CGDataProviderRelease(dataProvider);


### PR DESCRIPTION
In previous versions of AFNetworking, image requests were more forgiving of the content type of an image, since loading was left to UIImage/NSImage internals. Recent changes attempt to load images with format-specific CG functions, using the returned content type to determine which function should be used.

Some popular services are known to serve incorrect content types based on file extension, regardless of the actual image data. An example is the following URL, which claims to be a PNG although the actual file is a JPEG:

http://a0.twimg.com/profile_images/1753463783/image1326512084_normal.png

The attached commit will fall back to AFImageWithDataAtScale if CGImageCreateWithPNGDataProvider or CGImageCreateWithJPEGDataProvider returns nil.
