### PR TITLE
Adding runtime hack for supporting the file:/// scheme.

### DIFF
--- a/AFNetworking/AFHTTPRequestOperation.m
+++ b/AFNetworking/AFHTTPRequestOperation.m
@@ -169,7 +169,7 @@ static void AFSwizzleClassMethodWithClassAndSelectorUsingBlock(Class klass, SEL 
 - (NSStringEncoding)responseStringEncoding {
     // When no explicit charset parameter is provided by the sender, media subtypes of the "text" type are defined to have a default charset value of "ISO-8859-1" when received via HTTP. Data in character sets other than "ISO-8859-1" or its subsets MUST be labeled with an appropriate charset value.
     // See http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.4.1
-    if (self.response && !self.response.textEncodingName && self.responseData && [self.response respondsToSelector:@selector(allHeaderFields)]) {
+    if (self.response && !self.response.textEncodingName && self.responseData) {
         NSString *type = nil;
         AFGetMediaTypeAndSubtypeWithString([[self.response allHeaderFields] valueForKey:@"Content-Type"], &type, nil);
 
@@ -190,7 +190,7 @@ static void AFSwizzleClassMethodWithClassAndSelectorUsingBlock(Class klass, SEL 
     }
 
     NSMutableURLRequest *mutableURLRequest = [self.request mutableCopy];
-    if ([self.response respondsToSelector:@selector(allHeaderFields)] && [[self.response allHeaderFields] valueForKey:@"ETag"]) {
+    if ([[self.response allHeaderFields] valueForKey:@"ETag"]) {
         [mutableURLRequest setValue:[[self.response allHeaderFields] valueForKey:@"ETag"] forHTTPHeaderField:@"If-Range"];
     }
     [mutableURLRequest setValue:[NSString stringWithFormat:@"bytes=%llu-", offset] forHTTPHeaderField:@"Range"];

--- a/AFNetworking/AFURLConnectionOperation.m
+++ b/AFNetworking/AFURLConnectionOperation.m
@@ -21,6 +21,7 @@
 // THE SOFTWARE.
 
 #import "AFURLConnectionOperation.h"
+#import <objc/runtime.h>
 
 #if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
 #import <UIKit/UIKit.h>
@@ -30,6 +31,27 @@
 #error AFNetworking must be built with ARC.
 // You can turn on ARC for only AFNetworking files by adding -fobjc-arc to the build phase for each of its files.
 #endif
+
+@implementation NSURLResponse (NSHTTPURLResponse)
+
++ (void)load
+{
+    if (![NSURLResponse instancesRespondToSelector:@selector(allHeaderFields)]) {
+        IMP implementation = imp_implementationWithBlock(^NSDictionary *(id self) {
+            return [NSDictionary dictionary];
+        });
+        class_addMethod(self, @selector(allHeaderFields), implementation, "@@:");
+    }
+    
+    if (![NSURLResponse instancesRespondToSelector:@selector(statusCode)]) {
+        IMP implementation = imp_implementationWithBlock(^NSInteger(id self) {
+            return 200;
+        });
+        class_addMethod(self, @selector(statusCode), implementation, "i@:");
+    }
+}
+
+@end
 
 typedef enum {
     AFOperationPausedState      = -1,

--- a/Tests/Podfile.lock
+++ b/Tests/Podfile.lock
@@ -17,7 +17,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   AFHTTPRequestOperationLogger: 34ba125cb9eeb77a3b67aaaca105720ba3a0798c
-  AFNetworking: 9ec8aafb9269236a7630bd8d9838ce2ba30fa2a0
+  AFNetworking: 7337ed638bf25ca2ab2bdec944b036e568e2b0e7
   Expecta: d46fb1bd78c90a83da0158b9b1e108de106e369f
   OCMock: 79212e5e328378af5cfd6edb5feacfd6c49cd8a3
 


### PR DESCRIPTION
Back when AFNetworking decided to support the file:/// scheme, I suggested this runtime hack to future proof this scenario but got rejected because "I was overthinking it". After reading #1146 and #1155 where it seems people are using the file scheme for images which AFInflatedImageFromResponseWithDataAtScale can't handle, I feel its time to rethink using this hack. By merging this pull request, AFNetworking will never have to deal with statements like `[response respondsToSelector:@selector(allHeaderFields)]` again (which can easily be forgotten).
