### PR TITLE
Use AFHTTPResponseSerializer for AFHTTPRequestOperation

### DIFF
--- a/AFNetworking/AFHTTPRequestOperation.m
+++ b/AFNetworking/AFHTTPRequestOperation.m
@@ -61,7 +61,7 @@ static dispatch_group_t http_request_operation_completion_group() {
         return nil;
     }
 
-    self.responseSerializer = [AFJSONResponseSerializer serializer];
+    self.responseSerializer = [AFHTTPResponseSerializer serializer];
 
     return self;
 }


### PR DESCRIPTION
For some reason the response serializer of AFHTTPRequestOperation defaults to AFJSONResponseSerializer. This forces MIME types to the json ones which prevents AFHTTPRequestOperation to be used for anything else (unless the serializer is explicitly set).

In my opinion AFHTTPRequestOperation should be "response neutral" i.e. allow any response by default and shouldn't be performing any response parsing by default, unless explicitly set. The choice of JSON over XML, binary data, image, etc. seems to be quite arbitrary here.
