### PR TITLE
NULL completionQueue shouldn't dispatch to the main queue

### DIFF
--- a/AFNetworking/AFURLConnectionOperation.h
+++ b/AFNetworking/AFURLConnectionOperation.h
@@ -181,7 +181,7 @@
 ///---------------------------------
 
 /**
- The dispatch queue for `completionBlock`. If `NULL` (default), the main queue is used.
+ The dispatch queue for `completionBlock`. If `NULL` a private background queue will be used. Defaults to the main queue.
  */
 @property (nonatomic, strong) dispatch_queue_t completionQueue;
 

--- a/AFNetworking/AFURLConnectionOperation.m
+++ b/AFNetworking/AFURLConnectionOperation.m
@@ -181,6 +181,8 @@ static inline BOOL AFStateTransitionIsValid(AFOperationState fromState, AFOperat
 
     self.securityPolicy = [AFSecurityPolicy defaultPolicy];
 
+    self.completionQueue = dispatch_get_main_queue();
+
     return self;
 }
 
@@ -214,16 +216,23 @@ static inline BOOL AFStateTransitionIsValid(AFOperationState fromState, AFOperat
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wgnu"
             dispatch_group_t group = strongSelf.completionGroup ?: url_request_operation_completion_group();
-            dispatch_queue_t queue = strongSelf.completionQueue ?: dispatch_get_main_queue();
+            dispatch_queue_t queue = strongSelf.completionQueue;
 #pragma clang diagnostic pop
 
-            dispatch_group_async(group, queue, ^{
-                block();
-            });
+            if (queue) {
+                dispatch_group_async(group, queue, ^{
+                    block();
+                });
 
-            dispatch_group_notify(group, queue, ^{
+                dispatch_group_notify(group, queue, ^{
+                    [strongSelf setCompletionBlock:nil];
+                });
+            } else {
+                dispatch_group_enter(group);
+                block();
                 [strongSelf setCompletionBlock:nil];
-            });
+                dispatch_group_leave(group);
+            }
         }];
     }
     [self.lock unlock];
@@ -511,9 +520,10 @@ static inline BOOL AFStateTransitionIsValid(AFOperationState fromState, AFOperat
             __strong __typeof(weakOperation)strongOperation = weakOperation;
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wgnu"
-            dispatch_queue_t queue = strongOperation.completionQueue ?: dispatch_get_main_queue();
+            dispatch_queue_t queue = strongOperation.completionQueue;
 #pragma clang diagnostic pop
-            dispatch_group_async(group, queue, ^{
+
+            dispatch_block_t block = ^{
                 if (originalCompletionBlock) {
                     originalCompletionBlock();
                 }
@@ -527,7 +537,15 @@ static inline BOOL AFStateTransitionIsValid(AFOperationState fromState, AFOperat
                 }
 
                 dispatch_group_leave(group);
-            });
+            };
+
+            if (queue) {
+                dispatch_group_async(group, queue, block);
+            } else {
+                dispatch_group_enter(group);
+                block();
+                dispatch_group_leave(group);
+            }
         };
 
         dispatch_group_enter(group);

--- a/AFNetworking/AFURLSessionManager.h
+++ b/AFNetworking/AFURLSessionManager.h
@@ -148,7 +148,7 @@
 ///---------------------------------
 
 /**
- The dispatch queue for `completionBlock`. If `NULL` (default), the main queue is used.
+ The dispatch queue for `completionBlock`. If `NULL` a private background queue will be used. Defaults to the main queue.
  */
 @property (nonatomic, strong) dispatch_queue_t completionQueue;
 

--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -159,7 +159,9 @@ didCompleteWithError:(NSError *)error
         if (error) {
             userInfo[AFNetworkingTaskDidFinishErrorKey] = error;
 
-            dispatch_group_async(manager.completionGroup ?: url_session_manager_completion_group(), manager.completionQueue ?: dispatch_get_main_queue(), ^{
+            dispatch_group_t group = manager.completionGroup ?: url_session_manager_completion_group();
+            dispatch_queue_t queue = manager.completionQueue;
+            dispatch_block_t block = ^{
                 if (self.completionHandler) {
                     self.completionHandler(task.response, responseObject, error);
                 }
@@ -167,7 +169,15 @@ didCompleteWithError:(NSError *)error
                 dispatch_async(dispatch_get_main_queue(), ^{
                     [[NSNotificationCenter defaultCenter] postNotificationName:AFNetworkingTaskDidFinishNotification object:task userInfo:userInfo];
                 });
-            });
+            };
+
+            if (queue) {
+                dispatch_group_async(group, queue, block);
+            } else {
+                dispatch_group_enter(group);
+                block();
+                dispatch_group_leave(group);
+            }
         } else {
             dispatch_async(url_session_manager_processing_queue(), ^{
                 NSError *serializationError = nil;
@@ -185,15 +195,25 @@ didCompleteWithError:(NSError *)error
                     userInfo[AFNetworkingTaskDidFinishErrorKey] = serializationError;
                 }
 
-                dispatch_group_async(manager.completionGroup ?: url_session_manager_completion_group(), manager.completionQueue ?: dispatch_get_main_queue(), ^{
+                dispatch_group_t group = manager.completionGroup ?: url_session_manager_completion_group();
+                dispatch_queue_t queue = manager.completionQueue;
+                dispatch_block_t block = ^{
                     if (self.completionHandler) {
                         self.completionHandler(task.response, responseObject, serializationError);
                     }
-                    
+
                     dispatch_async(dispatch_get_main_queue(), ^{
                         [[NSNotificationCenter defaultCenter] postNotificationName:AFNetworkingTaskDidFinishNotification object:task userInfo:userInfo];
                     });
-                });
+                };
+
+                if (group) {
+                    dispatch_group_async(group, queue, block);
+                } else {
+                    dispatch_group_enter(group);
+                    block();
+                    dispatch_group_leave(group);
+                }
             });
         }
     }
@@ -311,6 +331,7 @@ expectedTotalBytes:(int64_t)expectedTotalBytes {
 
     self.lock = [[NSLock alloc] init];
     self.lock.name = AFURLSessionManagerLockName;
+    self.completionQueue = dispatch_get_main_queue();
 
     return self;
 }


### PR DESCRIPTION
This also changes the default value of the completionQueue to the main queue.

NULL should mean we don't dispatch to another queue. Instead run the block on our own private queue. This will prevent having to dispatch onto the main queue to then dispatch to other private queues. For example, when using Core Data:

``` objective-c
[managedObjectContext performBlock:^{}];
```

The default behaviour would mean wasting a run-loop cycle to get to main queue and then dispatch back off using another cycle on a different queue.
