### PR TITLE
Added AFHTTPImageLoader as a stand-alone component.

### DIFF
--- a/AFNetworking.podspec
+++ b/AFNetworking.podspec
@@ -31,6 +31,10 @@ Pod::Spec.new do |s|
     ss.frameworks = 'SystemConfiguration'
   end
 
+  s.subspec 'AFHTTPImageLoader' do |ss|
+    ss.source_files = 'AFNetworking/AFHTTPImageLoader.{h,m}'
+  end
+
   s.subspec 'NSURLConnection' do |ss|
     ss.dependency 'AFNetworking/Serialization'
     ss.dependency 'AFNetworking/Reachability'

--- a/AFNetworking.xcworkspace/contents.xcworkspacedata
+++ b/AFNetworking.xcworkspace/contents.xcworkspacedata
@@ -9,6 +9,16 @@
       </FileRef>
       <Group
          location = "container:"
+         name = "HTTPImageLoader">
+         <FileRef
+            location = "group:AFNetworking/AFHTTPImageLoader.h">
+         </FileRef>
+         <FileRef
+            location = "group:AFNetworking/AFHTTPImageLoader.m">
+         </FileRef>
+      </Group>
+      <Group
+         location = "container:"
          name = "NSURLConnection">
          <FileRef
             location = "group:AFNetworking/AFURLConnectionOperation.h">

--- a/AFNetworking/AFHTTPImageLoader.h
+++ b/AFNetworking/AFHTTPImageLoader.h
@@ -1,0 +1,129 @@
+// AFHTTPRequestOperation.h
+//
+// Copyright (c) 2013 AFNetworking (http://afnetworking.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+
+#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
+
+#import <UIKit/UIKit.h>
+
+@protocol AFImageCache, AFURLResponseSerialization;
+@class AFImageResponseSerializer;
+
+typedef void(^AFHTTPImageLoaderSuccessBlock)(NSURLRequest *request, NSHTTPURLResponse *response, UIImage *image);
+typedef void(^AFHTTPImageLoaderFailureBlock)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error);
+
+@interface AFHTTPImageLoader : NSObject
+
+///----------------------------
+/// @name Accessing Image Cache
+///----------------------------
+
+/**
+ The image cache used to improve image loadiing performance on scroll views. By default, this is an `NSCache` subclass conforming to the `AFImageCache` protocol, which listens for notification warnings and evicts objects accordingly.
+ */
+@property (nonatomic, strong) id<AFImageCache> imageCache;
+
+///------------------------------------
+/// @name Accessing Response Serializer
+///------------------------------------
+
+/**
+ The response serializer used to create an image representation from the server response and response data. By default, this is an instance of `AFImageResponseSerializer`.
+ 
+ @discussion Subclasses of `AFImageResponseSerializer` could be used to perform post-processing, such as color correction, face detection, or other effects. See https://github.com/AFNetworking/AFCoreImageSerializer
+ */
+@property (nonatomic, strong) AFImageResponseSerializer <AFURLResponseSerialization> * imageResponseSerializer;
+
+#pragma mark - Shared Image Cache
+
+/**
+ Use this method to get the shared image cache for this class.  This is the default image cache used when imageCache is not explicitely set.
+ 
+ @returns	The shared image cache.  Will never be nil.
+ */
++ (id <AFImageCache>)sharedImageCache;
+
+#pragma mark - Requesting images
+
+/**
+ Use this method to asynchronously request an image with an URL.
+ 
+ @param url					The url for the image. Cannot be nil.
+ @param	success				The block to execute on success.  Can be nil.
+ @param	failure				The block to execute on failure.  Can be nil.
+ 
+ @returns	If a cached image is found, it is returned immediately and the success and failure blocks will never
+			be executed.
+ */
+- (UIImage*)imageWithURL:(NSURL *)url
+				 success:(AFHTTPImageLoaderSuccessBlock)success
+				 failure:(AFHTTPImageLoaderFailureBlock)failure;
+
+/**
+ Use this method to asynchronously request an image with an URL request.
+ 
+ @param urlRequest			The request for the image. Cannot be nil.
+ @param	success				The block to execute on success.  Can be nil.
+ @param	failure				The block to execute on failure.  Can be nil.
+ 
+ @returns	If a cached image is found, it is returned immediately and the success and failure blocks will never
+			be executed.
+ */
+- (UIImage*)imageWithURLRequest:(NSURLRequest *)urlRequest
+						success:(AFHTTPImageLoaderSuccessBlock)success
+						failure:(AFHTTPImageLoaderFailureBlock)failure;
+
+/**
+ Cancels any executing image operation for the receiver, if one exists.
+ */
+- (void)cancelImageRequestOperation;
+
+@end
+
+#pragma mark -
+
+/**
+ The `AFImageCache` protocol is adopted by an object used to cache images loaded by the AFNetworking category on `UIImageView`.
+ */
+@protocol AFImageCache
+
+/**
+ Returns a cached image for the specififed request, if available.
+ 
+ @param request The image request.
+ 
+ @return The cached image.
+ */
+- (UIImage *)cachedImageForRequest:(NSURLRequest *)request;
+
+/**
+ Caches a particular image for the specified request.
+ 
+ @param image The image to cache.
+ @param request The request to be used as a cache key.
+ */
+- (void)cacheImage:(UIImage *)image
+        forRequest:(NSURLRequest *)request;
+@end
+
+#endif

--- a/AFNetworking/AFHTTPImageLoader.m
+++ b/AFNetworking/AFHTTPImageLoader.m
@@ -1,0 +1,196 @@
+// AFHTTPRequestOperation.m
+//
+// Copyright (c) 2013 AFNetworking (http://afnetworking.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "AFHTTPImageLoader.h"
+
+#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
+
+#import "AFHTTPRequestOperation.h"
+
+@interface AFImageCache : NSCache <AFImageCache>
+@end
+
+@interface AFHTTPImageLoader ()
+@property (readwrite, nonatomic, strong, setter = af_setImageRequestOperation:) AFHTTPRequestOperation *af_imageRequestOperation;
+@end
+
+@implementation AFHTTPImageLoader
+
+#pragma mark - Shared Objects
+
++ (id <AFImageCache>)sharedImageCache {
+    static id <AFImageCache> af_sharedImageCache = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        af_sharedImageCache = [[AFImageCache alloc] init];
+    });
+	
+    return af_sharedImageCache;
+}
+
++ (NSOperationQueue *)af_sharedImageRequestOperationQueue {
+    static NSOperationQueue *_af_sharedImageRequestOperationQueue = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        _af_sharedImageRequestOperationQueue = [[NSOperationQueue alloc] init];
+        _af_sharedImageRequestOperationQueue.maxConcurrentOperationCount = NSOperationQueueDefaultMaxConcurrentOperationCount;
+    });
+	
+    return _af_sharedImageRequestOperationQueue;
+}
+
+#pragma mark - Getters & setters
+
+- (id <AFImageCache>)imageCache
+{
+	if (!_imageCache)
+	{
+		_imageCache = [[self class] sharedImageCache];
+	}
+	
+	return _imageCache;
+}
+
+- (AFImageResponseSerializer <AFURLResponseSerialization> *)imageResponseSerializer
+{
+	if (!_imageResponseSerializer)
+	{
+		_imageResponseSerializer = [[AFImageResponseSerializer alloc] init];
+	}
+	
+	return _imageResponseSerializer;
+}
+
+#pragma mark - Requesting images
+
+- (UIImage*)imageWithURL:(NSURL *)url
+				 success:(AFHTTPImageLoaderSuccessBlock)success
+				 failure:(AFHTTPImageLoaderFailureBlock)failure
+{
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
+    [request addValue:@"image/*" forHTTPHeaderField:@"Accept"];
+	
+	return [self imageWithURLRequest:request
+							 success:success
+							 failure:failure];
+}
+
+- (UIImage*)imageWithURLRequest:(NSURLRequest *)urlRequest
+						success:(AFHTTPImageLoaderSuccessBlock)success
+						failure:(AFHTTPImageLoaderFailureBlock)failure
+{
+	NSParameterAssert(urlRequest);
+	
+    [self cancelImageRequestOperation];
+	
+    UIImage* cachedImage = [self.imageCache cachedImageForRequest:urlRequest];
+	
+	if (!cachedImage) {
+		BOOL hasAtLeastOneCompletionBlock = (success || failure);
+		
+		if (hasAtLeastOneCompletionBlock)
+		{
+			[self downloadImageWithURLRequest:urlRequest
+									  success:success
+									  failure:failure];
+		}
+    }
+	
+	return cachedImage;
+}
+
+/**
+ Downloads the image specified by the URL request.  This method does not check against the local cache.
+ 
+ @param	urlRequest		The URL request that identifies the image to download.
+ @param	success			The block to execute on success.  Can be nil.
+ @param	failure			The block to execute on failure.  Can be nil.
+ */
+- (void)downloadImageWithURLRequest:(NSURLRequest*)urlRequest
+							success:(AFHTTPImageLoaderSuccessBlock)success
+							failure:(AFHTTPImageLoaderFailureBlock)failure
+{
+	NSCAssert([urlRequest isKindOfClass:[NSURLRequest class]], @"Expected a proper request object.");
+	
+	__weak __typeof(self)weakSelf = self;
+	self.af_imageRequestOperation = [[AFHTTPRequestOperation alloc] initWithRequest:urlRequest];
+	self.af_imageRequestOperation.responseSerializer = self.imageResponseSerializer;
+	[self.af_imageRequestOperation setCompletionBlockWithSuccess:^(AFHTTPRequestOperation *operation, id responseObject) {
+		__strong __typeof(weakSelf)strongSelf = weakSelf;
+		if ([[urlRequest URL] isEqual:[operation.request URL]]) {
+			if (success) {
+				success(urlRequest, operation.response, responseObject);
+			}
+		}
+		
+		[strongSelf.imageCache cacheImage:responseObject forRequest:urlRequest];
+	} failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+		if ([[urlRequest URL] isEqual:[operation.request URL]]) {
+			if (failure) {
+				failure(urlRequest, operation.response, error);
+			}
+		}
+	}];
+	
+	[[[self class] af_sharedImageRequestOperationQueue] addOperation:self.af_imageRequestOperation];
+}
+
+#pragma mark - Request Operation handling
+
+- (void)cancelImageRequestOperation {
+    [self.af_imageRequestOperation cancel];
+    self.af_imageRequestOperation = nil;
+}
+
+@end
+
+#pragma mark -
+
+static inline NSString * AFImageCacheKeyFromURLRequest(NSURLRequest *request) {
+    return [[request URL] absoluteString];
+}
+
+@implementation AFImageCache
+
+- (UIImage *)cachedImageForRequest:(NSURLRequest *)request {
+    switch ([request cachePolicy]) {
+        case NSURLRequestReloadIgnoringCacheData:
+        case NSURLRequestReloadIgnoringLocalAndRemoteCacheData:
+            return nil;
+        default:
+            break;
+    }
+	
+	return [self objectForKey:AFImageCacheKeyFromURLRequest(request)];
+}
+
+- (void)cacheImage:(UIImage *)image
+        forRequest:(NSURLRequest *)request
+{
+    if (image && request) {
+        [self setObject:image forKey:AFImageCacheKeyFromURLRequest(request)];
+    }
+}
+
+@end
+
+#endif

--- a/UIKit+AFNetworking/UIImageView+AFNetworking.h
+++ b/UIKit+AFNetworking/UIImageView+AFNetworking.h
@@ -28,41 +28,21 @@
 
 #import <UIKit/UIKit.h>
 
-@protocol AFURLResponseSerialization, AFImageCache;
-
-@class AFImageResponseSerializer;
+@class AFHTTPImageLoader;
 
 /**
  This category adds methods to the UIKit framework's `UIImageView` class. The methods in this category provide support for loading remote images asynchronously from a URL.
  */
 @interface UIImageView (AFNetworking)
 
-///----------------------------
-/// @name Accessing Image Cache
-///----------------------------
+///-----------------------------
+/// @name Accessing Image Loader
+///-----------------------------
 
 /**
- The image cache used to improve image loadiing performance on scroll views. By default, this is an `NSCache` subclass conforming to the `AFImageCache` protocol, which listens for notification warnings and evicts objects accordingly.
-*/
-+ (id <AFImageCache>)sharedImageCache;
-
-/**
- Set the cache used for image loading.
- 
- @param imageCache The image cache.
+ The image loader takes care of asnychronously loading an image from an URL.
  */
-+ (void)setSharedImageCache:(id <AFImageCache>)imageCache;
-
-///------------------------------------
-/// @name Accessing Response Serializer
-///------------------------------------
-
-/**
- The response serializer used to create an image representation from the server response and response data. By default, this is an instance of `AFImageResponseSerializer`.
- 
- @discussion Subclasses of `AFImageResponseSerializer` could be used to perform post-processing, such as color correction, face detection, or other effects. See https://github.com/AFNetworking/AFCoreImageSerializer
- */
-@property (nonatomic, strong) AFImageResponseSerializer <AFURLResponseSerialization> * imageResponseSerializer;
+@property (nonatomic, strong) AFHTTPImageLoader* imageLoader;
 
 ///--------------------
 /// @name Setting Image
@@ -114,32 +94,6 @@
  */
 - (void)cancelImageRequestOperation;
 
-@end
-
-#pragma mark -
-
-/**
- The `AFImageCache` protocol is adopted by an object used to cache images loaded by the AFNetworking category on `UIImageView`.
- */
-@protocol AFImageCache
-
-/**
- Returns a cached image for the specififed request, if available.
- 
- @param request The image request.
- 
- @return The cached image.
- */
-- (UIImage *)cachedImageForRequest:(NSURLRequest *)request;
-
-/**
- Caches a particular image for the specified request.
- 
- @param image The image to cache.
- @param request The request to be used as a cache key.
- */
-- (void)cacheImage:(UIImage *)image
-        forRequest:(NSURLRequest *)request;
 @end
 
 #endif

--- a/UIKit+AFNetworking/UIImageView+AFNetworking.m
+++ b/UIKit+AFNetworking/UIImageView+AFNetworking.m
@@ -26,81 +26,28 @@
 
 #if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
 
-#import "AFHTTPRequestOperation.h"
-
-@interface AFImageCache : NSCache <AFImageCache>
-@end
-
-#pragma mark -
-
-@interface UIImageView (_AFNetworking)
-@property (readwrite, nonatomic, strong, setter = af_setImageRequestOperation:) AFHTTPRequestOperation *af_imageRequestOperation;
-@end
-
-@implementation UIImageView (_AFNetworking)
-
-+ (NSOperationQueue *)af_sharedImageRequestOperationQueue {
-    static NSOperationQueue *_af_sharedImageRequestOperationQueue = nil;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        _af_sharedImageRequestOperationQueue = [[NSOperationQueue alloc] init];
-        _af_sharedImageRequestOperationQueue.maxConcurrentOperationCount = NSOperationQueueDefaultMaxConcurrentOperationCount;
-    });
-
-    return _af_sharedImageRequestOperationQueue;
-}
-
-- (AFHTTPRequestOperation *)af_imageRequestOperation {
-    return (AFHTTPRequestOperation *)objc_getAssociatedObject(self, @selector(af_imageRequestOperation));
-}
-
-- (void)af_setImageRequestOperation:(AFHTTPRequestOperation *)imageRequestOperation {
-    objc_setAssociatedObject(self, @selector(af_imageRequestOperation), imageRequestOperation, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-}
-
-@end
+#import "AFHTTPImageLoader.h"
 
 #pragma mark -
 
 @implementation UIImageView (AFNetworking)
-@dynamic imageResponseSerializer;
+@dynamic imageLoader;
 
-+ (id <AFImageCache>)sharedImageCache {
-    static AFImageCache *_af_defaultImageCache = nil;
-    static dispatch_once_t oncePredicate;
-    dispatch_once(&oncePredicate, ^{
-        _af_defaultImageCache = [[AFImageCache alloc] init];
-
-        [[NSNotificationCenter defaultCenter] addObserverForName:UIApplicationDidReceiveMemoryWarningNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification * __unused notification) {
-            [_af_defaultImageCache removeAllObjects];
-        }];
-    });
-
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wgnu"
-    return objc_getAssociatedObject(self, @selector(sharedImageCache)) ?: _af_defaultImageCache;
-#pragma clang diagnostic pop
-}
-
-+ (void)setSharedImageCache:(id<AFImageCache>)imageCache {
-    objc_setAssociatedObject(self, @selector(sharedImageCache), imageCache, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-}
-
-- (id <AFURLResponseSerialization>)imageResponseSerializer {
-    static id <AFURLResponseSerialization> _af_defaultImageResponseSerializer = nil;
+- (AFHTTPImageLoader*)imageLoader {
+    static AFHTTPImageLoader* _af_defaultImageLoader = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        _af_defaultImageResponseSerializer = [AFImageResponseSerializer serializer];
+        _af_defaultImageLoader = [[AFHTTPImageLoader alloc] init];
     });
-
+	
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wgnu"
-    return objc_getAssociatedObject(self, @selector(imageResponseSerializer)) ?: _af_defaultImageResponseSerializer;
+    return objc_getAssociatedObject(self, @selector(imageLoader)) ?: _af_defaultImageLoader;
 #pragma clang diagnostic pop
 }
 
-- (void)setImageResponseSerializer:(id <AFURLResponseSerialization>)serializer {
-    objc_setAssociatedObject(self, @selector(imageResponseSerializer), serializer, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+- (void)setImageLoader:(AFHTTPImageLoader *)imageLoader {
+    objc_setAssociatedObject(self, @selector(imageLoader), imageLoader, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
 #pragma mark -
@@ -123,81 +70,34 @@
                        success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, UIImage *image))success
                        failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error))failure
 {
-    [self cancelImageRequestOperation];
-
-    UIImage *cachedImage = [[[self class] sharedImageCache] cachedImageForRequest:urlRequest];
-    if (cachedImage) {
-        if (success) {
-            success(nil, nil, cachedImage);
-        } else {
-            self.image = cachedImage;
-        }
-
-        self.af_imageRequestOperation = nil;
-    } else {
-        if (placeholderImage) {
-            self.image = placeholderImage;
-        }
-        
-        __weak __typeof(self)weakSelf = self;
-        self.af_imageRequestOperation = [[AFHTTPRequestOperation alloc] initWithRequest:urlRequest];
-        self.af_imageRequestOperation.responseSerializer = self.imageResponseSerializer;
-        [self.af_imageRequestOperation setCompletionBlockWithSuccess:^(AFHTTPRequestOperation *operation, id responseObject) {
-            __strong __typeof(weakSelf)strongSelf = weakSelf;
-            if ([[urlRequest URL] isEqual:[strongSelf.af_imageRequestOperation.request URL]]) {
-                if (success) {
-                    success(urlRequest, operation.response, responseObject);
-                } else if (responseObject) {
-                    strongSelf.image = responseObject;
-                }
-            }
-
-            [[[strongSelf class] sharedImageCache] cacheImage:responseObject forRequest:urlRequest];
-        } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
-            if ([[urlRequest URL] isEqual:[operation.request URL]]) {
-                if (failure) {
-                    failure(urlRequest, operation.response, error);
-                }
-            }
-        }];
-
-        [[[self class] af_sharedImageRequestOperationQueue] addOperation:self.af_imageRequestOperation];
-    }
+	__weak typeof(self) weakSelf = self;
+	
+	self.image = placeholderImage;
+	
+	UIImage* image = [self.imageLoader imageWithURLRequest:urlRequest
+												   success:^(NSURLRequest *request, NSHTTPURLResponse *response, UIImage *image) {
+		if (success) {
+			success(nil, nil, image);
+		} else {
+			weakSelf.image = image;
+		}
+	} failure:^(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error) {
+		if (failure) {
+			failure(request, response, error);
+		}
+	}];
+	
+	if (image) {
+		if (success) {
+			success(nil, nil, image);
+		} else {
+			self.image = image;
+		}
+	}
 }
 
 - (void)cancelImageRequestOperation {
-    [self.af_imageRequestOperation cancel];
-    self.af_imageRequestOperation = nil;
-}
-
-@end
-
-#pragma mark -
-
-static inline NSString * AFImageCacheKeyFromURLRequest(NSURLRequest *request) {
-    return [[request URL] absoluteString];
-}
-
-@implementation AFImageCache
-
-- (UIImage *)cachedImageForRequest:(NSURLRequest *)request {
-    switch ([request cachePolicy]) {
-        case NSURLRequestReloadIgnoringCacheData:
-        case NSURLRequestReloadIgnoringLocalAndRemoteCacheData:
-            return nil;
-        default:
-            break;
-    }
-
-	return [self objectForKey:AFImageCacheKeyFromURLRequest(request)];
-}
-
-- (void)cacheImage:(UIImage *)image
-        forRequest:(NSURLRequest *)request
-{
-    if (image && request) {
-        [self setObject:image forKey:AFImageCacheKeyFromURLRequest(request)];
-    }
+	[self.imageLoader cancelImageRequestOperation];
 }
 
 @end


### PR DESCRIPTION
Adds AFHTTPImageLoader as a stand-alone component that can be used to asynchronously download images without needing an UIImageView+AFNetworking to do so.

The code for this class was mostly taken from UIImageView+AFNetworking and reorganized.

Class UIImageView+AFNetworking was modified to rely on this component.
