### PR TITLE
Enabling invalid SSL certificates on UIImageView+AFNetworking

### DIFF
--- a/Tests/Podfile.lock
+++ b/Tests/Podfile.lock
@@ -17,8 +17,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   AFHTTPRequestOperationLogger: 34ba125cb9eeb77a3b67aaaca105720ba3a0798c
-  AFNetworking: 7337ed638bf25ca2ab2bdec944b036e568e2b0e7
+  AFNetworking: 9ec8aafb9269236a7630bd8d9838ce2ba30fa2a0
   Expecta: d46fb1bd78c90a83da0158b9b1e108de106e369f
   OCMock: 79212e5e328378af5cfd6edb5feacfd6c49cd8a3
 
-COCOAPODS: 0.22.1
+COCOAPODS: 0.22.2


### PR DESCRIPTION
I simply set allowsInvalidSSLCertificate = YES on `[UIImageView setImageWithURLRequest:placeholderImage:success:failure:]` when _AFNETWORKING_ALLOW_INVALID_SSL_CERTIFICATES_ is defined.

Sadly, there's no testing for this category and I honestly don't have enough knowledge to do so.
