### PR TITLE
Added exception handling when removing an observer on a task.

### DIFF
--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -761,7 +761,10 @@ didCompleteWithError:(NSError *)error
         [self removeDelegateForTask:task];
     }
 
-    [task removeObserver:self forKeyPath:@"state" context:AFTaskStateChangedContext];
+    @try {
+        [task removeObserver:self forKeyPath:@"state" context:AFTaskStateChangedContext];
+    }
+    @catch (NSException *exception) {}
 }
 
 #pragma mark - NSURLSessionDataDelegate


### PR DESCRIPTION
When a background task is completed, the task may no longer be observed by AFURLSessionManager. In that case, a call to removeObserver will cause an exception. So a try/catch needs to be added to only remove the observer when it has an observer.
