### PR TITLE
Let the UIWebView extension handle binary responses

### DIFF
--- a/UIKit+AFNetworking/UIWebView+AFNetworking.h
+++ b/UIKit+AFNetworking/UIWebView+AFNetworking.h
@@ -51,7 +51,7 @@
  
  @param request A URL request identifying the location of the content to load.
  @param progress A block object to be called when an undetermined number of bytes have been downloaded from the server. This block has no return value and takes three arguments: the number of bytes read since the last time the download progress block was called, the total bytes read, and the total bytes expected to be read during the request, as initially determined by the expected content size of the `NSHTTPURLResponse` object. This block may be called multiple times, and will execute on the main thread.
- @param success A block object to be executed when the request finishes loading successfully. This block has no return value and takes two arguments: the response, and the HTML string.
+ @param success A block object to be executed when the request finishes loading successfully. If this block returns a `NSString` the contents of that string will be placed in the web view. If it returns `nil`, the `NSData` results of the fetch operation will be put into the web view (accoring to the returned MIME-type), letting the UIWebView itself detect file encoding.
  @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes a single argument: the error that occurred.
  */
 - (void)loadRequest:(NSURLRequest *)request

--- a/UIKit+AFNetworking/UIWebView+AFNetworking.m
+++ b/UIKit+AFNetworking/UIWebView+AFNetworking.m
@@ -106,7 +106,12 @@ static char kAFHTTPRequestOperationKey;
     [self.af_HTTPRequestOperation setDownloadProgressBlock:progress];
     [self.af_HTTPRequestOperation setCompletionBlockWithSuccess:^(AFHTTPRequestOperation *operation, id __unused responseObject) {
         NSString *HTML = success ? success(operation.response, operation.responseString) : operation.responseString;
-        [weakSelf loadHTMLString:HTML baseURL:[operation.response URL]];
+        NSString *mimeType = [[operation.response allHeaderFields] objectForKey:@"Content-Type"];
+        if (HTML == nil || [mimeType isEqual:@"application/rtf"]) {
+            [weakSelf loadData:operation.responseData MIMEType:mimeType textEncodingName:nil baseURL:[operation.response URL]];
+        } else {
+            [weakSelf loadHTMLString:HTML baseURL:[operation.response URL]];
+        }
     } failure:^(AFHTTPRequestOperation * __unused operation, NSError *error) {
         if (failure) {
             failure(error);


### PR DESCRIPTION
As I wrote about in #1499, the extension to `UIWebView`, `loadRequest:progress:success:failure:` seems to not handle binary responses very well. After looking a little bit closer at the code I'm now submitting this patch, which at least does what I want in my app. The new interface for the `success:` callback is now changed to try to load the response with `UIWebView loadData:MIMEType:textEncodingName:baseURL:` when a `nil` is returned.

I've also edited the docstring of `loadRequest:progress:success:failure:` to mention that any returned string will be entered to the `UIWebView` as HTML.

One caveat though: `.RTF` files are returned as `NSString`'s in the `operation.responseString` property in the code, and I'm not familiar enough with the rest of the code base to handle that case very gracefully. For now, I simply added a clause to the `if` statement that checks the result of the `success` / `operation.responseString` to crudely look for responses of MIME-type `'application/rtf'` and force them to enter the code path where binary values are handled. I'm aware that this isn't the most flexible nor elegant way of handling this case, maybe someone have a better suggestion?

Secondly I wasn't able to get the tests to run on my setup so I hope I'm not missing a test somewhere. I had a quick look but couldn't find any directly related to the `UIWebView` extensions, so I submitted anyways.
