### PR TITLE
Added shouldParseOnError flag to JSON response serializer.

### DIFF
--- a/AFNetworking/AFURLResponseSerialization.h
+++ b/AFNetworking/AFURLResponseSerialization.h
@@ -117,6 +117,11 @@
 @property (nonatomic, assign) NSJSONReadingOptions readingOptions;
 
 /**
+ If validateReponse returns an error and this set to NO then don't attempt to parse the response body as JSON. YES by default.
+*/
+@property (nonatomic, assign) BOOL shouldParseOnError;
+
+/**
  Creates and returns a JSON serializer with specified reading and writing options.
 
  @param readingOptions The specified JSON reading options.

--- a/AFNetworking/AFURLResponseSerialization.m
+++ b/AFNetworking/AFURLResponseSerialization.m
@@ -153,6 +153,7 @@ extern NSString * const AFNetworkingOperationFailingURLResponseErrorKey;
     }
 
     self.acceptableContentTypes = [NSSet setWithObjects:@"application/json", @"text/json", @"text/javascript", nil];
+    self.shouldParseOnError = YES;
 
     return self;
 }
@@ -166,6 +167,13 @@ extern NSString * const AFNetworkingOperationFailingURLResponseErrorKey;
     if (![self validateResponse:(NSHTTPURLResponse *)response data:data error:error]) {
         if ([(NSError *)(*error) code] == NSURLErrorCannotDecodeContentData) {
             return nil;
+        }
+
+        // If there was an error, its likely that the content is not valid JSON,
+        // resulting in an JSON parse error instead of an invalid HTTP response
+        // error. The HTTP response error is more useful.
+        if (!self.shouldParseOnError && error) {
+          return nil;
         }
     }
 


### PR DESCRIPTION
Setting this to NO allows HTTP errors instead of JSON parse errors to be passed
to the callbacks.
