### PR TITLE
A couple of changes to `AFInflatedImageFromResponseWithDataAtScale`:

### DIFF
--- a/AFNetworking/AFURLResponseSerialization.m
+++ b/AFNetworking/AFURLResponseSerialization.m
@@ -455,7 +455,7 @@ static UIImage * AFInflatedImageFromResponseWithDataAtScale(NSHTTPURLResponse *r
         return nil;
     }
 
-    CGImageRef imageRef = nil;
+    CGImageRef imageRef = NULL;
     CGDataProviderRef dataProvider = CGDataProviderCreateWithCFData((__bridge CFDataRef)data);
 
     if ([response.MIMEType isEqualToString:@"image/png"]) {
@@ -477,12 +477,12 @@ static UIImage * AFInflatedImageFromResponseWithDataAtScale(NSHTTPURLResponse *r
 
     CGDataProviderRelease(dataProvider);
 
-    UIImage *image = nil;
+    UIImage *image;
 
     if (!imageRef) {
         image = AFImageWithDataAtScale(data, scale);
 
-        if (image.images || image == nil) {
+        if (image.images || !image) {
             return image;
         }
 
@@ -509,7 +509,6 @@ static UIImage * AFInflatedImageFromResponseWithDataAtScale(NSHTTPURLResponse *r
         return image;
     }
 
-    size_t            bytesPerRow     = 0; // CGImageGetBytesPerRow() calculates incorrectly in iOS 5.0, so defer to CGBitmapContextCreate()
     CGColorSpaceRef   colorSpace      = CGColorSpaceCreateDeviceRGB();
     CGColorSpaceModel colorSpaceModel = CGColorSpaceGetModel(colorSpace);
     CGBitmapInfo      bitmapInfo      = CGImageGetBitmapInfo(imageRef);
@@ -525,15 +524,14 @@ static UIImage * AFInflatedImageFromResponseWithDataAtScale(NSHTTPURLResponse *r
         }
     }
 
-    CGContextRef context = CGBitmapContextCreate(NULL, width, height, bitsPerComponent, bytesPerRow, colorSpace, bitmapInfo);
+    CGContextRef context = CGBitmapContextCreate(NULL, width, height, bitsPerComponent, 0, colorSpace, bitmapInfo);
 
     CGColorSpaceRelease(colorSpace);
 
     if (!context) {
-        CGImageRelease(imageRef);
-
         if (!image)
             image = [[UIImage alloc] initWithCGImage:imageRef scale:scale orientation:image.imageOrientation];
+
         CGImageRelease(imageRef);
 
         return image;


### PR DESCRIPTION
In my diagnosis of [issue 1706](https://github.com/AFNetworking/AFNetworking/issues/1706), I noticed a couple of issues with `AFInflatedImageFromResponseWithDataAtScale`:
1. `CGImageCreateWithJPEGDataProvider` does not properly handle CMYK images, so if CMYK image, fall back to `AFImageWithDataAtScale`, which handles CMYK JPEG images properly.
2. `CGBitmapContextCreate` does not handle 16 or 32 npc images properly (or at least it generates warning), so abort inflate process if more than 8 bpc.
3. Simplify the invocation of `CGDataProviderRelease` so we only have it in one place.
4. Previous incarnation of `AFInflatedImageFromResponseWithDataAtScale` could, in some circumstances, make redundant calls to `AFImageWithDataAtScale`, so tweaked the logic to remove these redundant calls.
5. This routine was manipulating the alpha settings in `bitmapInfo` if the colorspace had three components. Technically, because there are other colorspaces with three components (e.g. Lab), it’s probably more prudent to check to see if the colorspace is RGB.
