### PR TITLE
Form url encoded array serialization fix.

### DIFF
--- a/AFNetworking/AFURLRequestSerialization.m
+++ b/AFNetworking/AFURLRequestSerialization.m
@@ -135,9 +135,9 @@ NSArray * AFQueryStringPairsFromKeyAndValue(NSString *key, id value) {
         }
     } else if ([value isKindOfClass:[NSArray class]]) {
         NSArray *array = value;
-        for (id nestedValue in array) {
-            [mutableQueryStringComponents addObjectsFromArray:AFQueryStringPairsFromKeyAndValue([NSString stringWithFormat:@"%@[]", key], nestedValue)];
-        }
+        [array enumerateObjectsUsingBlock:^(id nestedValue, NSUInteger idx, BOOL *stop) {
+            [mutableQueryStringComponents addObjectsFromArray:AFQueryStringPairsFromKeyAndValue([NSString stringWithFormat:@"%@[%d]", key, idx], nestedValue)];
+        }];
     } else if ([value isKindOfClass:[NSSet class]]) {
         NSSet *set = value;
         for (id obj in set) {


### PR DESCRIPTION
I found issue, when parameters dictionary include array which include few dictionaries with the same structure, then it's serialization form is an array without indexes. And server side can not make difference between that data.

For example:
Array with two dictionaries:
[{
   email: user+athlete@example.com,
   role: "athlete"
},
{
   email: user+family@example.com,
   role: "family"
}]

Serialized:

space[invitations_attributes][][email]=user%2Bathlete%40example.com
&space[invitations_attributes][][role]=athlete
&space[invitations_attributes][][email]=user%2Bfamily%40example.com
&space[invitations_attributes][][role]=family

I think more correct serialization will next:

space[invitations_attributes][0][email]=user%2Bathlete%40example.com
&space[invitations_attributes][0][role]=athlete
&space[invitations_attributes][1][email]=user%2Bfamily%40example.com
&space[invitations_attributes][1][role]=family

The same in 1.3.x version.

What do you think?
