### PR TITLE
Completely reset the session, including cookies.

### DIFF
--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -406,11 +406,13 @@ expectedTotalBytes:(int64_t)expectedTotalBytes {
 #pragma mark -
 
 - (void)invalidateSessionCancelingTasks:(BOOL)cancelPendingTasks {
-    if (cancelPendingTasks) {
-        [self.session invalidateAndCancel];
-    } else {
-        [self.session finishTasksAndInvalidate];
-    }
+    [self.session resetWithCompletionHandler:^{
+        if (cancelPendingTasks) {
+            [self.session invalidateAndCancel];
+        } else {
+            [self.session finishTasksAndInvalidate];
+        }
+    }];
 }
 
 #pragma mark -


### PR DESCRIPTION
I found that if the session contains a cookie, that cookie is not removed unless -resetWithCompletionHandler: is called to completely clear it.

I made the change internally to my app, but it seems like this should be handled by AFNetworking itself. I could make the complete reset a parameter, but I don't think that breaking the API is the best thing to do.

It looks like -resetWithCompletionHandler: is the only API documented as clearing the cookies.

Thanks for making AFNetworking!
