### PR TITLE
[URL Operation] Use the ivar directly in initialization

### DIFF
--- a/AFNetworking/AFURLConnectionOperation.m
+++ b/AFNetworking/AFURLConnectionOperation.m
@@ -116,7 +116,15 @@ static inline BOOL AFStateTransitionIsValid(AFOperationState fromState, AFOperat
         case AFOperationPausedState:
             return toState == AFOperationReadyState;
         default:
-            return YES;
+            switch (toState) {
+                case AFOperationPausedState:
+                case AFOperationReadyState:
+                case AFOperationExecutingState:
+                case AFOperationFinishedState:
+                    return YES;
+                default:
+                    return NO;
+            }
     }
 }
 


### PR DESCRIPTION
This is to prevent calling the custom setter inside initialization which broadcasts KVO notifications and relies on existing state which isn't yet setup.

Re #1845
