### PR TITLE
1.x: Give a human readable Warning when SSL Pinning fails.

### DIFF
--- a/AFNetworking/AFURLConnectionOperation.m
+++ b/AFNetworking/AFURLConnectionOperation.m
@@ -634,6 +634,7 @@ willSendRequestForAuthenticationChallenge:(NSURLAuthenticationChallenge *)challe
                     }
                 }
                 
+                NSLog(@"Error: Unknown Public Key during Pinning operation");
                 [[challenge sender] cancelAuthenticationChallenge:challenge];
                 break;
             }
@@ -646,6 +647,7 @@ willSendRequestForAuthenticationChallenge:(NSURLAuthenticationChallenge *)challe
                     }
                 }
                 
+                NSLog(@"Error: Unknown Certificate during Pinning operation");
                 [[challenge sender] cancelAuthenticationChallenge:challenge];
                 break;
             }


### PR DESCRIPTION
Encryption, SSL and Certificates are hard to gasp.
And generally errors like "The operation couldn’t be completed.
(NSURLErrorDomain error -1012.)" are hard to make sense of.

I subscribe to the theory that if you enable SSL Pinning
and it fails, something went horribly wrong

a) you misconfigured the thing, a certificate expired or some other developer screw up.
b) your application is unter attack.

Both secenarios warrant a clear and obvious message in the
log files. This breaks with the "no logging" approach in
AFURLConnectionOperation and maybe an `NSAssert` would
be better but if SSP pinning fails something fishy is going
on and we should leave some obvious evidence about this.
