### PR TITLE
Subclass AFHTTPRequestOperationManager and AFHTTPSessionManager

### DIFF
--- a/AFNetworking/AFHTTPRequestOperationManager.m
+++ b/AFNetworking/AFHTTPRequestOperationManager.m
@@ -40,7 +40,7 @@
 @implementation AFHTTPRequestOperationManager
 
 + (instancetype)manager {
-    return [[AFHTTPRequestOperationManager alloc] initWithBaseURL:nil];
+    return [[[self class] alloc] initWithBaseURL:nil];
 }
 
 - (instancetype)initWithBaseURL:(NSURL *)url {

--- a/AFNetworking/AFHTTPSessionManager.m
+++ b/AFNetworking/AFHTTPSessionManager.m
@@ -49,7 +49,7 @@
 @implementation AFHTTPSessionManager
 
 + (instancetype)manager {
-    return [[AFHTTPSessionManager alloc] initWithBaseURL:nil];
+    return [[[self class] alloc] initWithBaseURL:nil];
 }
 
 - (instancetype)init {


### PR DESCRIPTION
It's easier to subclass AFHTTPRequestOperationManager and AFHTTPSessionManager if the `manager` method uses the current class type instead of a hardcoded one
