### PR TITLE
Update 2.0 podspec

### DIFF
--- a/AFNetworking.podspec
+++ b/AFNetworking.podspec
@@ -1,20 +1,22 @@
 Pod::Spec.new do |s|
   s.name     = 'AFNetworking'
-  s.version  = '1.3.1'
+  s.version  = '2.0'
   s.license  = 'MIT'
   s.summary  = 'A delightful iOS and OS X networking framework.'
   s.homepage = 'https://github.com/AFNetworking/AFNetworking'
   s.authors  = { 'Mattt Thompson' => 'm@mattt.me', 'Scott Raymond' => 'sco@gowalla.com' }
-  s.source   = { :git => 'https://github.com/AFNetworking/AFNetworking.git', :tag => '1.3.1' }
-  s.source_files = 'AFNetworking'
+  s.source   = { :git => 'https://github.com/AFNetworking/AFNetworking.git', :tag => '2.0' }
+
   s.requires_arc = true
 
   s.ios.deployment_target = '5.0'
   s.ios.frameworks = 'MobileCoreServices', 'SystemConfiguration', 'Security', 'CoreGraphics'
+  s.ios.source_files = 'AFNetworking', 'UIKit+AFNetworking'
 
   s.osx.deployment_target = '10.7'
   s.osx.frameworks = 'CoreServices', 'SystemConfiguration', 'Security'
-
+  s.osx.source_files = 'AFNetworking'
+  
   s.prefix_header_contents = <<-EOS
 #import <Availability.h>
 


### PR DESCRIPTION
Currently the iOS version doesn't include the UIKit+AFNetworking, and it'd be nice if it did. I've changed the version number to 2.0.

With the tag change, as at this point anyone wanting to use it will have to use `pod 'AFNetworking', :git => 'https://github.com/AFNetworking/AFNetworking', :branch => '2.0'` which negates the tag in the podspec. I don't know if you prefer keeping the older one around until it's release time, to remind you to make the tag. So, I can undo that if needs be.
