### PR TITLE
Allow nesting of batch operations when operation count is zero

### DIFF
--- a/AFNetworking/AFURLConnectionOperation.m
+++ b/AFNetworking/AFURLConnectionOperation.m
@@ -482,10 +482,6 @@ static inline BOOL AFStateTransitionIsValid(AFOperationState fromState, AFOperat
                         progressBlock:(void (^)(NSUInteger numberOfFinishedOperations, NSUInteger totalNumberOfOperations))progressBlock
                       completionBlock:(void (^)(NSArray *operations))completionBlock
 {
-    if (!operations || [operations count] == 0) {
-        return 0;
-    }
-
     __block dispatch_group_t group = dispatch_group_create();
     NSBlockOperation *batchedOperation = [NSBlockOperation blockOperationWithBlock:^{
         dispatch_group_notify(group, dispatch_get_main_queue(), ^{
@@ -525,8 +521,12 @@ static inline BOOL AFStateTransitionIsValid(AFOperationState fromState, AFOperat
         dispatch_group_enter(group);
         [batchedOperation addDependency:operation];
     }
-
-    return [operations arrayByAddingObject:batchedOperation];
+    
+    if (!operations || [operations count] == 0) {
+        return @[batchedOperation];
+    } else {
+        return [operations arrayByAddingObject:batchedOperation];
+    }
 }
 
 #pragma mark - NSURLConnectionDelegate


### PR DESCRIPTION
In some of our projects we nest our batch operations, for example:

``` objective-c
NSOperationQueue *uploadQueue = [[NSOperationQueue alloc] init];
NSArray *groupOneBatch = [AFURLConnectionOperation batchOfRequestOperations:groupOneOperations progressBlock:^(NSUInteger numberOfFinishedOperations, NSUInteger totalNumberOfOperations) {
    // Do something with progress
} completionBlock:^(NSArray *operations) {
    NSArray *groupTwoBatch = [AFURLConnectionOperation batchOfRequestOperations:groupTwoOperations progressBlock:^(NSUInteger numberOfFinishedOperations, NSUInteger totalNumberOfOperations) {
        // Do something with progress
    } completionBlock:^(NSArray *operations) {
        // All uploads complete
    }];
    [uploadQueue addOperations:groupTwoBatch waitUntilFinished:YES];
}];
[uploadQueue addOperations:groupOneBatch waitUntilFinished:YES];
```

If `[groupOneOperations count] == 0` then we can move on to `groupTwoOperations`

Closes #1493 Handle batch operations of size zero
