### PR TITLE
Add boundary to copyWithZone for AFHTTPBodyPart

### DIFF
--- a/AFNetworking/AFURLRequestSerialization.m
+++ b/AFNetworking/AFURLRequestSerialization.m
@@ -1093,6 +1093,7 @@ typedef enum {
     bodyPart.headers = self.headers;
     bodyPart.bodyContentLength = self.bodyContentLength;
     bodyPart.body = self.body;
+    bodyPart.boundary = self.boundary;
     
     return bodyPart;
 }


### PR DESCRIPTION
I added `boundary` to `copyWithZone` for `AFHTTPBodyPart`. Failure to do so resulted in multipart requests where the boundary for that body part was `--(null)` rather than the correct boundary.
