### PR TITLE
JSON serialization now supports dictionaries and arrays

### DIFF
--- a/AFNetworking/AFURLRequestSerialization.h
+++ b/AFNetworking/AFURLRequestSerialization.h
@@ -191,7 +191,7 @@ forHTTPHeaderField:(NSString *)field;
  */
 - (NSMutableURLRequest *)requestWithMethod:(NSString *)method
                                  URLString:(NSString *)URLString
-                                parameters:(NSDictionary *)parameters DEPRECATED_ATTRIBUTE;
+                                parameters:(id)parameters DEPRECATED_ATTRIBUTE;
 
 /**
  Creates an `NSMutableURLRequest` object with the specified HTTP method and URL string.
@@ -207,7 +207,7 @@ forHTTPHeaderField:(NSString *)field;
  */
 - (NSMutableURLRequest *)requestWithMethod:(NSString *)method
                                  URLString:(NSString *)URLString
-                                parameters:(NSDictionary *)parameters
+                                parameters:(id)parameters
                                      error:(NSError * __autoreleasing *)error;
 
 /**

--- a/AFNetworking/AFURLRequestSerialization.m
+++ b/AFNetworking/AFURLRequestSerialization.m
@@ -263,14 +263,14 @@ NSArray * AFQueryStringPairsFromKeyAndValue(NSString *key, id value) {
 
 - (NSMutableURLRequest *)requestWithMethod:(NSString *)method
                                  URLString:(NSString *)URLString
-                                parameters:(NSDictionary *)parameters
+                                parameters:(id)parameters
 {
     return [self requestWithMethod:method URLString:URLString parameters:parameters error:nil];
 }
 
 - (NSMutableURLRequest *)requestWithMethod:(NSString *)method
                                  URLString:(NSString *)URLString
-                                parameters:(NSDictionary *)parameters
+                                parameters:(id)parameters
                                      error:(NSError *__autoreleasing *)error
 {
     NSParameterAssert(method);

--- a/Tests/Tests/AFJSONSerializationTests.m
+++ b/Tests/Tests/AFJSONSerializationTests.m
@@ -22,6 +22,7 @@
 
 #import "AFTestCase.h"
 
+#import "AFURLRequestSerialization.h"
 #import "AFURLResponseSerialization.h"
 
 static NSData * AFJSONTestData() {
@@ -34,6 +35,34 @@ static NSData * AFJSONTestData() {
 @end
 
 @implementation AFJSONSerializationTests
+
+- (void)testThatJSONRequestSerializationHandlesParametersDictionary {
+    NSDictionary *parameters = @{@"key":@"value"};
+    NSError *error = nil;
+    AFJSONRequestSerializer *serializer = [[AFJSONRequestSerializer alloc] init];
+    NSMutableURLRequest *request = [serializer requestWithMethod:@"POST"
+                                                       URLString:AFNetworkingTestsBaseURLString
+                                                      parameters:parameters
+                                                           error:&error];
+    XCTAssertNil(error, @"Serialization error should be nil");
+    NSString *body = [[NSString alloc] initWithData:[request HTTPBody]
+                                           encoding:NSUTF8StringEncoding];
+    XCTAssertTrue([@"{\"key\":\"value\"}" isEqualToString:body], @"Parameters were not encoded correctly");
+}
+
+- (void)testThatJSONRequestSerializationHandlesParametersArray {
+    NSArray *parameters = @[@{@"key":@"value"}];
+    NSError *error = nil;
+    AFJSONRequestSerializer *serializer = [[AFJSONRequestSerializer alloc] init];
+    NSMutableURLRequest *request = [serializer requestWithMethod:@"POST"
+                                                       URLString:AFNetworkingTestsBaseURLString
+                                                      parameters:parameters
+                                                           error:&error];
+    XCTAssertNil(error, @"Serialization error should be nil");
+    NSString *body = [[NSString alloc] initWithData:[request HTTPBody]
+                                                   encoding:NSUTF8StringEncoding];
+    XCTAssertTrue([@"[{\"key\":\"value\"}]" isEqualToString:body], @"Parameters were not encoded correctly");
+}
 
 - (void)testThatJSONResponseSerializerAcceptsApplicationJSONMimeType {
     NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:self.baseURL statusCode:200 HTTPVersion:@"1.1" headerFields:@{@"Content-Type": @"application/json"}];


### PR DESCRIPTION
- The JSON serialization was only allowing dictionaries to be passed in
- The JSON specification allows for both, and the underlying
  serializer NSJSONSerialization also supported both

RE: https://github.com/AFNetworking/AFNetworking/issues/1879
