### PR TITLE
Fix AFJSONRequestSerializer setting Content-Type to application/json

### DIFF
--- a/AFNetworking/AFURLRequestSerialization.m
+++ b/AFNetworking/AFURLRequestSerialization.m
@@ -1029,26 +1029,28 @@ typedef enum {
 {
     NSParameterAssert(request);
 
+    NSMutableURLRequest *mutableRequest;
+
     if ([self.HTTPMethodsEncodingParametersInURI containsObject:[[request HTTPMethod] uppercaseString]]) {
-        return [super requestBySerializingRequest:request withParameters:parameters error:error];
+        mutableRequest = [[super requestBySerializingRequest:request withParameters:parameters error:error] mutableCopy];
     }
+    else {
+        mutableRequest = [request mutableCopy];
 
-    NSMutableURLRequest *mutableRequest = [request mutableCopy];
+        [self.HTTPRequestHeaders enumerateKeysAndObjectsUsingBlock:^(id field, id value, BOOL * __unused stop) {
+            if (![request valueForHTTPHeaderField:field]) {
+                [mutableRequest setValue:value forHTTPHeaderField:field];
+            }
+        }];
 
-    [self.HTTPRequestHeaders enumerateKeysAndObjectsUsingBlock:^(id field, id value, BOOL * __unused stop) {
-        if (![request valueForHTTPHeaderField:field]) {
-            [mutableRequest setValue:value forHTTPHeaderField:field];
+        if (parameters) {
+            [mutableRequest setHTTPBody:[NSJSONSerialization dataWithJSONObject:parameters options:self.writingOptions error:error]];
         }
-    }];
-    
-    if (!parameters) {
-        return mutableRequest;
     }
 
     NSString *charset = (__bridge NSString *)CFStringConvertEncodingToIANACharSetName(CFStringConvertNSStringEncodingToEncoding(NSUTF8StringEncoding));
 
     [mutableRequest setValue:[NSString stringWithFormat:@"application/json; charset=%@", charset] forHTTPHeaderField:@"Content-Type"];
-    [mutableRequest setHTTPBody:[NSJSONSerialization dataWithJSONObject:parameters options:self.writingOptions error:error]];
 
     return mutableRequest;
 }

--- a/Tests/AFNetworking Tests.xcodeproj/project.pbxproj
+++ b/Tests/AFNetworking Tests.xcodeproj/project.pbxproj
@@ -31,6 +31,8 @@
 		29CBFC7A17DF6B200021AB75 /* httpbinorg_10242013.cer in Resources */ = {isa = PBXBuildFile; fileRef = 29CBFC7817DF6B200021AB75 /* httpbinorg_10242013.cer */; };
 		29CBFC8717DF74C60021AB75 /* ADNNetServerTrustChain in Resources */ = {isa = PBXBuildFile; fileRef = 29CBFC8617DF74C60021AB75 /* ADNNetServerTrustChain */; };
 		29CBFC8817DF74C60021AB75 /* ADNNetServerTrustChain in Resources */ = {isa = PBXBuildFile; fileRef = 29CBFC8617DF74C60021AB75 /* ADNNetServerTrustChain */; };
+		3286488D181F5BA500F35A4C /* AFURLRequestSerializationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3286488C181F5BA500F35A4C /* AFURLRequestSerializationTests.m */; };
+		3286488E181F5BA500F35A4C /* AFURLRequestSerializationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3286488C181F5BA500F35A4C /* AFURLRequestSerializationTests.m */; };
 		3D56634E3A564CEE86172413 /* libPods-osx.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 96A923755B00464187DEDBAF /* libPods-osx.a */; };
 		6D86BAA5C6174E98AE719CE9 /* libPods-ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 55E73C267F33406A9F92476C /* libPods-ios.a */; };
 /* End PBXBuildFile section */
@@ -81,6 +83,7 @@
 		29CBFC7817DF6B200021AB75 /* httpbinorg_10242013.cer */ = {isa = PBXFileReference; lastKnownFileType = file; path = httpbinorg_10242013.cer; sourceTree = "<group>"; };
 		29CBFC8617DF74C60021AB75 /* ADNNetServerTrustChain */ = {isa = PBXFileReference; lastKnownFileType = folder; path = ADNNetServerTrustChain; sourceTree = "<group>"; };
 		2B6D24F8E1B74E10A269E8B3 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		3286488C181F5BA500F35A4C /* AFURLRequestSerializationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFURLRequestSerializationTests.m; sourceTree = "<group>"; };
 		55E73C267F33406A9F92476C /* libPods-ios.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ios.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		96A923755B00464187DEDBAF /* libPods-osx.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-osx.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8C6F281174D2C6200B154D5 /* Icon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = Icon.png; path = ../Example/Icon.png; sourceTree = "<group>"; };
@@ -224,6 +227,7 @@
 				29CBFC3E17DF58000021AB75 /* AFHTTPSerializationTests.m */,
 				29CBFC3B17DF541F0021AB75 /* AFJSONSerializationTests.m */,
 				29CBFC5917DF61B30021AB75 /* AFSecurityPolicyTests.m */,
+				3286488C181F5BA500F35A4C /* AFURLRequestSerializationTests.m */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -435,6 +439,7 @@
 			files = (
 				29CBFC3917DF4F120021AB75 /* AFHTTPRequestOperationTests.m in Sources */,
 				29CBFC5A17DF61B30021AB75 /* AFSecurityPolicyTests.m in Sources */,
+				3286488D181F5BA500F35A4C /* AFURLRequestSerializationTests.m in Sources */,
 				29CBFC3F17DF58000021AB75 /* AFHTTPSerializationTests.m in Sources */,
 				29CBFC3C17DF541F0021AB75 /* AFJSONSerializationTests.m in Sources */,
 				2902D29C17DF4E3700C81C5A /* AFTestCase.m in Sources */,
@@ -447,6 +452,7 @@
 			files = (
 				29CBFC3A17DF4F120021AB75 /* AFHTTPRequestOperationTests.m in Sources */,
 				29CBFC5B17DF61B30021AB75 /* AFSecurityPolicyTests.m in Sources */,
+				3286488E181F5BA500F35A4C /* AFURLRequestSerializationTests.m in Sources */,
 				29CBFC4017DF58000021AB75 /* AFHTTPSerializationTests.m in Sources */,
 				29CBFC3D17DF541F0021AB75 /* AFJSONSerializationTests.m in Sources */,
 				2902D29D17DF4E3800C81C5A /* AFTestCase.m in Sources */,

--- a/Tests/Tests/AFURLRequestSerializationTests.m
+++ b/Tests/Tests/AFURLRequestSerializationTests.m
@@ -1,0 +1,25 @@
+//
+//  AFURLRequestSerializationTests.m
+//  AFNetworking Tests
+//
+//  Created by Travis Jeffery on 10/28/13.
+//  Copyright (c) 2013 AFNetworking. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import <AFNetworking/AFURLRequestSerialization.h>
+
+@interface AFURLRequestSerializationTests : XCTestCase
+
+@end
+
+@implementation AFURLRequestSerializationTests
+
+- (void)testThatJSONRequestSerializerReturnsRequestWithJSONContentType {
+    NSURLRequest *request = [[AFJSONRequestSerializer serializer] requestWithMethod:@"GET" URLString:@"http://google.com" parameters:nil];
+    NSString *contentType = [request valueForHTTPHeaderField:@"Content-Type"];
+    
+    XCTAssert([contentType hasPrefix:@"application/json"], @"Error Content-Type should be application/json but was: %@", contentType);
+}
+
+@end


### PR DESCRIPTION
The content-type was only being set in the else condition, so you'd have json requests with content-type: application/html.
