### PR TITLE
Call queryStringSerialization block of the AFHTTPRequestSerializer even if request parameters are nil

### DIFF
--- a/AFNetworking/AFURLRequestSerialization.m
+++ b/AFNetworking/AFURLRequestSerialization.m
@@ -324,10 +324,6 @@ NSArray * AFQueryStringPairsFromKeyAndValue(NSString *key, id value) {
         }
     }];
 
-    if (!parameters) {
-        return mutableRequest;
-    }
-
     NSString *query = nil;
     if (self.queryStringSerialization) {
         query = self.queryStringSerialization(request, parameters, error);
@@ -339,6 +335,10 @@ NSArray * AFQueryStringPairsFromKeyAndValue(NSString *key, id value) {
             default:
                 break;
         }
+    }
+	
+    if (!query) {
+        return mutableRequest;
     }
 
     if ([self.HTTPMethodsEncodingParametersInURI containsObject:[[request HTTPMethod] uppercaseString]]) {


### PR DESCRIPTION
Sometimes it may be useful to pass some parameters in the query string by default (timestamp for example) while creating the request. So `AFHTTPRequestSerializer` should call `queryStringSerialization` block (if it's set of course) even if there are no query parameters.
Moreover now the parameters are checked only for a `nil` and for empty containers (`NSDictionary` etc) block is called (it's a kind of workaround but in my opinion it's not right).
