### PR TITLE
Memory improvements

### DIFF
--- a/AFNetworking/AFURLConnectionOperation.m
+++ b/AFNetworking/AFURLConnectionOperation.m
@@ -644,6 +644,7 @@ didReceiveResponse:(NSURLResponse *)response
         if (self.outputStream.streamError) {
             [self.connection cancel];
             [self performSelector:@selector(connection:didFailWithError:) withObject:self.connection withObject:self.outputStream.streamError];
+            self.outputStream=nil;
             return;
         }
     }
@@ -660,10 +661,9 @@ didReceiveResponse:(NSURLResponse *)response
 - (void)connectionDidFinishLoading:(NSURLConnection __unused *)connection {
     self.responseData = [self.outputStream propertyForKey:NSStreamDataWrittenToMemoryStreamKey];
     
-    [self.outputStream close];
-    
     [self finish];
     
+    self.outputStream=nil;
     self.connection = nil;
 }
 
@@ -672,10 +672,9 @@ didReceiveResponse:(NSURLResponse *)response
 {
     self.error = error;
     
-    [self.outputStream close];
-    
     [self finish];
-    
+
+    self.outputStream=nil;
     self.connection = nil;
 }
 

--- a/UIKit+AFNetworking/UIImageView+AFNetworking.m
+++ b/UIKit+AFNetworking/UIImageView+AFNetworking.m
@@ -153,12 +153,16 @@
             }
 
             [[[strongSelf class] sharedImageCache] cacheImage:responseObject forRequest:urlRequest];
+            
+            strongSelf.af_imageRequestOperation = nil;
         } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+            __strong __typeof(weakSelf)strongSelf = weakSelf;
             if ([[urlRequest URL] isEqual:[operation.request URL]]) {
                 if (failure) {
                     failure(urlRequest, operation.response, error);
                 }
             }
+            strongSelf.af_imageRequestOperation = nil;
         }];
 
         [[[self class] af_sharedImageRequestOperationQueue] addOperation:self.af_imageRequestOperation];


### PR DESCRIPTION
Application is using more memory than necessary when using the UIImageView-category setImageWithURL.

Two fixes:
On AFURLConnectionOperation: clean up NSOutputStream when ready (so after getting self.responseDate from this stream)
Clean up af_imageRequestOperation on UIImageView when ready (operation is no longer needed when image is loaded. This releases the operation and so releases the output stream).

The first fix solves the problem, the second one is just cleanup.

See https://bitbucket.org/teunvr/memorytest
