### PR TITLE
Prevent network request thread from exiting prematurely on OS X

### DIFF
--- a/AFNetworking/AFURLConnectionOperation.m
+++ b/AFNetworking/AFURLConnectionOperation.m
@@ -186,9 +186,13 @@ static BOOL AFSecKeyIsEqualToKey(SecKeyRef key1, SecKeyRef key2) {
 @synthesize redirectResponse = _redirectResponse;
 @synthesize lock = _lock;
 
-+ (void)networkRequestThreadEntryPoint:(id)__unused object {
-    [[NSThread currentThread] setName:@"AFNetworking"];
-    [[NSRunLoop currentRunLoop] run];
++ (void) __attribute__((noreturn)) networkRequestThreadEntryPoint:(id)__unused object {
+    @autoreleasepool {
+        [[NSThread currentThread] setName:@"AFNetworking"];
+        while (YES) {
+            [[NSRunLoop currentRunLoop] run];
+        }
+    }
 }
 
 + (NSThread *)networkRequestThread {


### PR DESCRIPTION
This is a fix to prevent network request thread from exiting prematurely on OS X. I also add back an autorelease pool to wrap the thread entry routine as I explained in issue #1077, according to the [Threading Programming Guide](https://developer.apple.com/library/ios/#documentation/Cocoa/Conceptual/Multithreading/CreatingThreads/CreatingThreads.html#//apple_ref/doc/uid/10000057i-CH15-SW17).
