### PR TITLE
Pass disposition instead of forcing NSURLSessionAuthChallengePerformDefaultHandling

### DIFF
--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -450,7 +450,7 @@ didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
     }
 
     if (completionHandler) {
-        completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, credential);
+        completionHandler(disposition, credential);
     }
 }
 
@@ -489,7 +489,7 @@ didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
     }
 
     if (completionHandler) {
-        completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, credential);
+        completionHandler(disposition, credential);
     }
 }
 


### PR DESCRIPTION
This implementation (I believe unintentionally) forces `NSURLSessionAuthChallengePerformDefaultHandling` to be returned to the `completionHandler`.  This will ignore any `NSURLCredential` that may be provided in in the `sessionDidReceiveAuthenticationChallenge` or `taskDidReceiveAuthenticationChallenge` blocks.
