### PR TITLE
Authorize users to have self-signed pinned certificates

### DIFF
--- a/AFNetworking/AFSecurityPolicy.m
+++ b/AFNetworking/AFSecurityPolicy.m
@@ -261,7 +261,7 @@ static BOOL AFCertificateHostMatchesDomain(NSString *certificateHost, NSString *
         return YES;
     }
 
-    if (!AFServerTrustIsValid(serverTrust)) {
+    if (!AFServerTrustIsValid(serverTrust) && !self.allowInvalidCertificates) {
         return NO;
     }
 


### PR DESCRIPTION
The code as right now doesn't allow a user to have a self-signed certificate. This pull request attempts to fix that.
