### PR TITLE
Reachability explanation

### DIFF
--- a/AFNetworking/AFNetworkReachabilityManager.h
+++ b/AFNetworking/AFNetworkReachabilityManager.h
@@ -38,13 +38,13 @@ typedef NS_ENUM(NSInteger, AFNetworkReachabilityStatus) {
 
 /**
  `AFNetworkReachabilityManager` monitors the reachability of domains, and addresses for both WWAN and WiFi network interfaces.
-
+ 
  Reachability can be used to determine background information about why a network operation failed, or to trigger a network operation retrying when a connection is established. It should not be used to block a user from initiating a network request. It's possible that the user request may successfully initiate networking.
 
  You can see this behavior modeled in Safari on iOS. You can start a web request at any time. If iOS sees a network connection start, it will automatically retry a failed request. However, the network status does not prevent the user from trying a request.
 
  See Apple's Reachability Sample Code (https://developer.apple.com/library/ios/samplecode/reachability/)
-
+ 
  @warning Instances of `AFNetworkReachabilityManager` must be started with `-startMonitoring` before reachability status can be determined.
  */
 @interface AFNetworkReachabilityManager : NSObject


### PR DESCRIPTION
A common thought process problem I see is in Issues is relying on Reachability's initial state reporting. I wince every time I see this, since it's not supposed to matter. Under almost every circumstance, you're supposed to **try** first and check after.

I wrote up a short explanation of this. You may want to rewrite this, but I think something _like_ this should be included to reduce people trying to hang themselves on a useful class by using it inappropriately.
