### PR TITLE
Add convenience method for converting NSData to base-64 encoding.

### DIFF
--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -53,6 +53,9 @@ typedef void (^AFCompletionBlock)(void);
 
 static NSString * AFBase64EncodedStringFromString(NSString *string) {
     NSData *data = [NSData dataWithBytes:[string UTF8String] length:[string lengthOfBytesUsingEncoding:NSUTF8StringEncoding]];
+    return AFBase64EncoddingStringfromData(data);
+
+static NSString * AFBase64EncodedStringFromData(NSString *data) {
     NSUInteger length = [data length];
     NSMutableData *mutableData = [NSMutableData dataWithLength:((length + 2) / 3) * 4];
 


### PR DESCRIPTION
Although not strictly required for AFNetworking, there are
so many web services that embed binary data (like images) using
base-64 encoding that adding this method to AFNetworking makes sense,
especially since its a trivial change.
