### PR TITLE
Keep public keys in sync when pinned certificates is set to nil

### DIFF
--- a/AFNetworking/AFSecurityPolicy.m
+++ b/AFNetworking/AFSecurityPolicy.m
@@ -172,6 +172,7 @@ static NSArray * AFPublicKeyTrustChainForServerTrust(SecTrustRef serverTrust) {
         self.pinnedPublicKeys = [NSArray arrayWithArray:mutablePinnedPublicKeys];
     } else {
         self.pinnedCertificates = nil;
+        self.pinnedPublicKeys = nil;
     }
 }
 


### PR DESCRIPTION
Otherwise this could happen:

``` objective-c
[policy setPinnedCertificates:@[certificate]];
[policy setPinnedCertificates:nil];
```

Now the public certificate would still be set from the previous pinned certificate and we could have an inconsistent internal state.
