### PR TITLE
Revived reachable code.

### DIFF
--- a/AFNetworking/AFURLConnectionOperation.m
+++ b/AFNetworking/AFURLConnectionOperation.m
@@ -88,6 +88,8 @@ static inline NSString * AFKeyPathFromOperationState(AFOperationState state) {
             return @"isFinished";
         case AFOperationPausedState:
             return @"isPaused";
+        default:
+            return @"state";
     }
 }
 


### PR DESCRIPTION
When an AFURLConnectionOperation is initialized, the value of the "state" property is zero, which does not correspond to any of the AFOperation***State named enum values, so this line was in fact executed each time an object is created.

Deleting this line caused nil to be returned instead of "state", and causes the object to call [self willChangeValueForKey:nil] in the setState method.
