### PR TITLE
Fix test setup with CocoaPods 0.31.0

### DIFF
--- a/Tests/Podfile
+++ b/Tests/Podfile
@@ -5,7 +5,7 @@ inhibit_all_warnings!
 def import_pods
   pod 'OCMock', '~> 2.1.1'
   pod 'Expecta', '~> 0.2.1'
-  pod 'AFNetworking', :path => '../'
+  pod 'AFNetworking', :path => '../AFNetworking.podspec'
 end
 
 target :ios do


### PR DESCRIPTION
Fix unit test instructions of

$ cd Tests
$ pod install

to install dependencies for running unit tests with CocoaPods 0.31.0
