### PR TITLE
Reconnect NSURLSessionTasks to AFNetworking delegates when resuming a session

### DIFF
--- a/AFNetworking/AFURLSessionManager.h
+++ b/AFNetworking/AFURLSessionManager.h
@@ -261,6 +261,25 @@
                                              destination:(NSURL * (^)(NSURL *targetPath, NSURLResponse *response))destination
                                        completionHandler:(void (^)(NSURLResponse *response, NSURL *filePath, NSError *error))completionHandler;
 
+///-----------------------------
+/// @name Progress for Tasks
+///-----------------------------
+
+/**
+ Retrieves the download `NSProgress` instance for the specified task
+ 
+ @param task The task to retrieve download progress for
+ */
+- (NSProgress*)downloadProgressForTask:(NSURLSessionTask*)task;
+
+/**
+ Retrieves the upload `NSProgress` instance for the specified task
+ 
+ @param task The task to retrieve download progress for
+ */
+- (NSProgress*)uploadProgressForTask:(NSURLSessionTask*)task;
+
+
 ///-----------------------------------------
 /// @name Setting Session Delegate Callbacks
 ///-----------------------------------------


### PR DESCRIPTION
When coming back from the background, having the AFNetworking session reconnect its tasks with delegates would be useful, even if the blocks are no longer valid.  This allows us to access the progress of these tasks after returning to the app.
