### PR TITLE
[2.0] Bringing along the session headers for requests

### DIFF
--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -248,9 +248,9 @@ typedef id AFNetworkReachabilityRef;
     }
 
     NSURL *url = [NSURL URLWithString:path relativeToURL:self.baseURL];
-	NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:url];
+    NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:url];
     [request setHTTPMethod:method];
-
+    [request setAllHTTPHeaderFields:[self.session.configuration HTTPAdditionalHeaders]];
     if (self.requestSerializer) {
         request = [[self.requestSerializer requestBySerializingRequest:request withParameters:parameters error:nil] mutableCopy];
     }


### PR DESCRIPTION
I noticed that the session configuration headers were not being applied in the requests factory, meaning that anyone who configures the client with a session configuration and then uses the factory to create an old school AFOperation would not get those header values applied to their requests.

The docs have the following comment about `HTTPAdditionalHeaders`, so we should be safe to add them here:

`Note that these headers are added to the request only if not already present.`

A developer could now use `requestWithMethod:...` and `HTTPOperationWithRequest:...` and get all of the proper headers.
