### PR TITLE
Removed unreachable code

### DIFF
--- a/AFNetworking/AFSecurityPolicy.m
+++ b/AFNetworking/AFSecurityPolicy.m
@@ -303,8 +303,6 @@ static BOOL AFCertificateHostMatchesDomain(NSString *certificateHost, NSString *
             shouldTrustServer = trustedPublicKeyCount > 0 && ((self.validatesCertificateChain && trustedPublicKeyCount == [serverCertificates count]) || (!self.validatesCertificateChain && trustedPublicKeyCount >= 1));
         }
             break;
-        default:
-            break;
     }
     
     if (shouldTrustServer && domain && self.validatesDomainName) {

--- a/AFNetworking/AFURLConnectionOperation.m
+++ b/AFNetworking/AFURLConnectionOperation.m
@@ -88,8 +88,6 @@ static inline NSString * AFKeyPathFromOperationState(AFOperationState state) {
             return @"isFinished";
         case AFOperationPausedState:
             return @"isPaused";
-        default:
-            return @"state";
     }
 }
 

--- a/AFNetworking/AFURLRequestSerialization.m
+++ b/AFNetworking/AFURLRequestSerialization.m
@@ -424,8 +424,6 @@ NSArray * AFQueryStringPairsFromKeyAndValue(NSString *key, id value) {
             case AFHTTPRequestQueryStringDefaultStyle:
                 query = AFQueryStringFromParametersWithEncoding(parameters, self.stringEncoding);
                 break;
-            default:
-                break;
         }
     }
 


### PR DESCRIPTION
With the release of iOS 7.0.6 and the subsequent "goto fail;" bug, many people will turn on CFLAGS="-Wunreachable-code" in their code bases.

These are three (harmless) instances of unreachable code, since all the possible states of the enums are covered by the switch statements.
