### PR TITLE
Correct encoding for AFJSONResponseSerializer 

### DIFF
--- a/AFNetworking/AFURLResponseSerialization.m
+++ b/AFNetworking/AFURLResponseSerialization.m
@@ -173,7 +173,18 @@ extern NSString * const AFNetworkingOperationFailingURLResponseErrorKey;
 
     // Workaround for behavior of Rails to return a single space for `head :ok` (a workaround for a bug in Safari), which is not interpreted as valid input by NSJSONSerialization.
     // See https://github.com/rails/rails/issues/1742
-    NSString *responseString = [[NSString alloc] initWithData:data encoding:self.stringEncoding];
+    
+    NSStringEncoding encoding = self.stringEncoding;
+    
+    if (response.textEncodingName) {
+        CFStringEncoding aEncoding = CFStringConvertIANACharSetNameToEncoding((CFStringRef) response.textEncodingName);
+        if (aEncoding != kCFStringEncodingInvalidId) {
+            encoding = CFStringConvertEncodingToNSStringEncoding(aEncoding);
+        }
+    }
+    
+    
+    NSString *responseString = [[NSString alloc] initWithData:data encoding:encoding];
     if (responseString && ![responseString isEqualToString:@" "]) {
         // Workaround for a bug in NSJSONSerialization when Unicode character escape codes are used instead of the actual character
         // See http://stackoverflow.com/a/12843465/157142


### PR DESCRIPTION
Convert the data to string using the correct encoding, then convert to data using UTF-8 to avoid http://stackoverflow.com/a/12843465/157142. #1476 
