### PR TITLE
Update README.md: multi-part upload task example

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,34 @@ NSURLSessionUploadTask *uploadTask = [manager uploadTaskWithRequest:request from
 [uploadTask resume];
 ```
 
+#### Creating an Upload Task for a Multi-Part Request, with Progress
+
+```objective-c
+    NSURL *filePath = [NSURL fileURLWithPath:@"file://path/to/image.jpg"];
+    NSURL *URL = [NSURL URLWithString:@"http://example.com/upload"];
+    
+    NSMutableURLRequest *request = [[AFHTTPRequestSerializer serializer] multipartFormRequestWithMethod:HttpMethodPost URLString:[URL absoluteString] parameters:nil constructingBodyWithBlock:^(id<AFMultipartFormData> formData) {
+
+        [formData appendPartWithFileURL:filePath name:@"file" fileName:@"filename.jpg" mimeType:@"image/jpeg" error:nil];
+    } error:nil];
+
+    
+    NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
+    AFURLSessionManager *manager = [[AFURLSessionManager alloc] initWithSessionConfiguration:configuration];
+    NSProgress *progress;
+    
+    
+    NSURLSessionUploadTask *uploadTask = [manager uploadTaskWithStreamedRequest:request progress:&progress completionHandler:^(NSURLResponse *response, id responseObject, NSError *error) {
+        if (error) {
+            NSLog(@"Error: %@", error);
+        } else {
+            NSLog(@"%@ %@", response, responseObject);
+        }
+    }];
+    
+    [uploadTask resume];
+```
+
 #### Creating a Data Task
 
 ```objective-c


### PR DESCRIPTION
I found the documentation lacking an example of how to do multi-part uploads with feedback through NSProgress.
Specifically the crucial connection between multi-part upload and `uploadTaskWithStreamedRequest:progress:completionHandler:`.

(However, the progress part was not working correctly until https://github.com/AFNetworking/AFNetworking/pull/1617)
