### PR TITLE
Fix 64-bit iOS unit tests

### DIFF
--- a/Tests/Tests/AFHTTPRequestOperationTests.m
+++ b/Tests/Tests/AFHTTPRequestOperationTests.m
@@ -443,7 +443,8 @@
     [operation setOutputStream:({
         id mockStream = [OCMockObject mockForClass:[NSOutputStream class]];
         [[[mockStream stub] andReturn:streamError] streamError];
-        [[[mockStream stub] andReturnValue:@(NO)] hasSpaceAvailable];
+        BOOL no = NO;
+        [[[mockStream stub] andReturnValue:OCMOCK_VALUE(no)] hasSpaceAvailable];
 
         // "Note that currently partial mocks cannot be created for instances of toll-free bridged classes". Thus, we have to fully mock it
         [[mockStream stub] scheduleInRunLoop:OCMOCK_ANY forMode:OCMOCK_ANY];


### PR DESCRIPTION
Under 64-bit iOS, the `BOOL` type has changed from `signed char` to `bool` but NSNumber did not get the memo. So `[@NO objCType]` (which is equivalent to `[[NSNumber numberWithBool:NO] objCType]`) returns "c" (_C_CHR) instead of "B" (_C_BOOL). OCMock uses this information to check that the mock return type is compatible with the expected return type. Using the OCMOCK_VALUE macro solves the problem since it explicitly encodes the `BOOL` type.
