### PR TITLE
Update UIImageView+AFNetworking.m

### DIFF
--- a/UIKit+AFNetworking/UIImageView+AFNetworking.m
+++ b/UIKit+AFNetworking/UIImageView+AFNetworking.m
@@ -144,6 +144,7 @@
         self.af_imageRequestOperation.responseSerializer = self.imageResponseSerializer;
         [self.af_imageRequestOperation setCompletionBlockWithSuccess:^(AFHTTPRequestOperation *operation, id responseObject) {
             __strong __typeof(weakSelf)strongSelf = weakSelf;
+            [[[strongSelf class] sharedImageCache] cacheImage:responseObject forRequest:urlRequest];
             if ([[urlRequest URL] isEqual:[strongSelf.af_imageRequestOperation.request URL]]) {
                 if (success) {
                     success(urlRequest, operation.response, responseObject);
@@ -156,7 +157,6 @@
                 }
             }
 
-            [[[strongSelf class] sharedImageCache] cacheImage:responseObject forRequest:urlRequest];
         } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
             __strong __typeof(weakSelf)strongSelf = weakSelf;
             if ([[urlRequest URL] isEqual:[strongSelf.af_imageRequestOperation.request URL]]) {


### PR DESCRIPTION
Changed the order to first cache the responseObject, and then call the block.
This way the user can modify the downloaded image, and use the modified one as the cached one (with [[UIImageView sharedImageCache] cacheImage:newImage forRequest:imageRequest] )

i.e. if the user wants to downscale an image, he can cache the downscaled to save memory, and allow more objects in cache.
