### PR TITLE
Updated AFHTTPRequestOperation +canProcessRequest: method

### DIFF
--- a/AFNetworking/AFHTTPRequestOperation.m
+++ b/AFNetworking/AFHTTPRequestOperation.m
@@ -315,11 +315,8 @@ static void AFSwizzleClassMethodWithClassAndSelectorUsingBlock(Class klass, SEL 
 }
 
 + (BOOL)canProcessRequest:(NSURLRequest *)request {
-    if ([[self class] isEqual:[AFHTTPRequestOperation class]]) {
-        return YES;
-    }
-
-    return [[self acceptableContentTypes] intersectsSet:AFContentTypesFromHTTPHeader([request valueForHTTPHeaderField:@"Accept"])];
+    NSSet *contentTypes = AFContentTypesFromHTTPHeader([request valueForHTTPHeaderField:@"Accept"]);
+    return !contentTypes || ![self acceptableContentTypes] || [[self acceptableContentTypes] intersectsSet:contentTypes];
 }
 
 @end


### PR DESCRIPTION
I assume we should handle nil acceptableContentTypes and nil HTTP "Accept" header content types here. As of now, if either of them is nil, NO will be returned, and I guess that's not what we want, right?
