### PR TITLE
Added ability to specify the boundary used in a multipart upload request

### DIFF
--- a/AFNetworking/AFURLRequestSerialization.h
+++ b/AFNetworking/AFURLRequestSerialization.h
@@ -238,6 +238,18 @@ forHTTPHeaderField:(NSString *)field;
                                                   error:(NSError * __autoreleasing *)error;
 
 /**
+ Same as above, allowing you to specify your own boundary
+ @param boundary The multipart boundary to use when constructing the request
+ */
+
+- (NSMutableURLRequest *)multipartFormRequestWithMethod:(NSString *)method
+                                              URLString:(NSString *)URLString
+                                             parameters:(NSDictionary *)parameters
+                                               boundary:(NSString *)boundary
+                              constructingBodyWithBlock:(void (^)(id <AFMultipartFormData> formData))block
+                                                  error:(NSError *__autoreleasing *)error;
+
+/**
  Creates an `NSMutableURLRequest` by removing the `HTTPBodyStream` from a request, and asynchronously writing its contents into the specified file, invoking the completion handler when finished.
  
  @param request The multipart form request.

--- a/AFNetworking/AFURLRequestSerialization.m
+++ b/AFNetworking/AFURLRequestSerialization.m
@@ -157,6 +157,10 @@ NSArray * AFQueryStringPairsFromKeyAndValue(NSString *key, id value) {
 - (instancetype)initWithURLRequest:(NSMutableURLRequest *)urlRequest
                     stringEncoding:(NSStringEncoding)encoding;
 
+- (instancetype)initWithURLRequest:(NSMutableURLRequest *)urlRequest
+                    stringEncoding:(NSStringEncoding)encoding
+                          boundary:(NSString *)boundary;
+
 - (NSMutableURLRequest *)requestByFinalizingMultipartFormData;
 @end
 
@@ -308,12 +312,33 @@ NSArray * AFQueryStringPairsFromKeyAndValue(NSString *key, id value) {
                               constructingBodyWithBlock:(void (^)(id <AFMultipartFormData> formData))block
                                                   error:(NSError *__autoreleasing *)error
 {
+    return [self multipartFormRequestWithMethod:method
+                                      URLString:URLString
+                                     parameters:parameters
+                                       boundary:nil
+                      constructingBodyWithBlock:block
+                                          error:error];
+}
+
+- (NSMutableURLRequest *)multipartFormRequestWithMethod:(NSString *)method
+                                              URLString:(NSString *)URLString
+                                             parameters:(NSDictionary *)parameters
+                                               boundary:(NSString *)boundary
+                              constructingBodyWithBlock:(void (^)(id <AFMultipartFormData> formData))block
+                                                  error:(NSError *__autoreleasing *)error
+{
     NSParameterAssert(method);
     NSParameterAssert(![method isEqualToString:@"GET"] && ![method isEqualToString:@"HEAD"]);
 
     NSMutableURLRequest *mutableRequest = [self requestWithMethod:method URLString:URLString parameters:nil error:error];
 
-    __block AFStreamingMultipartFormData *formData = [[AFStreamingMultipartFormData alloc] initWithURLRequest:mutableRequest stringEncoding:NSUTF8StringEncoding];
+    __block AFStreamingMultipartFormData *formData;
+    
+    if (boundary) {
+        formData = [[AFStreamingMultipartFormData alloc] initWithURLRequest:mutableRequest stringEncoding:NSUTF8StringEncoding boundary:boundary];
+    } else {
+        formData = [[AFStreamingMultipartFormData alloc] initWithURLRequest:mutableRequest stringEncoding:NSUTF8StringEncoding];
+    }
 
     if (parameters) {
         for (AFQueryStringPair *pair in AFQueryStringPairsFromDictionary(parameters)) {
@@ -562,6 +587,20 @@ NSTimeInterval const kAFUploadStream3GSuggestedDelay = 0.2;
     self.boundary = AFCreateMultipartFormBoundary();
     self.bodyStream = [[AFMultipartBodyStream alloc] initWithStringEncoding:encoding];
 
+    return self;
+}
+
+- (id)initWithURLRequest:(NSMutableURLRequest *)urlRequest
+          stringEncoding:(NSStringEncoding)encoding
+                boundary:(NSString *)boundary
+{
+    self = [self initWithURLRequest:urlRequest stringEncoding:encoding];
+    if (!self) {
+        return nil;
+    }
+    
+    self.boundary = boundary;
+    
     return self;
 }
 


### PR DESCRIPTION
Now that the boundary is generated randomly, using AFNetworking to upload a pre-made HTTP body from disk (this can affect those that upload in the background using the Background Transfer Service), the boundary generated vs. used in that pre-made HTTP body will differ - causing uploads to fail.

This patch allows for a user to specify a boundary when generating a `multipartFormRequestWithMethod`. The extra parameter is optional and will default to existing behavior if set to `nil`.
