### PR TITLE
Adding the support of array values in AFDictionaryByRemovingKeysWithNullValues function

### DIFF
--- a/AFNetworking/AFURLResponseSerialization.m
+++ b/AFNetworking/AFURLResponseSerialization.m
@@ -65,10 +65,25 @@ static NSDictionary * AFDictionaryByRemovingKeysWithNullValues(NSDictionary *dic
         } else {
             if ([value isKindOfClass:[NSDictionary class]]) {
                 [mutableDictionary setObject:AFDictionaryByRemovingKeysWithNullValues(value) forKey:key];
+            } else if([value isKindOfClass:[NSArray class]]) {
+                NSMutableArray *mutableArray = [NSMutableArray arrayWithArray:value];
+                NSUInteger count = [mutableArray count];
+                for (NSUInteger index = 0; index < count ; index++) {
+                    id value = [mutableArray objectAtIndex:index];
+                    if (!value || [value isEqual:[NSNull null]]) {
+                        [mutableArray removeObjectAtIndex:index];
+                    } else {
+                        if ([value isKindOfClass:[NSDictionary class]]) {
+                            [mutableArray replaceObjectAtIndex:index withObject:AFDictionaryByRemovingKeysWithNullValues(value)];
+                        }
+                    }
+                }
+                
+                [mutableDictionary setObject:mutableArray forKey:key];
             }
         }
     }
-
+    
     return mutableDictionary;
 }
 


### PR DESCRIPTION
The implementation of AFDictionaryByRemovingKeysWithNullValues function in the master branch does not  removing the null values from the part of serialized JSON if that part is array. So I've fixed that for me, hope that also will be useful for you.
