### PR TITLE
AFJSONRequestSerializer: nil parameters in requestBySerializingRequest: ...

### DIFF
--- a/AFNetworking/AFURLRequestSerialization.m
+++ b/AFNetworking/AFURLRequestSerialization.m
@@ -938,6 +938,10 @@ typedef NS_ENUM(NSUInteger, AFHTTPBodyPartReadPhase) {
     [self.HTTPRequestHeaders enumerateKeysAndObjectsUsingBlock:^(id field, id value, BOOL *stop) {
         [mutableRequest setValue:value forHTTPHeaderField:field];
     }];
+    
+    if (!parameters) {
+        return mutableRequest;
+    }
 
     NSString *charset = (__bridge NSString *)CFStringConvertEncodingToIANACharSetName(CFStringConvertNSStringEncodingToEncoding(NSUTF8StringEncoding));
 


### PR DESCRIPTION
AFURLRequestSerialization does stop serializing when parameters are nil.
AFJSONRequestSerialization now does the same (and avoids crash when parameters is nil).
