### PR TITLE
Fixes/deployment target

### DIFF
--- a/AFNetworking.podspec
+++ b/AFNetworking.podspec
@@ -44,8 +44,8 @@ Pod::Spec.new do |s|
   end
 
   s.subspec 'NSURLSession' do |ss|
-    s.ios.deployment_target = '7.0'
-    s.osx.deployment_target = '10.9'
+    ss.ios.deployment_target = '7.0'
+    ss.osx.deployment_target = '10.9'
 
     ss.source_files = 'AFNetworking/AFURLSessionManager.{h,m}', 'AFNetworking/AFHTTPSessionManager.{h,m}'
   end


### PR DESCRIPTION
This fixes a typo so that the 7.0/10.9 requirement doesn't apply to the entire spec, but only the subspec.
