### PR TITLE
Fixes 2.0 podspec for mac

### DIFF
--- a/AFNetworking.podspec
+++ b/AFNetworking.podspec
@@ -14,11 +14,7 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = '10.9'
   s.osx.frameworks = 'CoreServices', 'SystemConfiguration', 'Security'
 
-  s.subspec 'Core' do |ss|
-    ss.source_files = 'AFNetworking'
-  end
+  s.source_files = 'AFNetworking'
+  s.ios.source_files = 'UIKit+AFNetworking'
 
-  s.subspec 'UIKit+AFNetworking' do |ss|
-    ss.source_files = 'UIKit+AFNetworking'
-  end
 end


### PR DESCRIPTION
When I run `pod spec lint` on the spec, i got compile error for osx. 

```
 -> AFNetworking (2.0.0-RC2)
    - ERROR | [OSX] [xcodebuild]  AFNetworking/UIKit+AFNetworking/UIActivityIndicatorView+AFNetworking.h:23:9: fatal error: 'UIKit/UIKit.h' file not found
    - ERROR | [OSX] [xcodebuild]  AFNetworking/UIKit+AFNetworking/UIProgressView+AFNetworking.h:23:9: fatal error: 'UIKit/UIKit.h' file not found
    - ERROR | [OSX] [xcodebuild]  AFNetworking/UIKit+AFNetworking/UIWebView+AFNetworking.h:23:9: fatal error: 'UIKit/UIKit.h' file not found
```

I believe what the spec want is only include UIKit classes for iOS. The PR should do that.
