### PR TITLE
Fixes compilation errors on RC1 while using Xcode 5 DP5

### DIFF
--- a/AFNetworking/AFHTTPRequestOperation.h
+++ b/AFNetworking/AFHTTPRequestOperation.h
@@ -50,12 +50,12 @@
 /**
  The dispatch queue for `completionBlock`. If `NULL` (default), the main queue is used.
  */
-@property (nonatomic, copy) dispatch_queue_t completionQueue;
+@property (nonatomic, assign) dispatch_queue_t completionQueue;
 
 /**
  The dispatch group for `completionBlock`. If `NULL` (default), a private dispatch group is used. 
  */
-@property (nonatomic, copy) dispatch_group_t completionGroup;
+@property (nonatomic, assign) dispatch_group_t completionGroup;
 
 
 ///-----------------------------------------------------------


### PR DESCRIPTION
This avoids the following compiler error, guessing assign is right:

`Property with 'copy' attribute must be of object type.`

It can be reproduced by simply creating an `Empty Application` Xcode project, and then adding a `Podfile` that looks like:

``` ruby
platform :ios, '7.0'
pod 'AFIncrementalStore'
```

then doing a `pod install` and opening the `.xcworkspace` will reveal the aforementioned error.

(Using `Xcode5-DP5.app`)
