### PR TITLE
Don't run the task did complete callback if we don't have a delegate for...

### DIFF
--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -743,15 +743,20 @@ totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend
 didCompleteWithError:(NSError *)error
 {
     AFURLSessionManagerTaskDelegate *delegate = [self delegateForTask:task];
-    [delegate URLSession:session task:task didCompleteWithError:error];
-
-    if (self.taskDidComplete) {
+    // If we don't have a delegate for this task, this is probably a task that
+    // finished in the background after the application was terminated. Don't do
+    // anything. 
+    if (delegate) {
+      [delegate URLSession:session task:task didCompleteWithError:error];
+      
+      if (self.taskDidComplete) {
         self.taskDidComplete(session, task, error);
+      }
+      
+      [self removeDelegateForTask:task];
+      
+      [task removeObserver:self forKeyPath:@"state" context:AFTaskStateChangedContext];
     }
-
-    [self removeDelegateForTask:task];
-
-    [task removeObserver:self forKeyPath:@"state" context:AFTaskStateChangedContext];
 }
 
 #pragma mark - NSURLSessionDataDelegate


### PR DESCRIPTION
... it.

If we don't have a delegate for it, it most likely means that the application terminated and this is a background download task that was "reattached" to the application when the session was recreated. This will cause a crash if we attempt to remove ourselves as an observer when we aren't observing it. 
