### PR TITLE
Fixed a crash caused by autoreleasing NSError object inside the method t...

### DIFF
--- a/AFNetworking/AFURLResponseSerialization.m
+++ b/AFNetworking/AFURLResponseSerialization.m
@@ -194,7 +194,9 @@ static BOOL AFErrorOrUnderlyingErrorHasCode(NSError *error, NSInteger code) {
                            data:(NSData *)data
                           error:(NSError *__autoreleasing *)error
 {
-    if (![self validateResponse:(NSHTTPURLResponse *)response data:data error:error]) {
+    NSError *localError = nil;
+
+    if (![self validateResponse:(NSHTTPURLResponse *)response data:data error:&localError]) {
         if (AFErrorOrUnderlyingErrorHasCode(*error, NSURLErrorCannotDecodeContentData)) {
             return nil;
         }
@@ -234,13 +236,15 @@ static BOOL AFErrorOrUnderlyingErrorHasCode(NSError *error, NSInteger code) {
 
                 serializationError = [NSError errorWithDomain:AFNetworkingErrorDomain code:NSURLErrorCannotDecodeContentData userInfo:userInfo];
             }
-
-            if (error) {
-                *error = AFErrorWithUnderlyingError(serializationError, *error);
-            }
+            
+            localError = AFErrorWithUnderlyingError(serializationError, localError);
         }
     }
-
+    
+    if (error) {
+        *error = localError;
+    }
+    
     return responseObject;
 }
 


### PR DESCRIPTION
...hat was supposed to be passed to the caller by reference using method's argument.

The crash is described in issue #1885. Removing the `@autoreleasepool` is an option as well but this PR fixes memory management only without changing when autoreleased objects are being released - except the `error` object.
