### PR TITLE
Sending urlRequest although the image comes from cache

### DIFF
--- a/UIKit+AFNetworking/UIImageView+AFNetworking.m
+++ b/UIKit+AFNetworking/UIImageView+AFNetworking.m
@@ -128,7 +128,7 @@
     UIImage *cachedImage = [[[self class] sharedImageCache] cachedImageForRequest:urlRequest];
     if (cachedImage) {
         if (success) {
-            success(nil, nil, cachedImage);
+            success(urlRequest, nil, cachedImage);
         } else {
             self.image = cachedImage;
         }


### PR DESCRIPTION
I think it would be useful to return the urlRequest in the block. this way the user can identify the returned resource ( where it comes from ) to make extra checking if needed.
