### PR TITLE
[2.0] Deprecation Warning Messages

### DIFF
--- a/AFNetworking/AFHTTPClient.h
+++ b/AFNetworking/AFHTTPClient.h
@@ -191,7 +191,7 @@ typedef NS_ENUM(NSInteger, AFNetworkReachabilityStatus) {
 
 - (NSMutableURLRequest *)requestWithMethod:(NSString *)method
                                       path:(NSString *)path
-                                parameters:(NSDictionary *)parameters __attribute__((deprecated));
+                                parameters:(NSDictionary *)parameters DEPRECATED_MSG_ATTRIBUTE("Use requestWithMethod:URLString:parameters: instead");
 
 /**
  Creates an `NSMutableURLRequest` object with the specified HTTP method and URLString, and constructs a `multipart/form-data` HTTP body, using the specified parameters and multipart form data block. See http://www.w3.org/TR/html4/interact/forms.html#h-17.13.4.2
@@ -213,7 +213,7 @@ typedef NS_ENUM(NSInteger, AFNetworkReachabilityStatus) {
 - (NSMutableURLRequest *)multipartFormRequestWithMethod:(NSString *)method
                                                    path:(NSString *)path
                                              parameters:(NSDictionary *)parameters
-                              constructingBodyWithBlock:(void (^)(id <AFMultipartFormData> formData))block __attribute__((deprecated));
+                              constructingBodyWithBlock:(void (^)(id <AFMultipartFormData> formData))block DEPRECATED_MSG_ATTRIBUTE("Use multipartFormRequestWithMethod:URLString:parameters:constructingBodyWithBlock: instead");
 
 ///---------------------------------------
 /// @name Managing HTTP Request Operations
@@ -249,7 +249,7 @@ typedef NS_ENUM(NSInteger, AFNetworkReachabilityStatus) {
                                 URLString:(NSString *)URLString;
 
 - (void)cancelAllHTTPOperationsWithMethod:(NSString *)method
-                                     path:(NSString *)path __attribute__((deprecated));
+                                     path:(NSString *)path DEPRECATED_MSG_ATTRIBUTE("Use cancelAllHTTPOperationsWithMethod:URLString: instead");
 
 ///---------------------------------------
 /// @name Batching HTTP Request Operations


### PR DESCRIPTION
Update to use `DEPRECATED_MSG_ATTRIBUTE(s)` for depreciation warnings. Added messages describing the API changes.
