### PR TITLE
Fixes reachability

### DIFF
--- a/AFNetworking/AFNetworkReachabilityManager.m
+++ b/AFNetworking/AFNetworkReachabilityManager.m
@@ -179,15 +179,12 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {
     SCNetworkReachabilityContext context = {0, (__bridge void *)callback, AFNetworkReachabilityRetainCallback, AFNetworkReachabilityReleaseCallback, NULL};
     SCNetworkReachabilitySetCallback(self.networkReachability, AFNetworkReachabilityCallback, &context);
 
-    // Network reachability monitoring does not establish a baseline for IP addresses as it does for hostnames, so if the base URL host is an IP address, the initial reachability callback is manually triggered.
-//    if (AFURLHostIsIPAddress(self.baseURL)) {
-//        SCNetworkReachabilityFlags flags;
-//        SCNetworkReachabilityGetFlags(self.networkReachability, &flags);
-//        dispatch_async(dispatch_get_main_queue(), ^{
-//            AFNetworkReachabilityStatus status = AFNetworkReachabilityStatusForFlags(flags);
-//            callback(status);
-//        });
-//    }
+    SCNetworkReachabilityFlags flags;
+    SCNetworkReachabilityGetFlags(self.networkReachability, &flags);
+    dispatch_async(dispatch_get_main_queue(), ^{
+        AFNetworkReachabilityStatus status = AFNetworkReachabilityStatusForFlags(flags);
+        callback(status);
+    });
 
     SCNetworkReachabilityScheduleWithRunLoop(self.networkReachability, CFRunLoopGetMain(), kCFRunLoopCommonModes);
 }


### PR DESCRIPTION
The reachability code is not working due to 2 issue:
- the startMonitoring will call stopMonitoring which will release the networkReachability, which then cause the monitoring not start at all. (#1304)
- the networkReachabilityStatus is UNKNOWN after starting monitoring, it will only change when the reachability change. it seems simpler to just always check for reachability status when start monitoring?
