### PR TITLE
Exposing adding operations to the operation queue.

### DIFF
--- a/AFNetworking/AFHTTPRequestOperationManager.h
+++ b/AFNetworking/AFHTTPRequestOperationManager.h
@@ -179,6 +179,13 @@
                                                     success:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
                                                     failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure;
 
+/**
+ Queues an 'AFHTTPRequestOperation' for processing in the operationQueue. Override this method, e.g., if you need to set any dependencies between the queued operation and any existing operations in the operationQueue.
+ 
+ @param operation The HTTP request operation to be queued for processing.
+ */
+- (void) queueHttpRequestOperation:(AFHTTPRequestOperation*) operation;
+
 ///---------------------------
 /// @name Making HTTP Requests
 ///---------------------------

--- a/AFNetworking/AFHTTPRequestOperationManager.m
+++ b/AFNetworking/AFHTTPRequestOperationManager.m
@@ -112,6 +112,11 @@
     return operation;
 }
 
+- (void) queueHttpRequestOperation:(AFHTTPRequestOperation*) operation
+{
+    [self.operationQueue addOperation:operation];
+}
+
 #pragma mark -
 
 - (AFHTTPRequestOperation *)GET:(NSString *)URLString
@@ -121,7 +126,7 @@
 {
     NSMutableURLRequest *request = [self.requestSerializer requestWithMethod:@"GET" URLString:[[NSURL URLWithString:URLString relativeToURL:self.baseURL] absoluteString] parameters:parameters];
     AFHTTPRequestOperation *operation = [self HTTPRequestOperationWithRequest:request success:success failure:failure];
-    [self.operationQueue addOperation:operation];
+    [self queueHttpRequestOperation:operation];
 
     return operation;
 }
@@ -137,7 +142,7 @@
             success(requestOperation);
         }
     } failure:failure];
-    [self.operationQueue addOperation:operation];
+    [self queueHttpRequestOperation:operation];
 
     return operation;
 }
@@ -149,7 +154,7 @@
 {
     NSMutableURLRequest *request = [self.requestSerializer requestWithMethod:@"POST" URLString:[[NSURL URLWithString:URLString relativeToURL:self.baseURL] absoluteString] parameters:parameters];
     AFHTTPRequestOperation *operation = [self HTTPRequestOperationWithRequest:request success:success failure:failure];
-    [self.operationQueue addOperation:operation];
+    [self queueHttpRequestOperation:operation];
 
     return operation;
 }
@@ -162,7 +167,7 @@
 {
     NSMutableURLRequest *request = [self.requestSerializer multipartFormRequestWithMethod:@"POST" URLString:[[NSURL URLWithString:URLString relativeToURL:self.baseURL] absoluteString] parameters:parameters constructingBodyWithBlock:block];
     AFHTTPRequestOperation *operation = [self HTTPRequestOperationWithRequest:request success:success failure:failure];
-    [self.operationQueue addOperation:operation];
+    [self queueHttpRequestOperation:operation];
 
     return operation;
 }
@@ -174,7 +179,7 @@
 {
     NSMutableURLRequest *request = [self.requestSerializer requestWithMethod:@"PUT" URLString:[[NSURL URLWithString:URLString relativeToURL:self.baseURL] absoluteString] parameters:parameters];
     AFHTTPRequestOperation *operation = [self HTTPRequestOperationWithRequest:request success:success failure:failure];
-    [self.operationQueue addOperation:operation];
+    [self queueHttpRequestOperation:operation];
 
     return operation;
 }
@@ -186,7 +191,7 @@
 {
     NSMutableURLRequest *request = [self.requestSerializer requestWithMethod:@"PATCH" URLString:[[NSURL URLWithString:URLString relativeToURL:self.baseURL] absoluteString] parameters:parameters];
     AFHTTPRequestOperation *operation = [self HTTPRequestOperationWithRequest:request success:success failure:failure];
-    [self.operationQueue addOperation:operation];
+    [self queueHttpRequestOperation:operation];
 
     return operation;
 }
@@ -198,7 +203,7 @@
 {
     NSMutableURLRequest *request = [self.requestSerializer requestWithMethod:@"DELETE" URLString:[[NSURL URLWithString:URLString relativeToURL:self.baseURL] absoluteString] parameters:parameters];
     AFHTTPRequestOperation *operation = [self HTTPRequestOperationWithRequest:request success:success failure:failure];
-    [self.operationQueue addOperation:operation];
+    [self queueHttpRequestOperation:operation];
 
     return operation;
 }


### PR DESCRIPTION
This is just a super simple change to expose adding an operation to the operation queue as an overridable method in AFHTTPRequestOperationManager. This lets you setup dependencies between the operation to be added and any any existing operations in the queue.

E.g., if you have endpoints for user CRUD operations for a system at /user_, you can make any operation that hits /user_ depend on any existing operation in the operation queue that hits /user\* so you don't have race conditions on a POST and PUT operation (for user creation and updating).

Would actually be awesome if this could be done with AFHTTPSessionManager, but I didn't see an easy way to do that since it doesn't use an NSOperationQueue (short of building out infrastructure in front of the AFHTTPSessionManager object to do the dependency stuff).
