### PR TITLE
Fix an issue with the reachability manager not monitoring in AFHTTPSessionManager

### DIFF
--- a/AFNetworking/AFHTTPSessionManager.m
+++ b/AFNetworking/AFHTTPSessionManager.m
@@ -43,7 +43,6 @@
 
 @interface AFHTTPSessionManager ()
 @property (readwrite, nonatomic, strong) NSURL *baseURL;
-@property (readwrite, nonatomic, strong) AFNetworkReachabilityManager *reachabilityManager;
 @end
 
 @implementation AFHTTPSessionManager
@@ -67,7 +66,12 @@
 - (instancetype)initWithBaseURL:(NSURL *)url
            sessionConfiguration:(NSURLSessionConfiguration *)configuration
 {
-    self = [super initWithSessionConfiguration:configuration];
+    AFNetworkReachabilityManager *reachabilityManager;
+    if (url.host) {
+        reachabilityManager = [AFNetworkReachabilityManager managerForDomain:url.host];
+    }
+
+    self = [super initWithSessionConfiguration:configuration reachabilityManager:reachabilityManager];
     if (!self) {
         return nil;
     }
@@ -81,12 +85,6 @@
 
     self.requestSerializer = [AFHTTPRequestSerializer serializer];
     self.responseSerializer = [AFJSONResponseSerializer serializer];
-
-    if (self.baseURL.host) {
-        self.reachabilityManager = [AFNetworkReachabilityManager managerForDomain:self.baseURL.host];
-    } else {
-        self.reachabilityManager = [AFNetworkReachabilityManager sharedManager];
-    }
 
     return self;
 }

--- a/AFNetworking/AFURLSessionManager.h
+++ b/AFNetworking/AFURLSessionManager.h
@@ -162,13 +162,24 @@
 ///---------------------
 
 /**
- Creates and returns a manager for a session created with the specified configuration. This is the designated initializer.
+ Creates and returns a manager for a session created with the specified configuration.
  
  @param configuration The configuration used to create the managed session.
  
  @return A manager for a newly-created session.
  */
 - (instancetype)initWithSessionConfiguration:(NSURLSessionConfiguration *)configuration;
+
+
+/**
+ Creates and returns a manager for a session created with the specified configuration with a reachability manager. This is the designated initializer.
+
+ @param configuration The configuration used to create the managed session.
+ @param reachabilityManager An optional reachability manager, defaults to the shared manager.
+
+ @return A manager for a newly-created session.
+ */
+- (instancetype)initWithSessionConfiguration:(NSURLSessionConfiguration *)configuration reachabilityManager:(AFNetworkReachabilityManager *)reachabilityManager;
 
 /**
  Invalidates the managed session, optionally canceling pending tasks.

--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -285,6 +285,10 @@ expectedTotalBytes:(int64_t)expectedTotalBytes {
 }
 
 - (instancetype)initWithSessionConfiguration:(NSURLSessionConfiguration *)configuration {
+    return [self initWithSessionConfiguration:configuration reachabilityManager:nil];
+}
+
+- (instancetype)initWithSessionConfiguration:(NSURLSessionConfiguration *)configuration reachabilityManager:(AFNetworkReachabilityManager *)reachabilityManager {
     self = [super init];
     if (!self) {
         return nil;
@@ -304,7 +308,11 @@ expectedTotalBytes:(int64_t)expectedTotalBytes {
 
     self.mutableTaskDelegatesKeyedByTaskIdentifier = [[NSMutableDictionary alloc] init];
 
-    self.reachabilityManager = [AFNetworkReachabilityManager sharedManager];
+    if (!reachabilityManager) {
+        reachabilityManager = [AFNetworkReachabilityManager sharedManager];
+    }
+
+    self.reachabilityManager = reachabilityManager;
     [self.reachabilityManager startMonitoring];
 
     self.securityPolicy = [AFSecurityPolicy defaultPolicy];


### PR DESCRIPTION
AFURLSessionManager re-declared a private property of it’s superclass and then incorrectly set it after super’s init which resulted in the shared manager already being started and potentially not even used. The newly set reachability manager in AFHTTPSessionManager wasn’t started.

This change allows passing AFURLSessionManager a reachability manager instead of having to redeclare private API (and incorrectly use it).
