### PR TITLE
Fixes an issue when using AFURLSessionManager on unsupported OS 

### DIFF
--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -468,9 +468,7 @@ expectedTotalBytes:(int64_t)expectedTotalBytes {
                                       progress:(NSProgress * __autoreleasing *)progress
                              completionHandler:(void (^)(NSURLResponse *response, id responseObject, NSError *error))completionHandler
 {
-    if (!uploadTask) {
-        return nil;
-    }
+    NSParameterAssert(uploadTask);
     
     AFURLSessionManagerTaskDelegate *delegate = [AFURLSessionManagerTaskDelegate delegateForManager:self completionHandler:completionHandler];
 
@@ -520,9 +518,7 @@ expectedTotalBytes:(int64_t)expectedTotalBytes {
                                        destination:(NSURL * (^)(NSURL *targetPath, NSURLResponse *response))destination
                                  completionHandler:(void (^)(NSURLResponse *response, NSURL *filePath, NSError *error))completionHandler
 {
-    if (!downloadTask) {
-        return nil;
-    }
+    NSParameterAssert(downloadTask);
     
     AFURLSessionManagerTaskDelegate *delegate = [AFURLSessionManagerTaskDelegate delegateForManager:self completionHandler:completionHandler];
     delegate.downloadTaskDidFinishDownloading = ^NSURL * (NSURLSession * __unused session, NSURLSessionDownloadTask *task, NSURL *location) {


### PR DESCRIPTION
0a3de62849224ad0f878c801c4aa0a33edc30a98 allowed building this for iOS 6 and OS X 10.8 however it didn't prevent running it. When people run it, NSURLSession will become nil and it can cause some issues when using AFURLSessionManager such as in #1592. Let's just bail early and prevent the developer for continuing.
