### PR TITLE
NSURLConnectionDelegate should be NSURLConnectionDataDelegate

### DIFF
--- a/AFNetworking/AFURLConnectionOperation.h
+++ b/AFNetworking/AFURLConnectionOperation.h
@@ -282,7 +282,7 @@
 - (void)setWillSendRequestForAuthenticationChallengeBlock:(void (^)(NSURLConnection *connection, NSURLAuthenticationChallenge *challenge))block;
 
 /**
- Sets a block to be executed when the server redirects the request from one URL to another URL, or when the request URL changed by the `NSURLProtocol` subclass handling the request in order to standardize its format, as handled by the `NSURLConnectionDelegate` method `connection:willSendRequest:redirectResponse:`.
+ Sets a block to be executed when the server redirects the request from one URL to another URL, or when the request URL changed by the `NSURLProtocol` subclass handling the request in order to standardize its format, as handled by the `NSURLConnectionDataDelegate` method `connection:willSendRequest:redirectResponse:`.
 
  @param block A block object to be executed when the request URL was changed. The block returns an `NSURLRequest` object, the URL request to redirect, and takes three arguments: the URL connection object, the the proposed redirected request, and the URL response that caused the redirect.
  */


### PR DESCRIPTION
The documentation for `-[AFURLConnectionOperation setRedirectResponseBlock:]` points at `-[NSURLConnectionDelegate connection:willSendRequest:redirectResponse]`. That method is actually defined on `NSURLConnectionDataDelegate`.

I can't get my 15 minutes back, but I can save 15 minutes of others' time many times over.
