### PR TITLE
[2.0] Fixed issue where default headers were not getting applied

### DIFF
--- a/AFNetworking/AFSerialization.m
+++ b/AFNetworking/AFSerialization.m
@@ -232,15 +232,17 @@ NSArray * AFQueryStringPairsFromKeyAndValue(NSString *key, id value) {
 {
     NSParameterAssert(request);
 
-    if (!parameters) {
-        return request;
-    }
 
     NSMutableURLRequest *mutableRequest = [request mutableCopy];
 
     [self.HTTPRequestHeaders enumerateKeysAndObjectsUsingBlock:^(id field, id value, BOOL *stop) {
         [mutableRequest setValue:value forHTTPHeaderField:field];
     }];
+    
+    
+    if (!parameters) {
+        return mutableRequest;
+    }
 
     NSString *query = nil;
     if (self.queryStringSerialization) {


### PR DESCRIPTION
The default headers weren't getting applied if you passed in nil parameters. This fixes that :)
