### PR TITLE
[2.0] Refactor `completionQueue` / `completionBlock` to AFURLConnectionOperation

### DIFF
--- a/AFNetworking/AFHTTPRequestOperation.h
+++ b/AFNetworking/AFHTTPRequestOperation.h
@@ -43,20 +43,6 @@
  */
 @property (nonatomic, strong) id <AFURLResponseSerialization> responseSerializer;
 
-///---------------------------------
-/// @name Managing Callback Queues
-///---------------------------------
-
-/**
- The dispatch queue for `completionBlock`. If `NULL` (default), the main queue is used.
- */
-@property (nonatomic, strong) dispatch_queue_t completionQueue;
-
-/**
- The dispatch group for `completionBlock`. If `NULL` (default), a private dispatch group is used. 
- */
-@property (nonatomic, strong) dispatch_group_t completionGroup;
-
 ///-----------------------------------------------------------
 /// @name Setting Completion Block Success / Failure Callbacks
 ///-----------------------------------------------------------

--- a/AFNetworking/AFURLConnectionOperation.h
+++ b/AFNetworking/AFURLConnectionOperation.h
@@ -182,6 +182,20 @@ typedef NS_ENUM(NSUInteger, AFURLConnectionOperationSSLPinningMode) {
  */
 @property (nonatomic, strong) NSOutputStream *outputStream;
 
+///---------------------------------
+/// @name Managing Callback Queues
+///---------------------------------
+
+/**
+ The dispatch queue for `completionBlock`. If `NULL` (default), the main queue is used.
+ */
+@property (nonatomic, strong) dispatch_queue_t completionQueue;
+
+/**
+ The dispatch group for `completionBlock`. If `NULL` (default), a private dispatch group is used.
+ */
+@property (nonatomic, strong) dispatch_group_t completionGroup;
+
 ///---------------------------------------------
 /// @name Managing Request Operation Information
 ///---------------------------------------------


### PR DESCRIPTION
After adding `completionQueue` / `completionBlock` to `AFURLSessionManager`, I found myself wondering if it would be more consistent to move those properties to `AFURLConnectionOperation` from `AFHTTPRequestOperation`.

The one advantage to this approach is that vanilla `completionBlock`s can be run on a specified queue and group. It also appears to safeguard against potential threading issues in `nil`-ing out `completionBlock` to break the retain cycle.

Initial tests show this to work alright, but I'd love another set of eyes to make sure my understanding of GCD here is correct, and that this API is indeed desirable.
