### PR TITLE
`preferred_dependency` has been renamed to `default_subspec`

### DIFF
--- a/AFNetworking.podspec
+++ b/AFNetworking.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '6.0'
   s.osx.deployment_target = '10.8'
 
-  s.preferred_dependency = 'Core'
+  s.default_subspec = 'Core'
 
   s.subspec 'Core' do |ss|
     ss.source_files = 'AFNetworking'


### PR DESCRIPTION
`preferred_dependency` has been renamed to `default_subspec` in the latest versions of CocoaPods.
