### PR TITLE
dispatch items shouldn't be referenced as strong but assign

### DIFF
--- a/AFNetworking/AFURLConnectionOperation.h
+++ b/AFNetworking/AFURLConnectionOperation.h
@@ -183,12 +183,12 @@
 /**
  The dispatch queue for `completionBlock`. If `NULL` (default), the main queue is used.
  */
-@property (nonatomic, strong) dispatch_queue_t completionQueue;
+@property (nonatomic, assign) dispatch_queue_t completionQueue;
 
 /**
  The dispatch group for `completionBlock`. If `NULL` (default), a private dispatch group is used.
  */
-@property (nonatomic, strong) dispatch_group_t completionGroup;
+@property (nonatomic, assign) dispatch_group_t completionGroup;
 
 ///---------------------------------------------
 /// @name Managing Request Operation Information


### PR DESCRIPTION
I'm not 100% sure about this but Xcode is really annoying me about this in my project. With the AFNetworking iOS example, there is no issues. 
