### PR TITLE
Make the request available to response serializers

### DIFF
--- a/AFNetworking/AFHTTPRequestOperation.m
+++ b/AFNetworking/AFHTTPRequestOperation.m
@@ -80,7 +80,7 @@ static dispatch_group_t http_request_operation_completion_group() {
     [self.lock lock];
     if (!_responseObject && [self isFinished] && !self.error) {
         NSError *error = nil;
-        self.responseObject = [self.responseSerializer responseObjectForResponse:self.response data:self.responseData error:&error];
+        self.responseObject = [self.responseSerializer responseObjectForResponse:self.response data:self.responseData request:self.request error:&error];
         if (error) {
             self.responseSerializationError = error;
         }

--- a/AFNetworking/AFURLResponseSerialization.h
+++ b/AFNetworking/AFURLResponseSerialization.h
@@ -35,12 +35,14 @@
 
  @param response The response to be processed.
  @param data The response data to be decoded.
+ @param request The request that generated the response.
  @param error The error that occurred while attempting to decode the response data.
 
  @return The object decoded from the specified response data.
  */
 - (id)responseObjectForResponse:(NSURLResponse *)response
                            data:(NSData *)data
+                        request:(NSURLRequest *)request
                           error:(NSError *__autoreleasing *)error;
 
 @end
@@ -87,12 +89,14 @@
 
  @param response The response to be validated.
  @param data The data associated with the response.
+ @param request The request that generated the response.
  @param error The error that occurred while attempting to validate the response.
 
  @return `YES` if the response is valid, otherwise `NO`.
  */
 - (BOOL)validateResponse:(NSHTTPURLResponse *)response
                     data:(NSData *)data
+                 request:(NSURLRequest *)request
                    error:(NSError *__autoreleasing *)error;
 
 @end

--- a/AFNetworking/AFURLResponseSerialization.m
+++ b/AFNetworking/AFURLResponseSerialization.m
@@ -55,6 +55,7 @@ extern NSString * const AFNetworkingOperationFailingURLResponseErrorKey;
 
 - (BOOL)validateResponse:(NSHTTPURLResponse *)response
                     data:(NSData *)data
+                 request:(NSURLRequest *)request
                    error:(NSError *__autoreleasing *)error
 {
     if (response && [response isKindOfClass:[NSHTTPURLResponse class]]) {
@@ -93,9 +94,10 @@ extern NSString * const AFNetworkingOperationFailingURLResponseErrorKey;
 
 - (id)responseObjectForResponse:(NSURLResponse *)response
                            data:(NSData *)data
+                        request:(NSURLRequest *)request
                           error:(NSError *__autoreleasing *)error
 {
-    [self validateResponse:(NSHTTPURLResponse *)response data:data error:error];
+    [self validateResponse:(NSHTTPURLResponse *)response data:data request:request error:error];
 
     return data;
 }
@@ -161,9 +163,10 @@ extern NSString * const AFNetworkingOperationFailingURLResponseErrorKey;
 
 - (id)responseObjectForResponse:(NSURLResponse *)response
                            data:(NSData *)data
+                        request:(NSURLRequest *)request
                           error:(NSError *__autoreleasing *)error
 {
-    if (![self validateResponse:(NSHTTPURLResponse *)response data:data error:error]) {
+    if (![self validateResponse:(NSHTTPURLResponse *)response data:data request:request error:error]) {
         if ([(NSError *)(*error) code] == NSURLErrorCannotDecodeContentData) {
             return nil;
         }
@@ -259,9 +262,10 @@ extern NSString * const AFNetworkingOperationFailingURLResponseErrorKey;
 
 - (id)responseObjectForResponse:(NSHTTPURLResponse *)response
                            data:(NSData *)data
+                        request:(NSURLRequest *)request
                           error:(NSError *__autoreleasing *)error
 {
-    if (![self validateResponse:(NSHTTPURLResponse *)response data:data error:error]) {
+    if (![self validateResponse:(NSHTTPURLResponse *)response data:data request:request error:error]) {
         if ([(NSError *)(*error) code] == NSURLErrorCannotDecodeContentData) {
             return nil;
         }
@@ -304,9 +308,10 @@ extern NSString * const AFNetworkingOperationFailingURLResponseErrorKey;
 
 - (id)responseObjectForResponse:(NSURLResponse *)response
                            data:(NSData *)data
+                        request:(NSURLRequest *)request
                           error:(NSError *__autoreleasing *)error
 {
-    if (![self validateResponse:(NSHTTPURLResponse *)response data:data error:error]) {
+    if (![self validateResponse:(NSHTTPURLResponse *)response data:data request:request error:error]) {
         if ([(NSError *)(*error) code] == NSURLErrorCannotDecodeContentData) {
             return nil;
         }
@@ -390,9 +395,10 @@ extern NSString * const AFNetworkingOperationFailingURLResponseErrorKey;
 
 - (id)responseObjectForResponse:(NSURLResponse *)response
                            data:(NSData *)data
+                        request:(NSURLRequest *)request
                           error:(NSError *__autoreleasing *)error
 {
-    if (![self validateResponse:(NSHTTPURLResponse *)response data:data error:error]) {
+    if (![self validateResponse:(NSHTTPURLResponse *)response data:data request:request error:error]) {
         if ([(NSError *)(*error) code] == NSURLErrorCannotDecodeContentData) {
             return nil;
         }
@@ -557,9 +563,10 @@ static UIImage * AFInflatedImageFromResponseWithDataAtScale(NSHTTPURLResponse *r
 
 - (id)responseObjectForResponse:(NSURLResponse *)response
                            data:(NSData *)data
+                        request:(NSURLRequest *)request
                           error:(NSError *__autoreleasing *)error
 {
-    if (![self validateResponse:(NSHTTPURLResponse *)response data:data error:error]) {
+    if (![self validateResponse:(NSHTTPURLResponse *)response data:data request:request error:error]) {
         if ([(NSError *)(*error) code] == NSURLErrorCannotDecodeContentData) {
             return nil;
         }
@@ -642,6 +649,7 @@ static UIImage * AFInflatedImageFromResponseWithDataAtScale(NSHTTPURLResponse *r
 
 - (id)responseObjectForResponse:(NSURLResponse *)response
                            data:(NSData *)data
+                        request:(NSURLRequest *)request
                           error:(NSError *__autoreleasing *)error
 {
     for (id <AFURLResponseSerialization> serializer in self.responseSerializers) {
@@ -650,14 +658,14 @@ static UIImage * AFInflatedImageFromResponseWithDataAtScale(NSHTTPURLResponse *r
         }
 
         NSError *serializerError = nil;
-        id responseObject = [serializer responseObjectForResponse:response data:data error:&serializerError];
+        id responseObject = [serializer responseObjectForResponse:response data:data request:request error:&serializerError];
         if (responseObject) {
             *error = serializerError;
             return responseObject;
         }
     }
     
-    return [super responseObjectForResponse:response data:data error:error];
+    return [super responseObjectForResponse:response data:data request:request error:error];
 }
 
 #pragma mark - NSCoding

--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -174,7 +174,7 @@ didCompleteWithError:(NSError *)error
                 if (self.downloadFileURL) {
                     responseObject = self.downloadFileURL;
                 } else {
-                    responseObject = [manager.responseSerializer responseObjectForResponse:task.response data:[NSData dataWithData:self.mutableData] error:&serializationError];
+                    responseObject = [manager.responseSerializer responseObjectForResponse:task.response data:[NSData dataWithData:self.mutableData] request:task.currentRequest error:&serializationError];
                 }
 
                 if (responseObject) {

--- a/Tests/Tests/AFHTTPSerializationTests.m
+++ b/Tests/Tests/AFHTTPSerializationTests.m
@@ -41,7 +41,7 @@
         XCTAssert([serializer.acceptableStatusCodes containsIndex:statusCode], @"Status code %d should be acceptable", statusCode);
 
         NSError *error = nil;
-        [serializer validateResponse:response data:[@"text" dataUsingEncoding:NSUTF8StringEncoding] error:&error];
+        [serializer validateResponse:response data:[@"text" dataUsingEncoding:NSUTF8StringEncoding] request:nil error:&error];
 
         XCTAssertNil(error, @"Error handling status code %d", statusCode);
     }];
@@ -56,7 +56,7 @@
         XCTAssert(![serializer.acceptableStatusCodes containsIndex:statusCode], @"Status code %d should not be acceptable", statusCode);
 
         NSError *error = nil;
-        [serializer validateResponse:response data:[@"text" dataUsingEncoding:NSUTF8StringEncoding] error:&error];
+        [serializer validateResponse:response data:[@"text" dataUsingEncoding:NSUTF8StringEncoding] request:nil error:&error];
 
         XCTAssertNotNil(error, @"Did not fail handling status code %d",statusCode);
     }];

--- a/Tests/Tests/AFJSONSerializationTests.m
+++ b/Tests/Tests/AFJSONSerializationTests.m
@@ -40,7 +40,7 @@ static NSData * AFJSONTestData() {
 
     AFJSONResponseSerializer *serializer = [AFJSONResponseSerializer serializer];
     NSError *error = nil;
-    [serializer validateResponse:response data:AFJSONTestData() error:&error];
+    [serializer validateResponse:response data:AFJSONTestData() request:nil error:&error];
 
     XCTAssertNil(error, @"Error handling application/json");
 }
@@ -50,7 +50,7 @@ static NSData * AFJSONTestData() {
 
     AFJSONResponseSerializer *serializer = [AFJSONResponseSerializer serializer];
     NSError *error = nil;
-    [serializer validateResponse:response data:AFJSONTestData()error:&error];
+    [serializer validateResponse:response data:AFJSONTestData() request:nil error:&error];
 
     XCTAssertNil(error, @"Error handling text/json");
 }
@@ -60,7 +60,7 @@ static NSData * AFJSONTestData() {
 
     AFJSONResponseSerializer *serializer = [AFJSONResponseSerializer serializer];
     NSError *error = nil;
-    [serializer validateResponse:response data:AFJSONTestData() error:&error];
+    [serializer validateResponse:response data:AFJSONTestData() request:nil error:&error];
 
     XCTAssertNil(error, @"Error handling text/javascript");
 }
@@ -70,7 +70,7 @@ static NSData * AFJSONTestData() {
 
     AFJSONResponseSerializer *serializer = [AFJSONResponseSerializer serializer];
     NSError *error = nil;
-    [serializer validateResponse:response data:AFJSONTestData() error:&error];
+    [serializer validateResponse:response data:AFJSONTestData() request:nil error:&error];
 
     XCTAssertNotNil(error, @"Error should have been thrown for nonstandard/json");
 }
@@ -80,7 +80,7 @@ static NSData * AFJSONTestData() {
 
     AFJSONResponseSerializer *serializer = [AFJSONResponseSerializer serializer];
     NSError *error = nil;
-    id responseObject = [serializer responseObjectForResponse:response data:AFJSONTestData() error:&error];
+    id responseObject = [serializer responseObjectForResponse:response data:AFJSONTestData() request:nil error:&error];
 
     XCTAssertNil(error, @"Serialization error should be nil");
     XCTAssert([responseObject isKindOfClass:[NSDictionary class]], @"Expected response to be a NSDictionary");
@@ -91,7 +91,7 @@ static NSData * AFJSONTestData() {
 
     AFJSONResponseSerializer *serializer = [AFJSONResponseSerializer serializer];
     NSError *error = nil;
-    [serializer responseObjectForResponse:response data:[@"{invalid}" dataUsingEncoding:NSUTF8StringEncoding] error:&error];
+    [serializer responseObjectForResponse:response data:[@"{invalid}" dataUsingEncoding:NSUTF8StringEncoding] request:nil error:&error];
 
     XCTAssertNotNil(error, @"Serialization error should not be nil");
 }


### PR DESCRIPTION
I have started work on the rather sizable project of porting RestKit to AFN 2.0. Thus far things have gone reasonably well and, as expected, the serializer architecture is greatly reducing the amount of subclassing and overrides at the seams between the libraries.

One issue that I ran into almost immediately is that the response serializers do not have access to the request that generated the response. I need access to the request for a number of reasons and I can imagine its generally useful, so I’ve amended the serialization protocol and validation methods to include the request.
