### PR TITLE
Call super copyWithZone: in subclasses.

### DIFF
--- a/AFNetworking/AFURLRequestSerialization.m
+++ b/AFNetworking/AFURLRequestSerialization.m
@@ -1180,7 +1180,7 @@ typedef enum {
 #pragma mark - NSCopying
 
 - (id)copyWithZone:(NSZone *)zone {
-    AFJSONRequestSerializer *serializer = [[[self class] allocWithZone:zone] init];
+    AFJSONRequestSerializer *serializer = [super copyWithZone:zone];
     serializer.writingOptions = self.writingOptions;
 
     return serializer;
@@ -1262,7 +1262,7 @@ typedef enum {
 #pragma mark - NSCopying
 
 - (id)copyWithZone:(NSZone *)zone {
-    AFPropertyListRequestSerializer *serializer = [[[self class] allocWithZone:zone] init];
+    AFPropertyListRequestSerializer *serializer = [super copyWithZone:zone];
     serializer.format = self.format;
     serializer.writeOptions = self.writeOptions;
 


### PR DESCRIPTION
By not calling the superclass' implementation, we end up not actually
copying over all the properties from the superclass. In this case, if we
call -copy on an instance of an AFJSONRequestSerializer, the headers for
the serializer are not copied over (as well as anything else that was
changed in the AFHTTPRequestSerializer implementation).
