### PR TITLE
[Race] Fixing AFHTTPRequestOperation.HTTPError being overreleased.

### DIFF
--- a/AFNetworking/AFHTTPRequestOperation.m
+++ b/AFNetworking/AFHTTPRequestOperation.m
@@ -108,6 +108,7 @@ static void AFSwizzleClassMethodWithClassAndSelectorUsingBlock(Class klass, SEL 
 #pragma mark -
 
 @interface AFHTTPRequestOperation ()
+@property (readwrite, nonatomic, strong) NSRecursiveLock *lock;
 @property (readwrite, nonatomic, strong) NSURLRequest *request;
 @property (readwrite, nonatomic, strong) NSHTTPURLResponse *response;
 @property (readwrite, strong) NSError *HTTPError;
@@ -117,8 +118,27 @@ static void AFSwizzleClassMethodWithClassAndSelectorUsingBlock(Class klass, SEL 
 @synthesize HTTPError = _HTTPError;
 @synthesize successCallbackQueue = _successCallbackQueue;
 @synthesize failureCallbackQueue = _failureCallbackQueue;
+@dynamic lock;
 @dynamic request;
 @dynamic response;
+
+- (NSError *)HTTPError
+{
+    [self.lock lock];
+    NSError *HTTPError = _HTTPError;
+    [self.lock unlock];
+    
+    return HTTPError;
+}
+
+- (void)setHTTPError:(NSError *)HTTPError
+{
+    [self.lock lock];
+    if (HTTPError != _HTTPError) {
+        _HTTPError = HTTPError;
+    }
+    [self.lock unlock];
+}
 
 - (void)dealloc {
     if (_successCallbackQueue) {


### PR DESCRIPTION
Just discovered that the following loop _always_ results in a crash in my app

``` objc
for (int i = 0; i < 10000; i++) {
    // fire up a JSON request with an unknown URL resulting in a 404 status code
}
```

due to `AFHTTPRequestOperation.HTTPError` being overreleased by arc. An easy fix for that is to make AFHTTPRequestOperation.HTTPError **atomic** (which makes sense anyway because it is being used on different threads).
- I think I remember another issue encountering this crash which I haven't been able to find as of this writing. I'm wondering if we could get a fast merge and version bump because Crashlytics told me that this crash happened quiet often in real world code.
- Maybe as a second step, we should consider making all properties which are being used by AF on different threads  atomic.
