### PR TITLE
Allow init and initWithSessionConfiguration: to work with AFHTTPSessionManager

### DIFF
--- a/AFNetworking/AFHTTPSessionManager.m
+++ b/AFNetworking/AFHTTPSessionManager.m
@@ -52,8 +52,16 @@
     return [[AFHTTPSessionManager alloc] initWithBaseURL:nil];
 }
 
+- (instancetype)init {
+    return [self initWithBaseURL:nil];
+}
+
 - (instancetype)initWithBaseURL:(NSURL *)url {
     return [self initWithBaseURL:url sessionConfiguration:nil];
+}
+
+- (instancetype)initWithSessionConfiguration:(NSURLSessionConfiguration *)configuration {
+    return [self initWithBaseURL:nil sessionConfiguration:configuration];
 }
 
 - (instancetype)initWithBaseURL:(NSURL *)url


### PR DESCRIPTION
Related to #1502

It turns out that these initializers can be used if we simply delegate to the other initializers.  No exception raising needed.
