### PR TITLE
Remove deletion of all task delegates in URLSessionDidFinishEventsForBac...

### DIFF
--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -792,8 +792,6 @@ didBecomeDownloadTask:(NSURLSessionDownloadTask *)downloadTask
     if (self.didFinishEventsForBackgroundURLSession) {
         self.didFinishEventsForBackgroundURLSession(session);
     }
-   
-    [self removeAllDelegates];
 }
 
 #pragma mark - NSURLSessionDownloadDelegate


### PR DESCRIPTION
...kgroundURLSession:

Fixes issue #1579 

This should not be done because sometimes this method is called after waking the app up to
respond to authentication challenges and no tasks have completed yet.  It is not safe to
assume that all tasks are complete and the delegates should be removed.  Doing some
results in orphaned tasks without AF delegates to handle them.

Task delegates already get deleted after the URLSession:task:didCompleteWithError: call
which will be made for each task.
