### PR TITLE
Remove unnecessary imports in UIImageView & UIWebView+AFNetworking headers

### DIFF
--- a/UIKit+AFNetworking/UIImageView+AFNetworking.h
+++ b/UIKit+AFNetworking/UIImageView+AFNetworking.h
@@ -28,9 +28,9 @@
 
 #import <UIKit/UIKit.h>
 
-#import "AFURLResponseSerialization.h"
+@protocol AFURLResponseSerialization, AFImageCache;
 
-@protocol AFImageCache;
+@class AFImageResponseSerializer;
 
 /**
  This category adds methods to the UIKit framework's `UIImageView` class. The methods in this category provide support for loading remote images asynchronously from a URL.

--- a/UIKit+AFNetworking/UIWebView+AFNetworking.h
+++ b/UIKit+AFNetworking/UIWebView+AFNetworking.h
@@ -28,8 +28,8 @@
 
 #import <UIKit/UIKit.h>
 
-#import "AFURLRequestSerialization.h"
-#import "AFURLResponseSerialization.h"
+@class AFHTTPRequestSerializer, AFHTTPResponseSerializer;
+@protocol AFURLRequestSerialization, AFURLResponseSerialization;
 
 /**
  This category adds methods to the UIKit framework's `UIWebView` class. The methods in this category provide increased control over the request cycle, including progress monitoring and success / failure handling.

--- a/UIKit+AFNetworking/UIWebView+AFNetworking.m
+++ b/UIKit+AFNetworking/UIWebView+AFNetworking.m
@@ -27,6 +27,8 @@
 #if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
 
 #import "AFHTTPRequestOperation.h"
+#import "AFURLResponseSerialization.h"
+#import "AFURLRequestSerialization.h"
 
 @interface UIWebView (_AFNetworking)
 @property (readwrite, nonatomic, strong, setter = af_setHTTPRequestOperation:) AFHTTPRequestOperation *af_HTTPRequestOperation;


### PR DESCRIPTION
This change brings the two headers mentioned inline with the other UIKit+AFN categories that do not import other AFN headers.

The imports are redundant if you are including `AFNetworking.h`. If you are _not_ importing AFNetworking.h and wish to use the protocols and classes that are now forward declared, you'd need to import the particular headers yourself.
