### PR TITLE
1.x: Ensure only ASCII characters are used in the User-Agent header.

### DIFF
--- a/AFNetworking/AFURLConnectionOperation.m
+++ b/AFNetworking/AFURLConnectionOperation.m
@@ -623,8 +623,7 @@ willSendRequestForAuthenticationChallenge:(NSURLAuthenticationChallenge *)challe
         switch (self.SSLPinningMode) {
             case AFSSLPinningModePublicKey: {
                 NSArray *pinnedPublicKeys = [self.class pinnedPublicKeys];
-                NSAssert([pinnedPublicKeys count] > 0, @"AFSSLPinningModePublicKey needs at least one key file in the application bundle");
-
+                
                 for (id publicKey in trustChain) {
                     for (id pinnedPublicKey in pinnedPublicKeys) {
                         if (AFSecKeyIsEqualToKey((__bridge SecKeyRef)publicKey, (__bridge SecKeyRef)pinnedPublicKey)) {
@@ -639,7 +638,6 @@ willSendRequestForAuthenticationChallenge:(NSURLAuthenticationChallenge *)challe
                 break;
             }
             case AFSSLPinningModeCertificate: {
-                NSAssert([[self.class pinnedCertificates] count] > 0, @"AFSSLPinningModeCertificate needs at least one certificate file in the application bundle");
                 for (id serverCertificateData in trustChain) {
                     if ([[self.class pinnedCertificates] containsObject:serverCertificateData]) {
                         NSURLCredential *credential = [NSURLCredential credentialForTrust:serverTrust];


### PR DESCRIPTION
The charset for HTTP headers has to be ASCII at best
and is ill defined at worst.

My Application has a Bundle Name with Umlauts in it
which results in messy Webserver log files due to the
"strange" engoding of the App name.
See http://filez.foxel.org/image/0c3a2n0N1H2Y for example

To me it seems, that AFNetworking is meant to transcode the
App name to ASCII but the implementation is lacking and thus
only encodes to Latin1/ISO8859-1.
This patch - although not tested with Asian scripts - should
result in User-Agent strings always beeing ASCII while remaining
mostly unchanged.

So `Überland/0.16.27` becomes `Uberland/0.16.27` which is much
more standards compliant.
