### PR TITLE
Fixed refs to AFJSONSerializer -> AFJSONResponseSerializer

### DIFF
--- a/AFNetworking/AFURLResponseSerialization.h
+++ b/AFNetworking/AFURLResponseSerialization.h
@@ -101,9 +101,9 @@
 
 
 /**
- `AFJSONSerializer` is a subclass of `AFHTTPResponseSerializer` that validates and decodes JSON responses.
+ `AFJSONResponseSerializer` is a subclass of `AFHTTPResponseSerializer` that validates and decodes JSON responses.
 
- By default, `AFJSONSerializer` accepts the following MIME types, which includes the official standard, `application/json`, as well as other commonly-used types:
+ By default, `AFJSONResponseSerializer` accepts the following MIME types, which includes the official standard, `application/json`, as well as other commonly-used types:
 
  - `application/json`
  - `text/json`


### PR DESCRIPTION
https://github.com/AFNetworking/AFNetworking/wiki/AFNetworking-2.0-Migration-Guide also needs its references to this updated (example code won't work because of this), under `AFHTTPRequestOperation Example`. Unfortunately GitHub doesn't seem to allow pull requests for wikis, so I can't fix and pull request. :thumbsdown: 
