### PR TITLE
Use result of serializer parameter encoding rather than re-encoding as form data for multipart requests

### DIFF
--- a/AFNetworking/AFURLRequestSerialization.m
+++ b/AFNetworking/AFURLRequestSerialization.m
@@ -310,25 +310,12 @@ NSArray * AFQueryStringPairsFromKeyAndValue(NSString *key, id value) {
     NSParameterAssert(method);
     NSParameterAssert(![method isEqualToString:@"GET"] && ![method isEqualToString:@"HEAD"]);
 
-    NSMutableURLRequest *mutableRequest = [self requestWithMethod:method URLString:URLString parameters:nil error:error];
+    NSMutableURLRequest *mutableRequest = [self requestWithMethod:method URLString:URLString parameters:parameters error:error];
 
     __block AFStreamingMultipartFormData *formData = [[AFStreamingMultipartFormData alloc] initWithURLRequest:mutableRequest stringEncoding:NSUTF8StringEncoding];
 
-    if (parameters) {
-        for (AFQueryStringPair *pair in AFQueryStringPairsFromDictionary(parameters)) {
-            NSData *data = nil;
-            if ([pair.value isKindOfClass:[NSData class]]) {
-                data = pair.value;
-            } else if ([pair.value isEqual:[NSNull null]]) {
-                data = [NSData data];
-            } else {
-                data = [[pair.value description] dataUsingEncoding:self.stringEncoding];
-            }
-
-            if (data) {
-                [formData appendPartWithFormData:data name:[pair.field description]];
-            }
-        }
+    if (mutableRequest.HTTPBody) {
+        [formData appendPartWithHeaders:@{@"Content-Disposition": @"form-data", @"Content-Type": [mutableRequest valueForHTTPHeaderField:@"Content-Type"]} body:mutableRequest.HTTPBody];
     }
 
     if (block) {


### PR DESCRIPTION
As pointed out in #1850, there's a mismatch of expectations when a JSON serializer encodes parameters as form data in multipart requests. This patch changes this behavior to use the www-form-url-encoded query string / JSON / plist / etc. body and `Content-Type` as a form-data part rather than attempting to build it manually.

I don't want to merge this in until I can be reasonably sure that it doesn't completely break existing behavior, so I'd appreciate anyone who could give this a try and report back.
