### PR TITLE
Set the image placeholder only if isn't nil

### DIFF
--- a/UIKit+AFNetworking/UIImageView+AFNetworking.m
+++ b/UIKit+AFNetworking/UIImageView+AFNetworking.m
@@ -139,8 +139,10 @@ static char kAFResponseSerializerKey;
 
         self.af_imageRequestOperation = nil;
     } else {
-        self.image = placeholderImage;
-
+        if (placeholderImage) {
+            self.image = placeholderImage;
+        }
+        
         __weak __typeof(self)weakSelf = self;
         self.af_imageRequestOperation = [[AFHTTPRequestOperation alloc] initWithRequest:urlRequest];
         self.af_imageRequestOperation.responseSerializer = self.imageResponseSerializer;


### PR DESCRIPTION
I was using one UIImageView to show a background image in a controller. When the user change the page in a UIScrollView I change the background image view. I was using the method: -setImageWithURLRequest:placeholderImage:success:failure: passing nil in the placeholderImage parameter, because I just want to change the 'old' image with the 'new' one. This behavior is typically seen in tours the first time the app is executed.

The problem is that this method change the image to nil and for a moment (unitl the new image is downloaded and set) the user can see behind the UIImageView (ex: the white color of the controller).
I solve this problem passing the imageview.image to the placeholder, but I think that this can be done easily inside the method, just checking if the placeholder image is nil. 

What I don't know if the behaviour of setting always the placeholder without checking is on purpose, but well, here it is the PR ^^
