### PR TITLE
Resolve static analyzer warning about 'Potential leak of an object stored into 'dataProvider''

### DIFF
--- a/AFNetworking/AFImageRequestOperation.m
+++ b/AFNetworking/AFImageRequestOperation.m
@@ -67,6 +67,7 @@ static UIImage * AFInflatedImageFromResponseWithDataAtScale(NSHTTPURLResponse *r
         imageRef = CGImageCreateCopy([image CGImage]);
 
         if (!imageRef) {
+            CGDataProviderRelease(dataProvider);
             return image;
         }
     }


### PR DESCRIPTION
Resolved in this manner in an attempt to remain in the spirit of how the code was originally written.
