### PR TITLE
Fix up format

### DIFF
--- a/AFNetworking/AFURLResponseSerialization.m
+++ b/AFNetworking/AFURLResponseSerialization.m
@@ -60,7 +60,7 @@ extern NSString * const AFNetworkingOperationFailingURLResponseErrorKey;
     if (response && [response isKindOfClass:[NSHTTPURLResponse class]]) {
         if (self.acceptableStatusCodes && ![self.acceptableStatusCodes containsIndex:(NSUInteger)response.statusCode]) {
             NSDictionary *userInfo = @{
-                                       NSLocalizedDescriptionKey: [NSString stringWithFormat:NSLocalizedStringFromTable(@"Request failed: %@ (%d), got %d", @"AFNetworking", nil), [NSHTTPURLResponse localizedStringForStatusCode:response.statusCode], response.statusCode],
+                                       NSLocalizedDescriptionKey: [NSString stringWithFormat:NSLocalizedStringFromTable(@"Request failed: %@ (%d)", @"AFNetworking", nil), [NSHTTPURLResponse localizedStringForStatusCode:response.statusCode], response.statusCode],
                                        NSURLErrorFailingURLErrorKey:[response URL],
                                        AFNetworkingOperationFailingURLResponseErrorKey: response
                                        };


### PR DESCRIPTION
Remove leftover portion of error message, where format string uses
an argument that no longer is passed, causing the error message to
have a random number added to it:

```
Request failed: %@ (%d), got %d
```

The ", got %d" portion is a left-over from a previous iteration of
the message, and the value it expects is now the one provided in
the parentesis before it.
