### PR TITLE
Fixed exposed private methods in UIProgressView category. Fixes #1394.

### DIFF
--- a/UIKit+AFNetworking/UIProgressView+AFNetworking.m
+++ b/UIKit+AFNetworking/UIProgressView+AFNetworking.m
@@ -39,18 +39,18 @@ static char kAFUploadProgressAnimated;
 static char kAFDownloadProgressAnimated;
 
 @interface AFURLConnectionOperation (_UIProgressView)
-@property (readwrite, nonatomic, copy) void (^af_uploadProgress)(NSUInteger bytes, long long totalBytes, long long totalBytesExpected);
+@property (readwrite, nonatomic, copy) void (^uploadProgress)(NSUInteger bytes, long long totalBytes, long long totalBytesExpected);
 @property (readwrite, nonatomic, assign, setter = af_setUploadProgressAnimated:) BOOL af_uploadProgressAnimated;
 
-@property (readwrite, nonatomic, copy) void (^af_downloadProgress)(NSUInteger bytes, long long totalBytes, long long totalBytesExpected);
+@property (readwrite, nonatomic, copy) void (^downloadProgress)(NSUInteger bytes, long long totalBytes, long long totalBytesExpected);
 @property (readwrite, nonatomic, assign, setter = af_setDownloadProgressAnimated:) BOOL af_downloadProgressAnimated;
 @end
 
 @implementation AFURLConnectionOperation (_UIProgressView)
-@dynamic af_uploadProgress;
+@dynamic uploadProgress; // Implemented in AFURLConnectionOperation
 @dynamic af_uploadProgressAnimated;
 
-@dynamic af_downloadProgress;
+@dynamic downloadProgress; // Implemented in AFURLConnectionOperation
 @dynamic af_downloadProgressAnimated;
 @end
 
@@ -104,7 +104,7 @@ static char kAFDownloadProgressAnimated;
                                         animated:(BOOL)animated
 {
     __weak __typeof(self)weakSelf = self;
-    void (^original)(NSUInteger bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite) = [operation.af_uploadProgress copy];
+    void (^original)(NSUInteger bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite) = [operation.uploadProgress copy];
     [operation setUploadProgressBlock:^(NSUInteger bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite) {
         if (original) {
             original(bytesWritten, totalBytesWritten, totalBytesExpectedToWrite);
@@ -122,7 +122,7 @@ static char kAFDownloadProgressAnimated;
                                           animated:(BOOL)animated
 {
     __weak __typeof(self)weakSelf = self;
-    void (^original)(NSUInteger bytesRead, long long totalBytesRead, long long totalBytesExpectedToRead) = [operation.af_downloadProgress copy];
+    void (^original)(NSUInteger bytesRead, long long totalBytesRead, long long totalBytesExpectedToRead) = [operation.downloadProgress copy];
     [operation setDownloadProgressBlock:^(NSUInteger bytesRead, long long totalBytesRead, long long totalBytesExpectedToRead) {
         if (original) {
             original(bytesRead, totalBytesRead, totalBytesExpectedToRead);


### PR DESCRIPTION
Fixed names of exposed private methods `downloadProgress` and `uploadProgress`.

I couldn't make sense of the extensions to AFURLConnectionOperation `af_uploadProgressAnimated` and `af_downloadProgressAnimated` so I left them unchanged. Maybe they can be removed?
