### PR TITLE
UIImageView allows weaker serializer subclasses

### DIFF
--- a/UIKit+AFNetworking/UIImageView+AFNetworking.h
+++ b/UIKit+AFNetworking/UIImageView+AFNetworking.h
@@ -30,8 +30,6 @@
 
 @protocol AFURLResponseSerialization, AFImageCache;
 
-@class AFImageResponseSerializer;
-
 /**
  This category adds methods to the UIKit framework's `UIImageView` class. The methods in this category provide support for loading remote images asynchronously from a URL.
  */
@@ -62,7 +60,7 @@
  
  @discussion Subclasses of `AFImageResponseSerializer` could be used to perform post-processing, such as color correction, face detection, or other effects. See https://github.com/AFNetworking/AFCoreImageSerializer
  */
-@property (nonatomic, strong) AFImageResponseSerializer <AFURLResponseSerialization> * imageResponseSerializer;
+@property (nonatomic, strong) id <AFURLResponseSerialization> imageResponseSerializer;
 
 ///--------------------
 /// @name Setting Image


### PR DESCRIPTION
Weakened serializer from subclasses of `AFImageResponseSerializer` to any class conforming to `AFURLResponseSerialization` protocol. This allows compound serializer to be used.

Example usage is handling gifs in a `UIImage` subclass. First serialiser inside the compound one is gif handler, which only accepts `image/gif` and creates a subclass or `UIImage`. If that didn't match, `AFImageResponseSerializer` would be used and would inflate images as needed and so on.

With current realisation one would need to subclass AFImageResponseSerializer, and perform checks before calling `super`. In my opinion, this approach breaks the idea or serialiser chaining and introduces strange side effects of handling data before calling superclass. If a user needs custom still image serialisers (e.g. with filters) and on top of that gif serialisers when needed, she would need either to have hierarchy hell or overcomplicated serialiser subclass.

Allowing `AFCompoundResponseSerializer` fixes all this with a one-liner.
