### PR TITLE
move self.uploadPorgress check to inside of dispatch_async block

### DIFF
--- a/AFNetworking/AFURLConnectionOperation.m
+++ b/AFNetworking/AFURLConnectionOperation.m
@@ -598,11 +598,11 @@ willSendRequestForAuthenticationChallenge:(NSURLAuthenticationChallenge *)challe
  totalBytesWritten:(NSInteger)totalBytesWritten
 totalBytesExpectedToWrite:(NSInteger)totalBytesExpectedToWrite
 {
-    if (self.uploadProgress) {
-        dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (self.uploadProgress) {
             self.uploadProgress((NSUInteger)bytesWritten, totalBytesWritten, totalBytesExpectedToWrite);
-        });
-    }
+        }
+    });
 }
 
 - (void)connection:(NSURLConnection __unused *)connection


### PR DESCRIPTION
 If I used upload and download progress at the same time, sometimes I got a BAD_ACCESS error.
Connection method check self.uploadProgress is not nil and execute dispatch_async block, but inside of dispatch_async black, self.uploadProgesss can not be guaranteed it is nil or not.
So, I moved self.uploadPorgess check code to inside of dispatch_async block to guaranteed self.uploadProgress is nil or not.
