### PR TITLE
Fix for AFNetworking.h left out of cocoapod for AFNetworking. Also Needed conditionalization of Session includes.

### DIFF
--- a/AFNetworking.podspec
+++ b/AFNetworking.podspec
@@ -13,6 +13,8 @@ Pod::Spec.new do |s|
 
   s.public_header_files = 'AFNetworking/*.h'
 
+  s.source_files = 'AFNetworking/AFNetworking.h'
+  
   s.subspec 'Serialization' do |ss|
     ss.source_files = 'AFNetworking/AFURL{Request,Response}Serialization.{h,m}'
     ss.ios.frameworks = 'MobileCoreServices', 'CoreGraphics'

--- a/AFNetworking/AFNetworking.h
+++ b/AFNetworking/AFNetworking.h
@@ -35,6 +35,10 @@
     #import "AFHTTPRequestOperation.h"
     #import "AFHTTPRequestOperationManager.h"
 
+#if ( ( defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 1090) || \
+      ( defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && __IPHONE_OS_VERSION_MIN_REQUIRED >= 70000 ) )
     #import "AFURLSessionManager.h"
     #import "AFHTTPSessionManager.h"
+#endif
+
 #endif /* _AFNETWORKING_ */


### PR DESCRIPTION
AFNetworking.h was left out of the cocoapodspec.  AFNetworking.h was always including the Session based includes but they are only valid for OS X 10.9+ and iOS 7.0+ so added conditionalized imports for them.

(note related issue:  https://github.com/AFNetworking/AFNetworking/issues/1378)
