### PR TITLE
Provides a default temporary file for default download task delegate

### DIFF
--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -65,6 +65,8 @@ NSString * const AFNetworkingTaskDidFinishResponseDataKey = @"com.alamofire.netw
 NSString * const AFNetworkingTaskDidFinishErrorKey = @"com.alamofire.networking.task.complete.error"; // Deprecated
 NSString * const AFNetworkingTaskDidFinishAssetPathKey = @"com.alamofire.networking.task.complete.assetpath"; // Deprecated
 
+NSString * const AFNetworkingDownloadTaskTemporaryFileExtension = @"af_";
+
 static NSString * const AFURLSessionManagerLockName = @"com.alamofire.networking.session.manager.lock";
 
 static void * AFTaskStateChangedContext = &AFTaskStateChangedContext;
@@ -188,7 +190,7 @@ didCompleteWithError:(NSError *)error
                     [[NSNotificationCenter defaultCenter] postNotificationName:AFNetworkingTaskDidCompleteNotification object:task userInfo:userInfo];
                     
                     // Clean up our temporary file
-                    if (self.downloadFileURL) {
+                    if ([self.downloadFileURL.pathExtension isEqualToString:AFNetworkingDownloadTaskTemporaryFileExtension]) {
                         NSError *fileManagerError = nil;
                         [[NSFileManager defaultManager] removeItemAtURL:self.downloadFileURL error:&fileManagerError];
                         if (fileManagerError) {
@@ -409,7 +411,7 @@ expectedTotalBytes:(int64_t)expectedTotalBytes {
             return destination(location, task.response);
         }
         
-        return [location URLByAppendingPathExtension:@"af"];
+        return [location URLByAppendingPathExtension:AFNetworkingDownloadTaskTemporaryFileExtension];
     };
 
     if (progress) {


### PR DESCRIPTION
When the session manager initializes, it provides a default delegate for any download tasks already in progress. By setting this default delegate, it doesn't give the application a way to provide the destination (at least that I could find) of the downloaded file.

Ideally, in cases where the default delegate is at work, applications would be able to respond to the task completion (via AFNetworkingTaskDidCompleteNotification) and move the temporary file to it's proper location. However, since the default download task delegate doesn't move the temporary file, that file gets [removed by NSURLSession on the return on -URLSession:downloadTask:didFinishDownloadingToURL:](https://developer.apple.com/library/ios/documentation/Foundation/Reference/NSURLSessionDownloadDelegate_protocol/Reference/Reference.html#//apple_ref/occ/intfm/NSURLSessionDownloadDelegate/URLSession:downloadTask:didFinishDownloadingToURL:).

This gives the default download task delegate a default temporary file that won't get cleaned up until the task has finished calling all it's completion handlers.
