### PR TITLE
Check CFStringTransform() call for success before using result

### DIFF
--- a/AFNetworking/AFHTTPClient.m
+++ b/AFNetworking/AFHTTPClient.m
@@ -272,8 +272,9 @@ NSArray * AFQueryStringPairsFromKeyAndValue(NSString *key, id value) {
     if (userAgent) {
         if (![userAgent canBeConvertedToEncoding:NSASCIIStringEncoding]) {
             NSMutableString *mutableUserAgent = [userAgent mutableCopy];
-            CFStringTransform((__bridge CFMutableStringRef)(mutableUserAgent), NULL, kCFStringTransformToLatin, false);
-            userAgent = mutableUserAgent;
+            if (CFStringTransform((__bridge CFMutableStringRef)(mutableUserAgent), NULL, kCFStringTransformToLatin, false)) {
+                userAgent = mutableUserAgent;
+            }
         }
         [self setDefaultHeader:@"User-Agent" value:userAgent];
     }


### PR DESCRIPTION
CFStringTransform returns a Boolean to report success/failure, and the string should probably only be used on success. Assuming CFStringTransform is well-behaved, the end result is likely the same.

In any case, our lovely security analysis tool flagged this as a must-fix failure to check error conditions before using a function result, so it seemed worth a pull request. I'm submitting this on the 1.x branch as we're including the library through RestKit, which still depends on 1.x. I have a matching pull request #1867 for master.
