### PR TITLE
Fixes a couple of bugs for when a task becomes a download task

### DIFF
--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -739,10 +739,8 @@ didCompleteWithError:(NSError *)error
     }
 
     [self removeDelegateForTask:task];
-    
-    @try {
-        [task removeObserver:self forKeyPath:@"state" context:AFTaskStateChangedContext];
-    } @catch (NSException *exception) {}
+
+    [task removeObserver:self forKeyPath:@"state" context:AFTaskStateChangedContext];
 }
 
 #pragma mark - NSURLSessionDataDelegate
@@ -767,6 +765,13 @@ didReceiveResponse:(NSURLResponse *)response
           dataTask:(NSURLSessionDataTask *)dataTask
 didBecomeDownloadTask:(NSURLSessionDownloadTask *)downloadTask
 {
+    AFURLSessionManagerTaskDelegate *delegate = [self delegateForTask:dataTask];
+    [self removeDelegateForTask:dataTask];
+    [dataTask removeObserver:self forKeyPath:@"state" context:AFTaskStateChangedContext];
+
+    [self setDelegate:delegate forTask:downloadTask];
+    [downloadTask addObserver:self forKeyPath:@"state" options:NSKeyValueObservingOptionOld|NSKeyValueObservingOptionNew context:AFTaskStateChangedContext];
+
     if (self.dataTaskDidBecomeDownloadTask) {
         self.dataTaskDidBecomeDownloadTask(session, dataTask, downloadTask);
     }


### PR DESCRIPTION
If a task becomes a download task. None of the old delegate methods for the old task will get called. This means it wont remove the observer and it will not delete the delegate.

We never setup the new task with observing and it’s delegate either. When the new task's delegate method gets called, we will remove the observer which we never registered.
