### PR TITLE
Fix incorrect documentation for HTTPRequestOperationWithRequest:success:failure:

### DIFF
--- a/AFNetworking/AFHTTPRequestOperationManager.h
+++ b/AFNetworking/AFHTTPRequestOperationManager.h
@@ -169,7 +169,7 @@
 ///---------------------------------------
 
 /**
- Creates an `AFHTTPRequestOperation`, setting the operation's request serializer and response serializers to those of the HTTP client.
+ Creates an `AFHTTPRequestOperation`, and sets the response serializers to that of the HTTP client.
 
  @param request The request object to be loaded asynchronously during execution of the operation.
  @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes two arguments: the created request operation and the object created from the response data of request.


### PR DESCRIPTION
We're already passing a request, there is no serialisation to do.

Fixes #1640
