### PR TITLE
[2.0] Workaround radar 14783825

### DIFF
--- a/UIKit+AFNetworking/AFNetworkActivityIndicatorManager.m
+++ b/UIKit+AFNetworking/AFNetworkActivityIndicatorManager.m
@@ -30,10 +30,9 @@ static NSTimeInterval const kAFNetworkActivityIndicatorInvisibilityDelay = 0.17;
 
 static NSURLRequest * AFNetworkRequestFromNotification(NSNotification *notification) {
     NSURLRequest *request = nil;
-    BOOL workaroundRadar14783825 = [[notification object] isKindOfClass:[NSURLSessionDataTask class]] || [[notification object] isKindOfClass:[NSURLSessionUploadTask class]] || [[notification object] isKindOfClass:[NSURLSessionDownloadTask class]];
     if ([[notification object] isKindOfClass:[AFURLConnectionOperation class]]) {
         request = [(AFURLConnectionOperation *)[notification object] request];
-    } else if ([[notification object] isKindOfClass:[NSURLSessionTask class]] || workaroundRadar14783825) {
+    } else if ([[notification object] respondsToSelector:@selector(originalRequest)]) {
         request = [(NSURLSessionTask *)[notification object] originalRequest];
     }
 


### PR DESCRIPTION
Testing for `[[notification object] isKindOfClass:[NSURLSessionTask class]]` should be enough but NSURLSessionTask subclasses lie about their class membership. See http://www.openradar.me/14783825

This commit can be hopefully reverted if rdar://problem/14783825 is fixed before iOS 7 goes public.
