### PR TITLE
Fixes an issue writing partial data to the output stream

### DIFF
--- a/AFNetworking/AFURLConnectionOperation.m
+++ b/AFNetworking/AFURLConnectionOperation.m
@@ -609,7 +609,7 @@ didReceiveResponse:(NSURLResponse *)response
 
             NSInteger numberOfBytesWritten = 0;
             while (totalNumberOfBytesWritten < (NSInteger)length) {
-                numberOfBytesWritten = [self.outputStream write:&dataBuffer[0] maxLength:length];
+                numberOfBytesWritten = [self.outputStream write:&dataBuffer[totalNumberOfBytesWritten] maxLength:(length - totalNumberOfBytesWritten)];
                 if (numberOfBytesWritten == -1) {
                     [self.connection cancel];
                     [self performSelector:@selector(connection:didFailWithError:) withObject:self.connection withObject:self.outputStream.streamError];


### PR DESCRIPTION
This will manifest in a way where you will get duplicate data because it will
write the same data again and again.
