### PR TITLE
Avoid unneccesary expensive isEqualToString: calls and conversions

### DIFF
--- a/AFNetworking/AFJSONRequestOperation.m
+++ b/AFNetworking/AFJSONRequestOperation.m
@@ -67,16 +67,14 @@ static dispatch_queue_t json_request_operation_processing_queue() {
     [self.lock lock];
     if (!_responseJSON && [self.responseData length] > 0 && [self isFinished] && !self.JSONError) {
         NSError *error = nil;
-
+        
         // Workaround for behavior of Rails to return a single space for `head :ok` (a workaround for a bug in Safari), which is not interpreted as valid input by NSJSONSerialization.
         // See https://github.com/rails/rails/issues/1742
-        if (self.responseString && ![self.responseString isEqualToString:@" "]) {
+        if (self.responseData && !(self.responseData.length == 1 && [self.responseString isEqualToString:@" "])) {
             // Workaround for a bug in NSJSONSerialization when Unicode character escape codes are used instead of the actual character
             // See http://stackoverflow.com/a/12843465/157142
-            NSData *data = [self.responseString dataUsingEncoding:NSUTF8StringEncoding];
-
-            if (data) {
-                self.responseJSON = [NSJSONSerialization JSONObjectWithData:data options:self.JSONReadingOptions error:&error];
+            if (self.responseData) {
+                self.responseJSON = [NSJSONSerialization JSONObjectWithData:self.responseData options:self.JSONReadingOptions error:&error];
             } else {
                 NSMutableDictionary *userInfo = [NSMutableDictionary dictionary];
                 [userInfo setValue:@"Operation responseData failed decoding as a UTF-8 string" forKey:NSLocalizedDescriptionKey];
@@ -84,11 +82,11 @@ static dispatch_queue_t json_request_operation_processing_queue() {
                 error = [[NSError alloc] initWithDomain:AFNetworkingErrorDomain code:NSURLErrorCannotDecodeContentData userInfo:userInfo];
             }
         }
-
+        
         self.JSONError = error;
     }
     [self.lock unlock];
-
+    
     return _responseJSON;
 }
 


### PR DESCRIPTION
As the `-[AFJSONRequestOperation responseJSON]` method is potentially called very often, unnecessary conversions between NSData and NSString should be avoided.

Also `-[NSString isEqualToString:]` is comparably expensive. As it is only needed to find out if the response is a single space the byte length of the NSData has to be 1 (quite strange that this is not checked in `-isEqualToString:`'s implementation). 

Before: 

![before](https://f.cloud.github.com/assets/15453/987162/797e89a0-08e6-11e3-8cca-25aad3e2df9b.png)

After:

![after](https://f.cloud.github.com/assets/15453/987164/7e20c8ec-08e6-11e3-9440-87db748504c7.png)
