### PR TITLE
Session manager: Fixes a bug with updating download progress

### DIFF
--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -222,7 +222,7 @@ didCompleteWithError:(NSError *)error
 {
     [self.mutableData appendData:data];
 
-    self.downloadProgress.totalUnitCount += [data length];
+    self.downloadProgress.completedUnitCount += [data length];
 }
 
 #pragma mark - NSURLSessionDownloadTaskDelegate


### PR DESCRIPTION
Instead of updating the completed progress, it was instead incremementing the total progress.

Related #1780
