### PR TITLE
Cocoa NSError conventions

### DIFF
--- a/AFNetworking/AFEventSource.h
+++ b/AFNetworking/AFEventSource.h
@@ -131,7 +131,7 @@
 
  @return `YES` if successful, otherwise `NO`, with the associated `error` available in the out parameter.
  */
-- (BOOL)open:(NSError * __autoreleasing *)error;
+- (BOOL)openAndReturnError:(NSError * __autoreleasing *)error;
 
 /**
  Closes the event source connection.
@@ -140,7 +140,7 @@
 
  @return `YES` if successful, otherwise `NO`, with the associated `error` available in the out parameter.
  */
-- (BOOL)close:(NSError * __autoreleasing *)error;
+- (BOOL)closeAndReturnError:(NSError * __autoreleasing *)error;
 
 ///-------------------------------
 /// @name Managing Event Listeners

--- a/AFNetworking/AFEventSource.m
+++ b/AFNetworking/AFEventSource.m
@@ -166,7 +166,7 @@ typedef NS_ENUM(NSUInteger, AFEventSourceState) {
     self.lock.name = AFEventSourceLockName;
 
     NSError *error = nil;
-    [self open:&error];
+    [self openAndReturnError:&error];
     if (error) {
         if ([self.delegate respondsToSelector:@selector(eventSource:didFailWithError:)]) {
             [self.delegate eventSource:self didFailWithError:error];
@@ -192,7 +192,7 @@ typedef NS_ENUM(NSUInteger, AFEventSourceState) {
     return self.requestOperation.response;
 }
 
-- (BOOL)open:(NSError * __autoreleasing *)error {
+- (BOOL)openAndReturnError:(NSError * __autoreleasing *)error {
     if ([self isOpen]) {
         if (error) {
             *error = [NSError errorWithDomain:AFEventSourceErrorDomain code:0 userInfo:@{ NSLocalizedDescriptionKey: NSLocalizedStringFromTable(@"Even Source Already Opened", @"AFEventSource", nil) }];
@@ -225,7 +225,7 @@ typedef NS_ENUM(NSUInteger, AFEventSourceState) {
     return YES;
 }
 
-- (BOOL)close:(NSError * __autoreleasing *)error {
+- (BOOL)closeAndReturnError:(NSError * __autoreleasing *)error {
     if ([self isClosed]) {
         if (error) {
             *error = [NSError errorWithDomain:AFEventSourceErrorDomain code:0 userInfo:@{ NSLocalizedDescriptionKey: NSLocalizedStringFromTable(@"Even Source Already Closed", @"AFEventSource", nil) }];

--- a/AFNetworking/AFHTTPClient+Rocket.m
+++ b/AFNetworking/AFHTTPClient+Rocket.m
@@ -48,7 +48,7 @@
         }
     }];
 
-    [eventSource open:error];
+    [eventSource openAndReturnError:error];
 
     return eventSource;
 }


### PR DESCRIPTION
Follow Cocoa conventions for methods without parameters returning errors, i.e. `xxxAndReturnError:(NSError *)error` instead of just `xxx:(NSError *)error`
