### PR TITLE
Fixes #2020 - Race Condition in UIImageView+AFNetworking for different URLs as well

### DIFF
--- a/UIKit+AFNetworking/UIImageView+AFNetworking.m
+++ b/UIKit+AFNetworking/UIImageView+AFNetworking.m
@@ -144,29 +144,25 @@
         self.af_imageRequestOperation.responseSerializer = self.imageResponseSerializer;
         [self.af_imageRequestOperation setCompletionBlockWithSuccess:^(AFHTTPRequestOperation *operation, id responseObject) {
             __strong __typeof(weakSelf)strongSelf = weakSelf;
-            if ([[urlRequest URL] isEqual:[strongSelf.af_imageRequestOperation.request URL]]) {
+            if (operation == strongSelf.af_imageRequestOperation) {
                 if (success) {
                     success(urlRequest, operation.response, responseObject);
                 } else if (responseObject) {
                     strongSelf.image = responseObject;
                 }
 
-                if (operation == strongSelf.af_imageRequestOperation){
-                        strongSelf.af_imageRequestOperation = nil;
-                }
+                strongSelf.af_imageRequestOperation = nil;
             }
 
             [[[strongSelf class] sharedImageCache] cacheImage:responseObject forRequest:urlRequest];
         } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
             __strong __typeof(weakSelf)strongSelf = weakSelf;
-            if ([[urlRequest URL] isEqual:[operation.request URL]]) {
+            if (operation == strongSelf.af_imageRequestOperation) {
                 if (failure) {
                     failure(urlRequest, operation.response, error);
                 }
 
-                if (operation == strongSelf.af_imageRequestOperation){
-                        strongSelf.af_imageRequestOperation = nil;
-                }
+                strongSelf.af_imageRequestOperation = nil;
             }
         }];
 


### PR DESCRIPTION
I was seeing a similar race condition to #2020 even when using URL requests with different URLs. This was happening to me 100% on a UICollectionView when the images had been cached to the NSURLCache disk cache. Moving the operation check to the outer if statement fixed the issue for me. 
