### PR TITLE
[2.0] Remove unnecessary #pragma clang diagnostic ignored "-Wassign-enum"

### DIFF
--- a/AFNetworking/AFSerialization.m
+++ b/AFNetworking/AFSerialization.m
@@ -383,10 +383,7 @@ NSArray * AFQueryStringPairsFromKeyAndValue(NSString *key, id value) {
     NSString *charset = (__bridge NSString *)CFStringConvertEncodingToIANACharSetName(CFStringConvertNSStringEncodingToEncoding(NSUTF8StringEncoding));
 
     [mutableRequest setValue:[NSString stringWithFormat:@"application/json; charset=%@", charset] forHTTPHeaderField:@"Content-Type"];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wassign-enum"
     [mutableRequest setHTTPBody:[NSJSONSerialization dataWithJSONObject:parameters options:self.writingOptions error:error]];
-#pragma clang diagnostic pop
 
     return mutableRequest;
 }


### PR DESCRIPTION
Removes some `#pragma clang diagnostic ignored` pollution in the 2.0 branch. #1263
