### PR TITLE
About imageOrientation for inflatedImage

### DIFF
--- a/AFNetworking/AFURLResponseSerialization.m
+++ b/AFNetworking/AFURLResponseSerialization.m
@@ -516,7 +516,8 @@ static UIImage * AFInflatedImageFromResponseWithDataAtScale(NSHTTPURLResponse *r
     CGImageRef inflatedImageRef = CGBitmapContextCreateImage(context);
     CGContextRelease(context);
 
-    UIImage *inflatedImage = [[UIImage alloc] initWithCGImage:inflatedImageRef scale:scale orientation:UIImageOrientationUp];
+    UIImage *image = [UIImage imageWithData:data];
+    UIImage *inflatedImage = [[UIImage alloc] initWithCGImage:inflatedImageRef scale:scale orientation:image.imageOrientation];
     CGImageRelease(inflatedImageRef);
     CGImageRelease(imageRef);
 


### PR DESCRIPTION
Hi there,
just found a small issue. For some cases, the images took in landscape mode can't be display according to the correct orientation. Just figured out the reason is that these images are always set in "UIImageOrientationUp". Therefore, I did a little adjustment. Hope it could help. Thanks!!!

Allen
