### PR TITLE
Transfer headers to request during request serialization

### DIFF
--- a/AFNetworking/AFSerialization.m
+++ b/AFNetworking/AFSerialization.m
@@ -237,6 +237,11 @@ NSArray * AFQueryStringPairsFromKeyAndValue(NSString *key, id value) {
     }
 
     NSMutableURLRequest *mutableRequest = [request mutableCopy];
+    
+    for( NSString *httpHeaderField in self.HTTPRequestHeaders.allKeys ) {
+    	[mutableRequest setValue:self.HTTPRequestHeaders[headerField] 
+    	      forHTTPHeaderField:headerField];
+    }
 
     NSString *query = nil;
     if (self.queryStringSerialization) {


### PR DESCRIPTION
I found my requests were failing authorisation.  I looked to find where the headers were transferred from the serializer to the request, but couldn't find any code that did that.  I appreciate I've looked at this brand new code base for all of 30 minutes so am possibly missing something, but this little loop fixed the problem for me?
