### PR TITLE
Fix issue with downloadTaskDidFinishDownloading not being called

### DIFF
--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -912,10 +912,7 @@ didBecomeDownloadTask:(NSURLSessionDownloadTask *)downloadTask
       downloadTask:(NSURLSessionDownloadTask *)downloadTask
 didFinishDownloadingToURL:(NSURL *)location
 {
-    AFURLSessionManagerTaskDelegate *delegate = [self delegateForTask:downloadTask];
-    if (delegate) {
-        [delegate URLSession:session downloadTask:downloadTask didFinishDownloadingToURL:location];
-    } else if (self.downloadTaskDidFinishDownloading) {
+    if (self.downloadTaskDidFinishDownloading) {
         NSURL *fileURL = self.downloadTaskDidFinishDownloading(session, downloadTask, location);
         if (fileURL) {
             NSError *error = nil;
@@ -923,7 +920,13 @@ didFinishDownloadingToURL:(NSURL *)location
             if (error) {
                 [[NSNotificationCenter defaultCenter] postNotificationName:AFURLSessionDownloadTaskDidFailToMoveFileNotification object:downloadTask userInfo:error.userInfo];
             }
+            return;
         }
+    }
+	
+    AFURLSessionManagerTaskDelegate *delegate = [self delegateForTask:downloadTask];
+    if (delegate) {
+        [delegate URLSession:session downloadTask:downloadTask didFinishDownloadingToURL:location];
     }
 }
 


### PR DESCRIPTION
The issue here is if destination is not provided for download task, then there is no way to access the download location later. 

This is especially critical for background downloads and I guess task delegate always exists, therefore `downloadTaskDidFinishDownloading` will never be called.

My solution is to give `-[AFURLSessionManager downloadTaskDidFinishDownloading]` block a higher priority if it's provided by application and returns non-nil, otherwise fallback to task delegate's implementation.

Related to issue #2050.
