### PR TITLE
Class level setter for default image response serializer

### DIFF
--- a/UIKit+AFNetworking/UIImageView+AFNetworking.h
+++ b/UIKit+AFNetworking/UIImageView+AFNetworking.h
@@ -58,6 +58,21 @@
 ///------------------------------------
 
 /**
+ Set the default image response serializer used. Will use `AFImageResponseSerializer` if none is set
+ 
+ @param serializer The image response serializer
+ */
++ (void)setDefaultImageResponseSerializer:(id <AFURLResponseSerialization>)serializer;
+
+
+/**
+ The default response serializer used to create an image representation from the server response and response data.
+ 
+ @discussion Subclasses of `AFImageResponseSerializer` could be used to perform post-processing, such as color correction, face detection, or other effects. See https://github.com/AFNetworking/AFCoreImageSerializer
+ */
++ (id <AFURLResponseSerialization>)defaultImageResponseSerializer;
+
+/**
  The response serializer used to create an image representation from the server response and response data. By default, this is an instance of `AFImageResponseSerializer`.
  
  @discussion Subclasses of `AFImageResponseSerializer` could be used to perform post-processing, such as color correction, face detection, or other effects. See https://github.com/AFNetworking/AFCoreImageSerializer

--- a/UIKit+AFNetworking/UIImageView+AFNetworking.m
+++ b/UIKit+AFNetworking/UIImageView+AFNetworking.m
@@ -36,6 +36,7 @@
 static char kAFSharedImageCacheKey;
 static char kAFImageRequestOperationKey;
 static char kAFResponseSerializerKey;
+static char kAFDefaultResponseSerializerKey;
 
 @interface UIImageView (_AFNetworking)
 @property (readwrite, nonatomic, strong, setter = af_setImageRequestOperation:) AFHTTPRequestOperation *af_imageRequestOperation;
@@ -90,11 +91,22 @@ static char kAFResponseSerializerKey;
     objc_setAssociatedObject(self, &kAFSharedImageCacheKey, imageCache, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
++ (void)setDefaultImageResponseSerializer:(id <AFURLResponseSerialization>)serializer {
+    objc_setAssociatedObject(self, &kAFDefaultResponseSerializerKey, serializer, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
++ (id <AFURLResponseSerialization>)defaultImageResponseSerializer {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wgnu"
+    return objc_getAssociatedObject(self, &kAFDefaultResponseSerializerKey) ?: [AFImageResponseSerializer serializer];
+#pragma clang diagnostic pop
+}
+
 - (id <AFURLResponseSerialization>)imageResponseSerializer {
     static id <AFURLResponseSerialization> _af_defaultImageResponseSerializer = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        _af_defaultImageResponseSerializer = [AFImageResponseSerializer serializer];
+        _af_defaultImageResponseSerializer = [UIImageView defaultImageResponseSerializer];
     });
 
 #pragma clang diagnostic push


### PR DESCRIPTION
Possibility to set class level default image response serializer.

The idea is that you can set a default image response serializer for all UIImageViews, it can be useful if you need to scale all images using URL parameter or do some filters on images. 
