### PR TITLE
Update AFHTTPClient documentation to clarify the scope of the parameterEncoding property.

### DIFF
--- a/AFNetworking/AFHTTPClient.h
+++ b/AFNetworking/AFHTTPClient.h
@@ -118,7 +118,7 @@ typedef enum {
 @property (nonatomic, assign) NSStringEncoding stringEncoding;
 
 /**
- The `AFHTTPClientParameterEncoding` value corresponding to how parameters are encoded into a request body. This is `AFFormURLParameterEncoding` by default.
+ The `AFHTTPClientParameterEncoding` value corresponding to how parameters are encoded into a request body for request methods other than `GET`, `HEAD` or `DELETE`. This is `AFFormURLParameterEncoding` by default.
 
  @warning Some nested parameter structures, such as a keyed array of hashes containing inconsistent keys (i.e. `@{@"": @[@{@"a" : @(1)}, @{@"b" : @(2)}]}`), cannot be unambiguously represented in query strings. It is strongly recommended that an unambiguous encoding, such as `AFJSONParameterEncoding`, is used when posting complicated or nondeterministic parameter structures.
  */


### PR DESCRIPTION
This drove me nuts. This clarifies exactly what happens and what effect occurs by setting this property, based on my reading of the source code.
