### PR TITLE
UIImageView+AFNetworking with high resolution images crashing the app

### DIFF
--- a/AFNetworking/AFImageRequestOperation.m
+++ b/AFNetworking/AFImageRequestOperation.m
@@ -77,6 +77,11 @@ static UIImage * AFInflatedImageFromResponseWithDataAtScale(NSHTTPURLResponse *r
 
     size_t width = CGImageGetWidth(imageRef);
     size_t height = CGImageGetHeight(imageRef);
+    
+    if (width*height > 2048*2048) {
+        return nil;
+    }
+    
     size_t bitsPerComponent = CGImageGetBitsPerComponent(imageRef);
     size_t bytesPerRow = 0; // CGImageGetBytesPerRow() calculates incorrectly in iOS 5.0, so defer to CGBitmapContextCreate()
     CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();


### PR DESCRIPTION
I am building an app with user defined content that may, in some circumstances, have images that are yet to be resized.

While testing, I found an image that was crashing my app while running on my iPad Mini. Some discussion later ([over at stackoverflow](http://stackoverflow.com/questions/17937643/uiimageviewafnetworking-on-device-memory-problems-for-large-images-leak)) it was apparent that the problem was the image had 12150×6075 pixels.

Should AFNetworking automatically discard huge images like this? Could it be a configuration of some sort?

For my own app I implemented the hotfix you see in the pull request. This is obviously not what you would implement but at least it shows it's possible and it may help someone in the same situation.
