### PR TITLE
Implementing default initializer on AFHTTPRequestOperationManager

### DIFF
--- a/AFNetworking/AFHTTPRequestOperationManager.m
+++ b/AFNetworking/AFHTTPRequestOperationManager.m
@@ -43,6 +43,10 @@
     return [[[self class] alloc] initWithBaseURL:nil];
 }
 
+- (instancetype)init {
+    return [self initWithBaseURL:nil];    
+}
+
 - (instancetype)initWithBaseURL:(NSURL *)url {
     self = [super init];
     if (!self) {


### PR DESCRIPTION
I've implemented `init` to make `AFHTTPRequestOperationManager` consistent to `AFHTTPSessionManager`, which already does that.
