### PR TITLE
New SSL pinning implementation

### DIFF
--- a/AFNetworking/AFSecurityPolicy.m
+++ b/AFNetworking/AFSecurityPolicy.m
@@ -223,8 +223,12 @@ static NSArray * AFPublicKeyTrustChainForServerTrust(SecTrustRef serverTrust) {
 - (BOOL)evaluateServerTrust:(SecTrustRef)serverTrust
                   forDomain:(NSString *)domain
 {
-    if (self.SSLPinningMode == AFSSLPinningModeNone || self.allowInvalidCertificates) {
+    if (self.SSLPinningMode == AFSSLPinningModeNone && self.allowInvalidCertificates) {
         return YES;
+    }
+
+    if (!AFServerTrustIsValid(serverTrust) && !self.allowInvalidCertificates) {
+        return NO;
     }
 
     NSArray *serverCertificates = AFCertificateTrustChainForServerTrust(serverTrust);


### PR DESCRIPTION
Regarding #1852 and #1891, here is an attempt to fix the current SSL pinning implementation:
##### `AFSSLPinningModeCertificate`:
- we are now using `SecTrustSetAnchorCertificates` which lets us explicitly specifies all certificates we want to trust.
- In case of `validatesDomainName = YES`, we are now explicitly using `SecPolicyCreateSSL` which also validated the domain name. Im not relying on the current policy of the trust here, because this might change in a future version (/cc @ericallam). I think being explicit is the better choice.
- In case of `validatesDomainName = NO`, the policy will be `SecPolicyCreateBasicX509`.
##### `AFSSLPinningModePublicKey`:
- The trust is solely determined by the number of trusted public keys without domain name validation.
- I don't think we can use any form of `SecTrustEvaluate` here because the pinned certificates (from which we receive the public keys), might have been expired and don't exist in the trust anymore. 
- I removed domain name validation completely because `SecCertificateCopySubjectSummary` might not return the correct domain, as stated by @ericallam. I don't see another way for us to correctly get the domain name from a certificate without introducing any other dependencies like OpenSSL.
