### PR TITLE
Fix completion blocks call order when executing batch of requests

### DIFF
--- a/AFNetworking/AFHTTPRequestOperation.m
+++ b/AFNetworking/AFHTTPRequestOperation.m
@@ -68,6 +68,10 @@ static dispatch_group_t http_request_operation_completion_group() {
 #pragma clang diagnostic ignored "-Warc-retain-cycles"
 #pragma clang diagnostic ignored "-Wgnu"
     self.completionBlock = ^{
+        if (self.completionGroup)
+        {
+            dispatch_group_enter(self.completionGroup);
+        }
         dispatch_async(http_request_operation_processing_queue(), ^{
             if (self.error) {
                 if (failure) {
@@ -94,7 +98,11 @@ static dispatch_group_t http_request_operation_completion_group() {
                         });
                     }
                 }
-            }            
+            }
+            if (self.completionGroup)
+            {
+                dispatch_group_leave(self.completionGroup);
+            }
         });
     };
 #pragma clang diagnostic pop


### PR DESCRIPTION
Fixes #1453. Completion block for group of requests should be called after all completion blocks have finished executing.

I also added a test, that ensures blocks are executed in correct order.
