### PR TITLE
Add Protocol Buffer support

### DIFF
--- a/AFNetworking.xcworkspace/contents.xcworkspacedata
+++ b/AFNetworking.xcworkspace/contents.xcworkspacedata
@@ -44,6 +44,12 @@
          <FileRef
             location = "group:AFNetworking/AFHTTPSessionManager.m">
          </FileRef>
+         <FileRef
+            location = "group:AFNetworking/AFProtocolBuffersSessionManager.h">
+         </FileRef>
+         <FileRef
+            location = "group:AFNetworking/AFProtocolBuffersSessionManager.m">
+         </FileRef>
       </Group>
       <Group
          location = "container:"

--- a/AFNetworking/AFProtocolBuffersSessionManager.h
+++ b/AFNetworking/AFProtocolBuffersSessionManager.h
@@ -1,0 +1,93 @@
+// AFProtocolBufferSessionManager.h
+//
+// Copyright (c) 2013 AFNetworking (http://afnetworking.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+
+#import "AFHTTPSessionManager.h"
+
+#if (defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 70000) || (defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && __MAC_OS_X_VERSION_MAX_ALLOWED >= 1090)
+
+/**
+ `AFProtocolBufferSessionManager` is a subclass of `AFHTTPSessionManager` for sending Protocol Buffers over TCP.
+ ## Serialization
+ 
+ Serializers are not used because they can not be uniquely set for the each endpoint request/response.
+ 
+ ## Exmaple
+ 
+ NSString * send:urlString = @"/api/user";
+ 
+ UserRequest_Builder * builder = [UserRequest_Builder new];
+ builder.email = email;
+ builder.password = password;
+ 
+ UserRequest * request = [builder build];
+ 
+ AFProtocolBufferSessionManager * manager = self.sharedManager;
+ 
+ NSURLSessionDataTask * task = [manager send:urlString
+ request:request
+ response:[UserBesponse class]
+ success:success
+ failure:failure];
+ 
+*/
+
+@interface AFProtocolBufferSessionManager : AFHTTPSessionManager <NSCoding, NSCopying>
+
+/**
+ Creates and runs an `NSURLSessionDataTask` with a `DELETE` request.
+ 
+ @param URLString The URL string used to create the request URL.
+ @param request PBGeneratedMessage subclass that is generated from a PBGeneratedMessage_Builder
+ @param ResponseClass PBGeneratedMessage subclass that will deserialize the response from the server
+ @param success A block object to be executed when the task finishes successfully. This block has no return value and takes two arguments: the data task, and the response object created by the client response serializer.
+ @param failure A block object to be executed when the task finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes a two arguments: the data task and the error describing the network or parsing error that occurred.
+ 
+ @see -dataTaskWithRequest:completionHandler:
+ */
+- (NSURLSessionDataTask *)send:(NSString*)URLString
+                       request:(id)request
+                      response:(Class)ResponseClass
+                       success:(void (^)(NSURLSessionDataTask *task, id responseObject))success
+                       failure:(void (^)(NSURLSessionDataTask *task, NSError *error))failure;
+
+/**
+ Creates and runs an `NSURLSessionDataTask` with a `DELETE` request.
+ 
+ @param URLString The URL string used to create the request URL.
+ @param token optional token for sending to over SSL
+ @param request PBGeneratedMessage subclass that is generated from a PBGeneratedMessage_Builder
+ @param ResponseClass PBGeneratedMessage subclass that will deserialize the response from the server
+ @param success A block object to be executed when the task finishes successfully. This block has no return value and takes two arguments: the data task, and the response object created by the client response serializer.
+ @param failure A block object to be executed when the task finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes a two arguments: the data task and the error describing the network or parsing error that occurred.
+ 
+ @see -dataTaskWithRequest:completionHandler:
+ */
+- (NSURLSessionDataTask *)send:(NSString*)URLString
+                         token:(NSString*)token
+                       request:(id)request
+                      response:(Class)ResponseClass
+                       success:(void (^)(NSURLSessionDataTask *task, id responseObject))success
+                       failure:(void (^)(NSURLSessionDataTask *task, NSError *error))failure;
+@end
+
+#endif

--- a/AFNetworking/AFProtocolBuffersSessionManager.m
+++ b/AFNetworking/AFProtocolBuffersSessionManager.m
@@ -1,0 +1,104 @@
+//  AFProtocolBufferSessionManager.m
+//
+// Copyright (c) 2013 AFNetworking (http://afnetworking.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "AFProtocolBuffersSessionManager.h"
+
+
+@implementation AFProtocolBufferSessionManager
+
+- (NSURLSessionDataTask *)send:(NSString*)URLString
+                       request:(PBGeneratedMessage*)request
+                      response:(Class)ResponseClass
+                       success:(void (^)(NSURLSessionDataTask *task, id responseObject))success
+                       failure:(void (^)(NSURLSessionDataTask *task, NSError *error))failure
+{
+    [self send:request token:nil request:request response:ResponseClass success:success failure:failure];
+}
+
+
+- (NSURLSessionDataTask *)send:(NSString*)URLString
+                         token:(NSString*)token
+                       request:(PBGeneratedMessage*)request
+                      response:(Class)ResponseClass
+                       success:(void (^)(NSURLSessionDataTask *task, id responseObject))success
+                       failure:(void (^)(NSURLSessionDataTask *task, NSError *error))failure
+{
+    NSParameterAssert(URLString);
+    NSParameterAssert(request);
+    NSParameterAssert(ResponseClass);
+    
+    NSURL *url = [NSURL URLWithString:URLString relativeToURL:self.baseURL];
+    
+    NSParameterAssert(url);
+    
+    if (!self.responseSerializer)
+    {
+        self.responseSerializer = [AFHTTPResponseSerializer serializer];
+    }
+    NSMutableSet * contentTypes = self.responseSerializer.acceptableContentTypes.mutableCopy;
+    [contentTypes addObject:@"application/x-protobuf"];
+    self.responseSerializer.acceptableContentTypes = contentTypes;
+    
+    // Serializers are used because serializer are a session manager-level properties. With Protocol Buffers every endpoint needs unique request and response serializer.
+    NSMutableURLRequest *mutableRequest = [[NSMutableURLRequest alloc] initWithURL:url];
+    mutableRequest.HTTPMethod = @"POST"; // all protobufs are posts
+    mutableRequest.allowsCellularAccess = YES;
+    mutableRequest.cachePolicy = NSURLRequestReloadIgnoringCacheData;
+    mutableRequest.HTTPShouldHandleCookies = NO;
+    mutableRequest.HTTPShouldUsePipelining = YES;
+    [mutableRequest setValue:@"application/x-protobuf" forHTTPHeaderField:@"Content-Type"];
+	
+    if (token)
+    {
+        NSString * tokenValue = [NSString stringWithFormat:@"Token token=\"%@\"", token];
+        [mutableRequest setValue:tokenValue forHTTPHeaderField:@"Authorization"];
+    }
+    
+    mutableRequest.HTTPBody = request.data;
+    
+    
+    // Drop back into the standard AFNetworking process
+    __block NSURLSessionDataTask *task;
+    void (^complete)(NSURLResponse * __unused, id, NSError *) = ^(NSURLResponse * __unused response, id responseObject, NSError *error)
+    {
+        if (error) {
+            if (failure) {
+                failure(task, error);
+            }
+        } else {
+            if (success) {
+                PBGeneratedMessage * result = (PBGeneratedMessage *)[ResponseClass parseFromData:(NSData*)responseObject];
+                success(task, (id)result);
+            }
+        }
+    };
+    
+    [(AFURLSessionManager*)task dataTaskWithRequest:mutableRequest completionHandler:complete];
+    
+    [task resume];
+    
+    return task;
+}
+
+@end
+
+


### PR DESCRIPTION
 `AFProtocolBufferSessionManager` is a subclass of `AFHTTPSessionManager` for sending Protocol Buffers over TCP.
 ## Serialization

 AFURLRequestSerialization and AFURLResponseSerialization is not used because they can not be uniquely set for the each endpoint request/response call.

 ## Example

 NSString \* send:urlString = @"/api/user";

 UserRequest_Builder \* builder = [UserRequest_Builder new];
 builder.email = email;
 builder.password = password;

 UserRequest \* request = [builder build];

 AFProtocolBufferSessionManager \* manager = self.sharedManager;

 NSURLSessionDataTask \* task = [manager send: urlString
                                                                  request: request
                                                               response: [UserResponse class]
                                                                 success: success
                                                                    failure: failure];
