### PR TITLE
Disable OS X tests on travis. They are still running OS X 10.8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ before_install:
     - brew update
     - brew uninstall xctool && brew install xctool --HEAD
     - cd Tests && pod install && cd $TRAVIS_BUILD_DIR
-script: rake test
+script: rake test:ios


### PR DESCRIPTION
AFNetworking's OS X tests depend on 10.9 and they are failing with a linking issue since travis ci are running on OS X  10.8.

You can see this in the logs of the previous tests: https://travis-ci.org/AFNetworking/AFNetworking/builds/15852718#L890
