### PR TITLE
[2.0] Default Security Policy should not allow invalid ssl certificates (and unit test updates)

### DIFF
--- a/AFNetworking/AFSecurityPolicy.m
+++ b/AFNetworking/AFSecurityPolicy.m
@@ -147,7 +147,6 @@ static NSArray * AFPublicKeyTrustChainForServerTrust(SecTrustRef serverTrust) {
 + (instancetype)defaultPolicy {
     AFSecurityPolicy *securityPolicy = [[self alloc] init];
     securityPolicy.SSLPinningMode = AFSSLPinningModeNone;
-    securityPolicy.allowInvalidCertificates = YES;
 
     return securityPolicy;
 }

--- a/Tests/Podfile.lock
+++ b/Tests/Podfile.lock
@@ -1,23 +1,15 @@
 PODS:
   - AFNetworking (2.0.0-RC3):
     - AFNetworking/Core
-    - AFNetworking/NSURLConnection
-    - AFNetworking/NSURLSession
-    - AFNetworking/Reachability
-    - AFNetworking/Security
-    - AFNetworking/Serialization
-    - AFNetworking/UIKit+AFNetworking
   - AFNetworking/Core (2.0.0-RC3):
     - AFNetworking/NSURLConnection
     - AFNetworking/Reachability
     - AFNetworking/Security
     - AFNetworking/Serialization
   - AFNetworking/NSURLConnection (2.0.0-RC3)
-  - AFNetworking/NSURLSession (2.0.0-RC3)
   - AFNetworking/Reachability (2.0.0-RC3)
   - AFNetworking/Security (2.0.0-RC3)
   - AFNetworking/Serialization (2.0.0-RC3)
-  - AFNetworking/UIKit+AFNetworking (2.0.0-RC3)
   - Expecta (0.2.2)
   - OCMock (2.1.1)
 
@@ -31,7 +23,7 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  AFNetworking: cf3c1f1019abe765bd0ec041651dd1441c950cb6
+  AFNetworking: 2c32044b6aeb1f022e462bcb73cf6f2679f0d1ff
   Expecta: 99adbb2e366a02796477523bfd426143350d9caf
   OCMock: 79212e5e328378af5cfd6edb5feacfd6c49cd8a3
 

--- a/Tests/Tests/AFSecurityPolicyTests.m
+++ b/Tests/Tests/AFSecurityPolicyTests.m
@@ -150,36 +150,19 @@ static SecCertificateRef AFUTHTTPBinOrgCertificate() {
 - (void)testDefaultPolicyIsSetToAFSSLPinningModePublicKey {
     AFSecurityPolicy *policy = [AFSecurityPolicy defaultPolicy];
 
-    XCTAssert(policy.SSLPinningMode==AFSSLPinningModePublicKey, @"HTTPBin.org default policy is not set to AFSSLPinningModePublicKey.");
+    XCTAssert(policy.SSLPinningMode==AFSSLPinningModeNone, @"Default policy is not set to AFSSLPinningModePublicKey.");
 }
 
 - (void)testDefaultPolicyIsSetToNotAllowInvalidSSLCertificates {
     AFSecurityPolicy *policy = [AFSecurityPolicy defaultPolicy];
 
-    XCTAssert(policy.allowInvalidCertificates == NO, @"HTTPBin.org default policy should not allow invalid ssl certificates");
+    XCTAssert(policy.allowInvalidCertificates == NO, @"Default policy should not allow invalid ssl certificates");
 }
 
-- (void)testDebugPolicyContainsHTTPBinOrgCertificate {
-    AFSecurityPolicy *policy = [AFSecurityPolicy debugPolicy];
-    SecCertificateRef cert = AFUTHTTPBinOrgCertificate();
-    NSData *certData = (__bridge NSData *)(SecCertificateCopyData(cert));
-    NSInteger index = [policy.pinnedCertificates indexOfObjectPassingTest:^BOOL(NSData *data, NSUInteger idx, BOOL *stop) {
-        return [data isEqualToData:certData];
-    }];
-
-    XCTAssert(index != NSNotFound, @"HTTPBin.org certificate not found in the default certificates");
-}
-
-- (void)testDebugPolicyIsSetToAFSSLPinningModePublicKey {
-    AFSecurityPolicy *policy = [AFSecurityPolicy debugPolicy];
-
-    XCTAssert(policy.SSLPinningMode == AFSSLPinningModeNone, @"HTTPBin.org debug policy is not set to AFSSLPinningModeNone.");
-}
-
-- (void)testDebugPolicyIsSetToAllowInvalidSSLCertificates {
-    AFSecurityPolicy *policy = [AFSecurityPolicy debugPolicy];
-
-    XCTAssert(policy.allowInvalidCertificates == YES, @"HTTPBin.org debug policy should allow invalid ssl certificates");
+- (void)testPolicyWithPinningModeIsSetToNotAllowInvalidSSLCertificates {
+    AFSecurityPolicy *policy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModeNone];
+    
+    XCTAssert(policy.allowInvalidCertificates == NO, @"policyWithPinningMode: should not allow invalid ssl certificates by default.");
 }
 
 @end


### PR DESCRIPTION
The latest updates to AFSecurityPolicy broke the unit tests, which are fixed with this pull.

In addition, I believe `defaultPolicy` should NOT allow invalid certificates by default, so I changed that setting. Would like to know if that was just an oversight and added in by mistake, or you believe that should in fact be the default.
