### PR TITLE
[2.0] Added additional information to AFNetworkingTaskDidFinishNotification

### DIFF
--- a/AFNetworking/AFURLSessionManager.h
+++ b/AFNetworking/AFURLSessionManager.h
@@ -352,9 +352,34 @@
 extern NSString * const AFNetworkingTaskDidStartNotification;
 
 /**
- Posted when a task finishes executing.
+ Posted when a task finishes executing. Includes a userInfo dictionary with additional information about the task.
  */
 extern NSString * const AFNetworkingTaskDidFinishNotification;
+
+/**
+ The raw response data of the task. Included in the userInfo dictionary of the `AFNetworkingTaskDidFinishNotification` if response data exists for the task.
+ */
+extern NSString * const AFNetworkingTaskDidFinishResponseDataKey;
+
+/**
+ The serialized response object of the task. Included in the userInfo dictionary of the `AFNetworkingTaskDidFinishNotification` if the response was serialized.
+ */
+extern NSString * const AFNetworkingTaskDidFinishSerializedResponseKey;
+
+/**
+ The response serializer used to serialize the response. Included in the userInfo dictionary of the `AFNetworkingTaskDidFinishNotification` if the task has an associated response serializer.
+ */
+extern NSString * const AFNetworkingTaskDidFinishResponseSerializerKey;
+
+/**
+ The file path assoicated with the download task. Included in the userInfo dictionary of the `AFNetworkingTaskDidFinishNotification` if an the response data has been stored directly to disk.
+ */
+extern NSString * const AFNetworkingTaskDidFinishAssetPathKey;
+
+/**
+ Any error assoicated with the task, or the serialization of the response. Included in the userInfo dictionary of the `AFNetworkingTaskDidFinishNotification` if an error exists.
+ */
+extern NSString * const AFNetworkingTaskDidFinishErrorKey;
 
 /**
  Posted when a task suspends its execution.


### PR DESCRIPTION
While working on making [AFHARchiver](https://github.com/mutualmobile/AFHARchiver) compatible with 2.0, I noticed that I don't actually have access to the raw response data, or the serialized response object, which is needed in order to produce thorough logs. This pull request attempts to rectify that by adding information to the userInfo dictionary posted with the notification.

While in the code, I noticed a few places where we duplicated code, so I tried to make a few DRY methods in order to reduce maintenance going forward.

Highlights from the PR:
- I can only access the response data and the serialized response from the task completion block of the task creation method (I really feel Apple dropped the ball here), so I had to move the posting of the DidFinishNotification from the KVO method to the completion block of the task.
- I noticed that the data task and upload task completion handler methods were exactly the same, so I moved those into one DRY method.
- The download task completion handlers were also similar to each other, so I've moved those into a single DRY method.
- That task completion methods now properly construct the user info dictionary, and posts the notification.
- I added a DRY method for posting the notification, since it now happens from a few different places.
- I added a DRY method for setting up KVO for a specific task since that happens in a few different places.
- I added a DRY method to tear down KVO for a specific task.
- I noticed a few places where the failure block was not being sent to the main queue. Fixed that in the new DRY methods.

As far as the keys for the user info, the dictionary may contain the following values:
- AFNetworkingTaskDidFinishResponseDataKey: the raw response object
- AFNetworkingTaskDidFinishSerializedResponseKey: the serialized response
- AFNetworkingTaskDidFinishResponseSerializerKey: the response serializer used to serialize the response
- AFNetworkingTaskDidFinishAssetPathKey: the path that response data was downloaded too (for download tasks)
- AFNetworkingTaskDidFinishErrorKey: any error associated with the task.

For `AFHTTPRequestOperations`, all of this information can be obtained from the operation directly. NSURLSessionTask doesnt give us those options, so I feel this is necessary. The above keys give me everything I need in order to implement AFHARciver for 2.0.

Let me know your thoughts.

:beers:
