### PR TITLE
[Issue #1833] Podspec fix.

### DIFF
--- a/AFNetworking.podspec
+++ b/AFNetworking.podspec
@@ -49,6 +49,7 @@ Pod::Spec.new do |s|
     ss.ios.deployment_target = '6.0'
 
     ss.dependency 'AFNetworking/NSURLConnection'
+    ss.dependency 'AFNetworking/NSURLSession'
 
     ss.ios.public_header_files = 'UIKit+AFNetworking/*.h'
     ss.ios.source_files = 'UIKit+AFNetworking'


### PR DESCRIPTION
"pod spec lint" will fail with the following error unless we include the dependency on NSURLSession in the UIKit sub spec:
- ERROR | [iOS] [AFNetworking/UIKit] [xcodebuild]  AFNetworking/UIKit+AFNetworking/AFNetworkActivityIndicatorManager.m:30:9: fatal error: 'AFURLSessionManager.h' file not found
