### PR TITLE
Update progress when using multipart requests

### DIFF
--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -133,7 +133,7 @@ typedef void (^AFURLSessionTaskCompletionHandler)(NSURLResponse *response, id re
 totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend
 {
     int64_t totalUnitCount = totalBytesExpectedToSend;
-    if(totalUnitCount == -1) {
+    if(totalUnitCount == NSURLSessionTransferSizeUnknown) {
         NSString *contentLength = [task.originalRequest valueForHTTPHeaderField:@"Content-Length"];
         if(contentLength) {
             totalUnitCount = (int64_t) [contentLength longLongValue];
@@ -478,7 +478,7 @@ expectedTotalBytes:(int64_t)expectedTotalBytes {
     AFURLSessionManagerTaskDelegate *delegate = [AFURLSessionManagerTaskDelegate delegateForManager:self completionHandler:completionHandler];
 
     int64_t totalUnitCount = uploadTask.countOfBytesExpectedToSend;
-    if(totalUnitCount == -1) {
+    if(totalUnitCount == NSURLSessionTransferSizeUnknown) {
         NSString *contentLength = [uploadTask.originalRequest valueForHTTPHeaderField:@"Content-Length"];
         if(contentLength) {
             totalUnitCount = (int64_t) [contentLength longLongValue];


### PR DESCRIPTION
There is a problem with upload progress not being updated when making multipart uploads. Multipart requests built using `AFStreamingMultipartFormData` do not report any progress because `NSURLSessionUploadTask` relays on requests Content-Length header. But, at the same time that header is removed when `NSURLSessionUploadTask` is being constructed. So no upload progress can be reported. 
Please refer to issue #1398 for detailed discussion on what's wrong. 

This can be solved because `AFStreamingMultipartFormData` correctly calculates content-length.

Not sure if this can be merged, but it's quite helpful when you want to upload image with extra post data.
