### PR TITLE
Only remove observer if we're observing

### DIFF
--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -759,9 +759,9 @@ didCompleteWithError:(NSError *)error
         }
 
         [self removeDelegateForTask:task];
-    }
 
-    [task removeObserver:self forKeyPath:@"state" context:AFTaskStateChangedContext];
+        [task removeObserver:self forKeyPath:@"state" context:AFTaskStateChangedContext];
+    }
 }
 
 #pragma mark - NSURLSessionDataDelegate
@@ -787,8 +787,10 @@ didReceiveResponse:(NSURLResponse *)response
 didBecomeDownloadTask:(NSURLSessionDownloadTask *)downloadTask
 {
     AFURLSessionManagerTaskDelegate *delegate = [self delegateForTask:dataTask];
-    [self removeDelegateForTask:dataTask];
-    [dataTask removeObserver:self forKeyPath:@"state" context:AFTaskStateChangedContext];
+    if (delegate) {
+        [self removeDelegateForTask:dataTask];
+        [dataTask removeObserver:self forKeyPath:@"state" context:AFTaskStateChangedContext];
+    }
 
     [self setDelegate:delegate forTask:downloadTask];
     [downloadTask addObserver:self forKeyPath:@"state" options:NSKeyValueObservingOptionOld|NSKeyValueObservingOptionNew context:AFTaskStateChangedContext];


### PR DESCRIPTION
We’re only observing this object if we have a delegate for it. Since a background task might come back when we create a new AFURLSessionManager.

Closes #1763
