### PR TITLE
Removing old rails 3.x glitch workaroung

### DIFF
--- a/AFNetworking/AFURLResponseSerialization.m
+++ b/AFNetworking/AFURLResponseSerialization.m
@@ -201,6 +201,13 @@ static NSString * AFStringFromIndexSet(NSIndexSet *indexSet) {
     if (![self validateResponse:(NSHTTPURLResponse *)response data:data error:error]) {
         return nil;
     }
+    
+    if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
+        NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
+        if (httpResponse.statusCode == 204) {
+            return nil;
+        }
+    }
 
     // Workaround for behavior of Rails to return a single space for `head :ok` (a workaround for a bug in Safari), which is not interpreted as valid input by NSJSONSerialization.
     // See https://github.com/rails/rails/issues/1742


### PR DESCRIPTION
This issue has beed fixed in stable rails version. I do think that maintaining this workaround is no longer necessary.

The current implementation causes trouble when server returns empty body, 204 NO_CONTENT (iOS 6 and 7):
1. data is not nil, but zero length (_NSZeroData)
2. responseString is zero length (@"")
3. condition is triggered
4. inner data is NSConcreteMutableData
5. deserialization fails

My fix solves that issue.
