### PR TITLE
Updated ssl pinning mode to have default pinned certificates by default

### DIFF
--- a/AFNetworking/AFSecurityPolicy.m
+++ b/AFNetworking/AFSecurityPolicy.m
@@ -154,6 +154,7 @@ static NSArray * AFPublicKeyTrustChainForServerTrust(SecTrustRef serverTrust) {
 + (instancetype)policyWithPinningMode:(AFSSLPinningMode)pinningMode {
     AFSecurityPolicy *securityPolicy = [[self alloc] init];
     securityPolicy.SSLPinningMode = pinningMode;
+    [securityPolicy setPinnedCertificates:[self defaultPinnedCertificates]];
 
     return securityPolicy;
 }

--- a/Example/Classes/AFAppDotNetAPIClient.m
+++ b/Example/Classes/AFAppDotNetAPIClient.m
@@ -31,6 +31,7 @@ static NSString * const AFAppDotNetAPIBaseURLString = @"https://alpha-api.app.ne
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         _sharedClient = [[AFAppDotNetAPIClient alloc] initWithBaseURL:[NSURL URLWithString:AFAppDotNetAPIBaseURLString]];
+        [_sharedClient setSecurityPolicy:[AFSecurityPolicy policyWithPinningMode:AFSSLPinningModePublicKey]];
     });
     
     return _sharedClient;

--- a/Tests/Tests/AFSecurityPolicyTests.m
+++ b/Tests/Tests/AFSecurityPolicyTests.m
@@ -165,4 +165,14 @@ static SecCertificateRef AFUTHTTPBinOrgCertificate() {
     XCTAssert(policy.allowInvalidCertificates == NO, @"policyWithPinningMode: should not allow invalid ssl certificates by default.");
 }
 
+- (void)testThatSSLPinningPolicyClassMethodContainsDefaultCertificates{
+    AFSecurityPolicy *policy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModePublicKey];
+    XCTAssertNotNil(policy.pinnedCertificates, @"Default certificate array should not be empty for SSL pinning mode policy");
+}
+
+- (void)testThatDefaultPinningPolicyClassMethodContainsNoDefaultCertificates{
+    AFSecurityPolicy *policy = [AFSecurityPolicy defaultPolicy];
+    XCTAssertNil(policy.pinnedCertificates, @"Default certificate array should be empty for default policy.");
+}
+
 @end


### PR DESCRIPTION
Referencing #1385

Looks the there is method to load default pinned certificates, but its never actually called anywhere.

I've got a PR here to set the default pinned certificates when you use the `policyWithPinningMode:` method. It could also go in the `init` method if we wanted them automatically pinned for every method, but I'm not sure that is the best option.

I added two additional unit tests to verify the state of the pinned certificate array when creating a policy, and also updated the example project to use pinning.
