### PR TITLE
Check CFStringTransform() call for success before using result

### DIFF
--- a/AFNetworking/AFURLRequestSerialization.m
+++ b/AFNetworking/AFURLRequestSerialization.m
@@ -212,8 +212,9 @@ NSArray * AFQueryStringPairsFromKeyAndValue(NSString *key, id value) {
     if (userAgent) {
         if (![userAgent canBeConvertedToEncoding:NSASCIIStringEncoding]) {
             NSMutableString *mutableUserAgent = [userAgent mutableCopy];
-            CFStringTransform((__bridge CFMutableStringRef)(mutableUserAgent), NULL, (__bridge CFStringRef)@"Any-Latin; Latin-ASCII; [:^ASCII:] Remove", false);
-            userAgent = mutableUserAgent;
+            if (CFStringTransform((__bridge CFMutableStringRef)(mutableUserAgent), NULL, (__bridge CFStringRef)@"Any-Latin; Latin-ASCII; [:^ASCII:] Remove", false)) {
+                userAgent = mutableUserAgent;
+            }
         }
         [self setValue:userAgent forHTTPHeaderField:@"User-Agent"];
     }


### PR DESCRIPTION
CFStringTransform returns a Boolean to report success/failure, and the string should probably only be used on success. Assuming CFStringTransform is well-behaved, the end result is likely the same.

In any case, our lovely security analysis tool flagged this as a must-fix failure to check error conditions before using a function result, so it seemed worth a pull request.

See matching request #1866 for the 1.x branch.
