### PR TITLE
Add image response serializer to UIButton+AFNetworking. Fixes #1447.

### DIFF
--- a/UIKit+AFNetworking/UIButton+AFNetworking.m
+++ b/UIKit+AFNetworking/UIButton+AFNetworking.m
@@ -99,6 +99,7 @@ static char kAFBackgroundImageRequestOperationKey;
 
     __weak __typeof(self)weakSelf = self;
     self.af_imageRequestOperation = [[AFHTTPRequestOperation alloc] initWithRequest:urlRequest];
+    self.af_imageRequestOperation.responseSerializer = [AFImageResponseSerializer serializer];
     [self.af_imageRequestOperation setCompletionBlockWithSuccess:^(AFHTTPRequestOperation *operation, id responseObject) {
         __strong __typeof(weakSelf)strongSelf = weakSelf;
         if ([[urlRequest URL] isEqual:[operation.request URL]]) {


### PR DESCRIPTION
Without this fix, the responseObject on the image request is nil and the image does not get updated.
