### PR TITLE
Reachability Manager of AFHTTPRequestOperationManager and AFHTTPSessionM...

### DIFF
--- a/AFNetworking/AFHTTPRequestOperationManager.m
+++ b/AFNetworking/AFHTTPRequestOperationManager.m
@@ -34,10 +34,11 @@
 
 @interface AFHTTPRequestOperationManager ()
 @property (readwrite, nonatomic, strong) NSURL *baseURL;
-@property (readwrite, nonatomic, strong) AFNetworkReachabilityManager *reachabilityManager;
 @end
 
 @implementation AFHTTPRequestOperationManager
+
+@synthesize reachabilityManager=_reachabilityManager;
 
 + (instancetype)manager {
     return [[[self class] alloc] initWithBaseURL:nil];
@@ -61,14 +62,6 @@
 
     self.securityPolicy = [AFSecurityPolicy defaultPolicy];
 
-    if (self.baseURL.host) {
-        self.reachabilityManager = [AFNetworkReachabilityManager managerForDomain:self.baseURL.host];
-    } else {
-        self.reachabilityManager = [AFNetworkReachabilityManager sharedManager];
-    }
-
-    [self.reachabilityManager startMonitoring];
-
     self.operationQueue = [[NSOperationQueue alloc] init];
 
     return self;
@@ -76,6 +69,20 @@
 
 - (NSString *)description {
     return [NSString stringWithFormat:@"<%@: %p, baseURL: %@, operationQueue: %@>", NSStringFromClass([self class]), self, [self.baseURL absoluteString], self.operationQueue];
+}
+
+- (AFNetworkReachabilityManager *)reachabilityManager
+{
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        if (self.baseURL.host) {
+            _reachabilityManager = [AFNetworkReachabilityManager managerForDomain:self.baseURL.host];
+        } else {
+            _reachabilityManager = [AFNetworkReachabilityManager sharedManager];
+        }
+    });
+    
+    return _reachabilityManager;
 }
 
 #pragma mark -

--- a/AFNetworking/AFHTTPSessionManager.m
+++ b/AFNetworking/AFHTTPSessionManager.m
@@ -43,10 +43,11 @@
 
 @interface AFHTTPSessionManager ()
 @property (readwrite, nonatomic, strong) NSURL *baseURL;
-@property (readwrite, nonatomic, strong) AFNetworkReachabilityManager *reachabilityManager;
 @end
 
 @implementation AFHTTPSessionManager
+
+@synthesize reachabilityManager=_reachabilityManager;
 
 + (instancetype)manager {
     return [[[self class] alloc] initWithBaseURL:nil];
@@ -82,18 +83,28 @@
     self.requestSerializer = [AFHTTPRequestSerializer serializer];
     self.responseSerializer = [AFJSONResponseSerializer serializer];
 
-    if (self.baseURL.host) {
-        self.reachabilityManager = [AFNetworkReachabilityManager managerForDomain:self.baseURL.host];
-    } else {
-        self.reachabilityManager = [AFNetworkReachabilityManager sharedManager];
-    }
-
     return self;
 }
 
 - (NSString *)description {
     return [NSString stringWithFormat:@"<%@: %p, baseURL: %@, session: %@, operationQueue: %@>", NSStringFromClass([self class]), self, [self.baseURL absoluteString], self.session, self.operationQueue];
 }
+
+
+- (AFNetworkReachabilityManager *)reachabilityManager
+{
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        if (self.baseURL.host) {
+            _reachabilityManager = [AFNetworkReachabilityManager managerForDomain:self.baseURL.host];
+        } else {
+            _reachabilityManager = [AFNetworkReachabilityManager sharedManager];
+        }
+    });
+    
+    return _reachabilityManager;
+}
+
 
 #pragma mark -
 


### PR DESCRIPTION
...anager is now lazily initialized. If it was not used then not created. And like AFHTTPSessionManager, AFHTTPRequestOperationManager should not start monitoring reachability by default.

I made this for fixing the startMonitoring call during startup, which took 20+ seconds when the network was bad, making the system to kill the app because it took too long to launch in version 2.0.3. Now the status checking is already deferred in the head version, I still would like to have them lazily initialized.
