### PR TITLE
fix to setBackgroundImageForState works correctly.

### DIFF
--- a/UIKit+AFNetworking/UIButton+AFNetworking.m
+++ b/UIKit+AFNetworking/UIButton+AFNetworking.m
@@ -152,7 +152,7 @@ static char kAFBackgroundImageRequestOperationKey;
 
     __weak __typeof(self)weakSelf = self;
     self.af_backgroundImageRequestOperation = [[AFHTTPRequestOperation alloc] initWithRequest:urlRequest];
-    self.af_imageRequestOperation.responseSerializer = [AFImageResponseSerializer serializer];
+    self.af_backgroundImageRequestOperation.responseSerializer = [AFImageResponseSerializer serializer];
     [self.af_backgroundImageRequestOperation setCompletionBlockWithSuccess:^(AFHTTPRequestOperation *operation, id responseObject) {
         __strong __typeof(weakSelf)strongSelf = weakSelf;
         if ([[urlRequest URL] isEqual:[operation.request URL]]) {


### PR DESCRIPTION
It causes response serializer is set to af_imageRequestOperation instead of af_backgroundImageRequestOperation.
