### PR TITLE
Fixed static analyzer warning

### DIFF
--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -348,6 +348,7 @@ expectedTotalBytes:(int64_t)expectedTotalBytes {
 - (void)setDelegate:(AFURLSessionManagerTaskDelegate *)delegate
             forTask:(NSURLSessionTask *)task
 {
+    NSParameterAssert(delegate);
     NSParameterAssert(task);
 
     [self.lock lock];


### PR DESCRIPTION
The analyzer was complaining that it would be possible to assign nil to a mutable dictionary.
