### PR TITLE
Include AFNetworking.h

### DIFF
--- a/AFNetworking.podspec
+++ b/AFNetworking.podspec
@@ -15,6 +15,10 @@ Pod::Spec.new do |s|
   s.public_header_files = 'AFNetworking/*.h'
   s.source_files = 'AFNetworking/AFNetworking.h'
 
+  s.subspec 'Headers' do |ss|
+    ss.source_files = 'AFNetworking/AFNetworking.h'
+  end
+
   s.subspec 'Serialization' do |ss|
     ss.source_files = 'AFNetworking/AFURL{Request,Response}Serialization.{h,m}'
     ss.ios.frameworks = 'MobileCoreServices', 'CoreGraphics'
@@ -35,6 +39,7 @@ Pod::Spec.new do |s|
     ss.dependency 'AFNetworking/Serialization'
     ss.dependency 'AFNetworking/Reachability'
     ss.dependency 'AFNetworking/Security'
+    ss.dependency 'AFNetworking/Headers'
 
     ss.source_files = 'AFNetworking/AFURLConnectionOperation.{h,m}', 'AFNetworking/AFHTTPRequestOperation.{h,m}', 'AFNetworking/AFHTTPRequestOperationManager.{h,m}'
   end


### PR DESCRIPTION
This fixes #1949.

I'm not sure what to do with root directives

```
s.public_header_files = 'AFNetworking/*.h'
s.source_files = 'AFNetworking/AFNetworking.h'
```

I'm newbie in Cocoapods, so, logically they should have been doing what I'm trying to fix with this change, however, it wasn't working.
