### PR TITLE
Removing .swp files from example

### DIFF
--- a/Example/AFNetworking Mac Example.xcodeproj/project.pbxproj
+++ b/Example/AFNetworking Mac Example.xcodeproj/project.pbxproj
@@ -7,8 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		7756506B18037FAB00A437A8 /* .AFURLSessionManager.h.swp in Resources */ = {isa = PBXBuildFile; fileRef = 7756505618037FAB00A437A8 /* .AFURLSessionManager.h.swp */; };
-		7756506C18037FAB00A437A8 /* .AFURLSessionManager.m.swp in Resources */ = {isa = PBXBuildFile; fileRef = 7756505718037FAB00A437A8 /* .AFURLSessionManager.m.swp */; };
 		7756506D18037FAB00A437A8 /* AFHTTPRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 7756505918037FAB00A437A8 /* AFHTTPRequestOperation.m */; };
 		7756506E18037FAB00A437A8 /* AFHTTPRequestOperationManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 7756505B18037FAB00A437A8 /* AFHTTPRequestOperationManager.m */; };
 		7756506F18037FAB00A437A8 /* AFHTTPSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 7756505D18037FAB00A437A8 /* AFHTTPSessionManager.m */; };
@@ -257,8 +255,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7756506C18037FAB00A437A8 /* .AFURLSessionManager.m.swp in Resources */,
-				7756506B18037FAB00A437A8 /* .AFURLSessionManager.h.swp in Resources */,
 				F8129C7115910B3E009BFE23 /* MainMenu.xib in Resources */,
 				B304CCE8177D58DD00F4FC85 /* adn.cer in Resources */,
 			);


### PR DESCRIPTION
Tiny change to fix breaking build of the Mac Example application, which was referencing some .swp files.
