### PR TITLE
[2.0] Fixing behavior if response is `nil`

### DIFF
--- a/UIKit+AFNetworking/UIImageView+AFNetworking.m
+++ b/UIKit+AFNetworking/UIImageView+AFNetworking.m
@@ -153,7 +153,7 @@ static char kAFResponseSerializerKey;
 
             [[[strongSelf class] af_sharedImageCache] cacheImage:responseObject forRequest:urlRequest];
         } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
-            if ([[urlRequest URL] isEqual:[operation.response URL]]) {
+            if ([[urlRequest URL] isEqual:[operation.request URL]]) {
                 if (failure) {
                     failure(urlRequest, operation.response, error);
                 }


### PR DESCRIPTION
Testing without internet connection, `operation.response` is `nil` and the `failure` block is not called. We can get the URL from the `operation.request` instead of `operation.response` (as done in the `success` block, a few lines above).

I don't know if this was occurring in 1.x, so maybe we need to change this on 1.x branch too.
