### PR TITLE
check self.uploadProgress inside of dispatch_async

### DIFF
--- a/AFNetworking/AFURLConnectionOperation.m
+++ b/AFNetworking/AFURLConnectionOperation.m
@@ -635,11 +635,11 @@ willSendRequestForAuthenticationChallenge:(NSURLAuthenticationChallenge *)challe
  totalBytesWritten:(NSInteger)totalBytesWritten
 totalBytesExpectedToWrite:(NSInteger)totalBytesExpectedToWrite
 {
-    if (self.uploadProgress) {
-        dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (self.uploadProgress) {
             self.uploadProgress((NSUInteger)bytesWritten, totalBytesWritten, totalBytesExpectedToWrite);
-        });
-    }
+        }
+    });
 }
 
 - (void)connection:(NSURLConnection __unused *)connection


### PR DESCRIPTION
Check self.uploadProgress is nil or not inside dispatch_async block.
If self.uploadProgress is checked outside of dispatch_async block,
thread can not guaranteed self.uploadPorgress is not nil.

Signed-off-by: Kyungkoo Kang kyungkoo.kang@yahoo.com
