### PR TITLE
AFHTTPSessionManager defined baseURL and not AFURLSessionManager.

### DIFF
--- a/AFNetworking/AFHTTPSessionManager.m
+++ b/AFNetworking/AFHTTPSessionManager.m
@@ -42,8 +42,11 @@
 #endif
 
 @interface AFURLSessionManager ()
-@property (readwrite, nonatomic, strong) NSURL *baseURL;
 @property (readwrite, nonatomic, strong) AFNetworkReachabilityManager *reachabilityManager;
+@end
+
+@interface AFHTTPSessionManager ()
+@property (readwrite, nonatomic, strong) NSURL *baseURL;
 @end
 
 @implementation AFHTTPSessionManager


### PR DESCRIPTION
This was really dumb of me. AFURLSessionManager doesn't define baseURL but rather AFHTTPSessionManager. Im sorry about the previous pull request which was already merged :(
