### PR TITLE
Add support for specifying a response serializer on `AFURLSessionManagerTaskDelegate`

### DIFF
--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -95,6 +95,7 @@ typedef void (^AFURLSessionTaskCompletionHandler)(NSURLResponse *response, id re
 
 @interface AFURLSessionManagerTaskDelegate : NSObject <NSURLSessionTaskDelegate, NSURLSessionDataDelegate, NSURLSessionDownloadDelegate>
 @property (nonatomic, weak) AFURLSessionManager *manager;
+@property (nonatomic, strong) id <AFURLResponseSerialization> responseSerializer;
 @property (nonatomic, strong) NSMutableData *mutableData;
 @property (nonatomic, strong) NSProgress *uploadProgress;
 @property (nonatomic, strong) NSProgress *downloadProgress;
@@ -114,6 +115,7 @@ typedef void (^AFURLSessionTaskCompletionHandler)(NSURLResponse *response, id re
 {
     AFURLSessionManagerTaskDelegate *delegate = [[self alloc] init];
     delegate.manager = manager;
+    delegate.responseSerializer = manager.responseSerializer;
     delegate.completionHandler = completionHandler;
 
     return delegate;
@@ -163,7 +165,7 @@ didCompleteWithError:(NSError *)error
     __block id responseObject = nil;
 
     __block NSMutableDictionary *userInfo = [NSMutableDictionary dictionary];
-    userInfo[AFNetworkingTaskDidCompleteResponseSerializerKey] = manager.responseSerializer;
+    userInfo[AFNetworkingTaskDidCompleteResponseSerializerKey] = self.responseSerializer;
 
     if (self.downloadFileURL) {
         userInfo[AFNetworkingTaskDidCompleteAssetPathKey] = self.downloadFileURL;
@@ -186,7 +188,7 @@ didCompleteWithError:(NSError *)error
     } else {
         dispatch_async(url_session_manager_processing_queue(), ^{
             NSError *serializationError = nil;
-            responseObject = [manager.responseSerializer responseObjectForResponse:task.response data:[NSData dataWithData:self.mutableData] error:&serializationError];
+            responseObject = [self.responseSerializer responseObjectForResponse:task.response data:[NSData dataWithData:self.mutableData] error:&serializationError];
 
             if (self.downloadFileURL) {
                 responseObject = self.downloadFileURL;


### PR DESCRIPTION
This pull request adds some functionality necessary to enable implementation of RestKit against AFNetworking 2.0. It adds a `responseSerializer` property to the private `AFURLSessionManagerTaskDelegate` class to enable the configuration of a per-task response serializer. This provides analogous functionality to the `responseSerializer` property that is available on `AFHTTPRequestOperation`.

Some background: In order to map deserialized representations into objects within RestKit we need to carry around some metadata about the request context and how the user has configured the library to handle the response. For the `NSOperation` API’s we have been able to configure a `responseSerializer` and attach it to the operation without issue. Under the `NSURLSession` API’s we are currently limited to exactly one response serializer — the one that is configured on the manager.

With this pull request applied, we can make the necessary configuration changes by adding the private class definitions within our implementation and using `delegateForTask:` to get back the delegate and then assign our fully configured response serializer. A more complete sketch of the API usage within RestKit is available on this Gist: https://gist.github.com/blakewatters/f600dcd18cd6d3cfc88a

I hope that you find this change to be acceptable for merge. It is small and has no public API impact, but provides a great deal of power for library implementors who need a bit more flexibility from the serialization architecture.
