### PR TITLE
Add a flag on AFHTTPRequestSerializer to optionally avoid ever requiring the main thread

### DIFF
--- a/AFNetworking/AFURLRequestSerialization.h
+++ b/AFNetworking/AFURLRequestSerialization.h
@@ -66,6 +66,12 @@ typedef NS_ENUM(NSUInteger, AFHTTPRequestQueryStringSerializationStyle) {
 @interface AFHTTPRequestSerializer : NSObject <AFURLRequestSerialization>
 
 /**
+ If true, enforces that AFNetorking never assumes the main thread is free to perform tasks.
+ Can be used for systems that lock the main thread themselves. Defaults to NO.
+ */
+@property (nonatomic, assign) BOOL avoidsMainThread;
+
+/**
  The string encoding used to serialize parameters. `NSUTF8StringEncoding` by default.
  */
 @property (nonatomic, assign) NSStringEncoding stringEncoding;


### PR DESCRIPTION
I have an implementation of integration specs that invokes an instance of `AFHTTPRequestOperation` synchronously using `waitUntilFinished` so that I can make assertions after running a series of calls, each guaranteed to finish before the next begins.  Pretty common pattern.

But I had to hunt down why things were timing out whenever I POSTed multipart forms.  Any reason why a networking library ever needs to perform anything on the main thread?  Would be much cleaner to just remove the `[[NSThread currentThread] isMainThread]` entirely.  Things seem to run perfectly with no issues when I simply kill this block.
