### PR TITLE
Smaller clang diagnostic scope.

### DIFF
--- a/AFNetworking/AFURLConnectionOperation.m
+++ b/AFNetworking/AFURLConnectionOperation.m
@@ -79,8 +79,6 @@ typedef NSCachedURLResponse * (^AFURLConnectionOperationCacheResponseBlock)(NSUR
 typedef NSURLRequest * (^AFURLConnectionOperationRedirectResponseBlock)(NSURLConnection *connection, NSURLRequest *request, NSURLResponse *redirectResponse);
 
 static inline NSString * AFKeyPathFromOperationState(AFOperationState state) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunreachable-code"
     switch (state) {
         case AFOperationReadyState:
             return @"isReady";
@@ -90,10 +88,13 @@ static inline NSString * AFKeyPathFromOperationState(AFOperationState state) {
             return @"isFinished";
         case AFOperationPausedState:
             return @"isPaused";
-        default:
+        default: {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunreachable-code"
             return @"state";
-    }
 #pragma clang diagnostic pop
+        }
+    }
 }
 
 static inline BOOL AFStateTransitionIsValid(AFOperationState fromState, AFOperationState toState, BOOL isCancelled) {


### PR DESCRIPTION
Limit the diagnostic scope, in case case handling changes in future versions.

This is probably unnecessary, as these particular cases won't get more complicated. But I'd hate to see this larger-scoped pattern repeated elsewhere.
