### PR TITLE
Manually evicting UIImageView category's NSCache on UIApplicationDidReceiveMemoryWarningNotification

### DIFF
--- a/AFNetworking/UIImageView+AFNetworking.m
+++ b/AFNetworking/UIImageView+AFNetworking.m
@@ -72,6 +72,10 @@ static char kAFImageRequestOperationObjectKey;
     static dispatch_once_t oncePredicate;
     dispatch_once(&oncePredicate, ^{
         _af_imageCache = [[AFImageCache alloc] init];
+
+        [[NSNotificationCenter defaultCenter] addObserverForName:UIApplicationDidReceiveMemoryWarningNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *note) {
+            [_af_imageCache removeAllObjects];
+        }];
     });
 
     return _af_imageCache;


### PR DESCRIPTION
Same fix as e4be80d for 1.x [Issue #1268]
