### PR TITLE
Add attemptsToRecreateUploadTasksForBackgroundSessions @property

### DIFF
--- a/AFNetworking/AFURLSessionManager.h
+++ b/AFNetworking/AFURLSessionManager.h
@@ -143,9 +143,9 @@
  */
 @property (readonly, nonatomic, strong) NSArray *downloadTasks;
 
-///---------------------------------
+///-------------------------------
 /// @name Managing Callback Queues
-///---------------------------------
+///-------------------------------
 
 /**
  The dispatch queue for `completionBlock`. If `NULL` (default), the main queue is used.
@@ -156,6 +156,19 @@
  The dispatch group for `completionBlock`. If `NULL` (default), a private dispatch group is used.
  */
 @property (nonatomic, strong) dispatch_group_t completionGroup;
+
+///---------------------------------
+/// @name Working Around System Bugs
+///---------------------------------
+
+/**
+ Whether to attempt to retry creation of upload tasks for background sessions when initial call returns `nil`. `NO` by default.
+
+ @bug As of iOS 7.0, there is a bug where upload tasks created for background tasks are sometimes `nil`. As a workaround, if this property is `YES`, AFNetworking will follow Apple's recommendation to try creating the task again.
+
+ @see https://github.com/AFNetworking/AFNetworking/issues/1675
+ */
+@property (nonatomic, assign) BOOL attemptsToRecreateUploadTasksForBackgroundSessions;
 
 ///---------------------
 /// @name Initialization
@@ -201,6 +214,8 @@
  @param fileURL A URL to the local file to be uploaded.
  @param progress A progress object monitoring the current upload progress.
  @param completionHandler A block object to be executed when the task finishes. This block has no return value and takes three arguments: the server response, the response object created by that serializer, and the error that occurred, if any.
+ 
+ @see `attemptsToRecreateUploadTasksForBackgroundSessions`
  */
 - (NSURLSessionUploadTask *)uploadTaskWithRequest:(NSURLRequest *)request
                                          fromFile:(NSURL *)fileURL


### PR DESCRIPTION
Following up from discussion in #1675, on the recommendation of @kolyuchiy, this patch adds a property to attempt the recommended workaround.

``` objective-c
/**
 Whether to attempt to retry creation of upload tasks for background sessions when initial call returns `nil`. `NO` by default.

 @bug As of iOS 7.0, there is a bug where upload tasks created for background tasks are sometimes `nil`. As a workaround, if this property is `YES`, AFNetworking will follow Apple's recommendation to try creating the task again.

 @see https://github.com/AFNetworking/AFNetworking/issues/1675
 */
@property (nonatomic, assign) BOOL attemptsToRecreateUploadTasksForBackgroundSessions;
```

For those noticing these bugs in production, any thoughts?
