### PR TITLE
When AFNetworking is in an embedded framework, load pinned certificates from app bundle

### DIFF
--- a/AFNetworking/AFURLConnectionOperation.m
+++ b/AFNetworking/AFURLConnectionOperation.m
@@ -200,13 +200,13 @@ static BOOL AFSecKeyIsEqualToKey(SecKeyRef key1, SecKeyRef key2) {
     static NSArray *_pinnedCertificates = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        NSBundle *bundle = [NSBundle mainBundle];
-        NSArray *paths = [bundle pathsForResourcesOfType:@"cer" inDirectory:@"."];
-        
-        NSMutableArray *certificates = [NSMutableArray arrayWithCapacity:[paths count]];
-        for (NSString *path in paths) {
-            NSData *certificateData = [NSData dataWithContentsOfFile:path];
-            [certificates addObject:certificateData];
+        NSMutableArray *certificates = [NSMutableArray array];
+        for (NSBundle *bundle in [NSBundle allBundles]) {
+            NSArray *paths = [bundle pathsForResourcesOfType:@"cer" inDirectory:@"."];
+            for (NSString *path in paths) {
+                NSData *certificateData = [NSData dataWithContentsOfFile:path];
+                [certificates addObject:certificateData];
+            }
         }
         
         _pinnedCertificates = [[NSArray alloc] initWithArray:certificates];


### PR DESCRIPTION
When AFNetworking is used in an embedded framework on Mac OS, the framework may attempt to load pinned certificates from the framework's bundle instead of the application's bundle.

The application's bundle seems to be the appropriate place.

``` objc
NSBundle *bundle = [NSBundle bundleForClass:[self class]];
NSArray *paths = [bundle pathsForResourcesOfType:@"cer" inDirectory:@"."];
```

When that code runs, `[self class]` is the first-used subclass of AFURLConnectionOperation. In the case I just encountered, it's RKObjectRequestOperation, which I'm building as a framework (not using CocoaPods). The bundle path then is RestKit.framework instead of MyApp.app, and `paths` is empty. In other cases the first-used class is my own AFHTTPRequestOperation subclass, in the app's bundle, and I don't have a problem.

This change seems to work correctly on Mac OS and iOS.
