### PR TITLE
Change `AFHTTPRequestOperation -(id)initWithCoder:` to call the `super` implementation

### DIFF
--- a/AFNetworking/AFHTTPRequestOperation.m
+++ b/AFNetworking/AFHTTPRequestOperation.m
@@ -123,9 +123,7 @@ static dispatch_group_t http_request_operation_completion_group() {
 #pragma mark - NSCoding
 
 - (id)initWithCoder:(NSCoder *)aDecoder {
-    NSURLRequest *request = [aDecoder decodeObjectForKey:@"request"];
-
-    self = [self initWithRequest:request];
+    self = [super initWithCoder:aDecoder];
     if (!self) {
         return nil;
     }


### PR DESCRIPTION
This change allows an instance of AFHTTPRequestOperation to be more completely archived.
