### PR TITLE
Fixed crash when setting completionQueue and completionGroup.

### DIFF
--- a/AFNetworking/AFHTTPRequestOperation.h
+++ b/AFNetworking/AFHTTPRequestOperation.h
@@ -50,12 +50,12 @@
 /**
  The dispatch queue for `completionBlock`. If `NULL` (default), the main queue is used.
  */
-@property (nonatomic, copy) dispatch_queue_t completionQueue;
+@property (nonatomic, strong) dispatch_queue_t completionQueue;
 
 /**
  The dispatch group for `completionBlock`. If `NULL` (default), a private dispatch group is used. 
  */
-@property (nonatomic, copy) dispatch_group_t completionGroup;
+@property (nonatomic, strong) dispatch_group_t completionGroup;
 
 
 ///-----------------------------------------------------------


### PR DESCRIPTION
While copy is best for dispatch_block_t, it is not supported for dispatch_queue_t or dispatch_group_t. Use strong instead.
