### PR TITLE
improve failure handling

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 namespace :test do
   def run_tests(scheme, sdk)
-    system("xcodebuild -workspace AFNetworking.xcworkspace -scheme '#{scheme}' -sdk '#{sdk}' -configuration Release test | xcpretty -c ; exit ${PIPESTATUS[0]}")
+    sh("xcodebuild -workspace AFNetworking.xcworkspace -scheme '#{scheme}' -sdk '#{sdk}' -configuration Release test | xcpretty -c ; exit ${PIPESTATUS[0]}") rescue nil
   end
 
   task :prepare do
@@ -9,23 +9,25 @@ namespace :test do
 
   desc "Run the AFNetworking Tests for iOS"
   task :ios => :prepare do
-    $ios_success = run_tests('iOS Tests', 'iphonesimulator')
+    run_tests('iOS Tests', 'iphonesimulator')
+    @ios_success = $?.success?
   end
 
   desc "Run the AFNetworking Tests for Mac OS X"
   task :osx => :prepare do
-    $osx_success = run_tests('OS X Tests', 'macosx')
+    run_tests('OS X Tests', 'macosx')
+    @osx_success = $?.success?
   end
 end
 
 desc "Run the AFNetworking Tests for iOS & Mac OS X"
 task :test => ['test:ios', 'test:osx'] do
-  puts "\033[0;31m! iOS unit tests failed" unless $ios_success
-  puts "\033[0;31m! OS X unit tests failed" unless $osx_success
-  if $ios_success && $osx_success
+  puts "\033[0;31m! iOS unit tests failed" unless @ios_success
+  puts "\033[0;31m! OS X unit tests failed" unless @osx_success
+  if @ios_success && @osx_success
     puts "\033[0;32m** All tests executed successfully"
   else
-    exit(-1)
+    exit 1
   end
 end
 


### PR DESCRIPTION
Currently, if Rake breaks, sometimes it exits with 0.
This reports build as passing instead of failing.

This PR makes sure we continue running OSX tests if iOS failed,
and exit with 1.

BTW the commit is from the web, i might have missed something.
Will double check in an hour
