### PR TITLE
[Issue #1735] Fixing dead store issues in AFSecurityPolicy.m

### DIFF
--- a/AFNetworking/AFSecurityPolicy.m
+++ b/AFNetworking/AFSecurityPolicy.m
@@ -120,12 +120,19 @@ static NSArray * AFPublicKeyTrustChainForServerTrust(SecTrustRef serverTrust) {
         
         SecTrustRef trust = NULL;
         
+#if defined(NS_BLOCK_ASSERTIONS)
+        SecTrustCreateWithCertificates(certificates, policy, &trust);
+        
+        SecTrustResultType result;
+        SecTrustEvaluate(trust, &result);
+#else
         OSStatus status = SecTrustCreateWithCertificates(certificates, policy, &trust);
         NSCAssert(status == errSecSuccess, @"SecTrustCreateWithCertificates error: %ld", (long int)status);
         
         SecTrustResultType result;
         status = SecTrustEvaluate(trust, &result);
         NSCAssert(status == errSecSuccess, @"SecTrustEvaluate error: %ld", (long int)status);
+#endif
         
         [trustChain addObject:(__bridge_transfer id)SecTrustCopyPublicKey(trust)];
         


### PR DESCRIPTION
Build and analyze yields the following issues when assertions are enabled:

```
AFNetworking/AFSecurityPolicy.m:123:18: Value stored to 'status' during its initialization is never read
AFNetworking/AFSecurityPolicy.m:127:9: Value stored to 'status' is never read
```

This patch mimics the pattern established previously in this file on line 89. It adds a check for whether NS_BLOCK_ASSERTIONS is defined to determine whether to use the status variable.
