### PR TITLE
Don't update NSProgress for data tasks.

### DIFF
--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -200,8 +200,6 @@ didCompleteWithError:(NSError *)error
     didReceiveData:(NSData *)data
 {
     [self.mutableData appendData:data];
-
-    self.downloadProgress.completedUnitCount += (int64_t)[data length];
 }
 
 #pragma mark - NSURLSessionDownloadTaskDelegate


### PR DESCRIPTION
1. Progress is never returned by dataTask methods, only downloadTask methods. Those methods update the progress elsewhere so removing this for dataTasks shouldn't affect downloadTasks.
2. The totalUnitCount is never being set during data tasks, so even if the progress object was being returned, the NSProgress always reports a fractionCompleted of 0 right now.
3. There is a crash that occurs here rarely. My best guess is that the delegate is still being sent messages as it's being released.
