### PR TITLE
Future-proofing AFURLRequestSerialization

### DIFF
--- a/AFNetworking/AFURLRequestSerialization.m
+++ b/AFNetworking/AFURLRequestSerialization.m
@@ -742,6 +742,9 @@ NSTimeInterval const kAFUploadStream3GSuggestedDelay = 0.2;
 
 @implementation AFMultipartBodyStream
 
+@synthesize streamStatus;
+@synthesize streamError;
+
 - (id)initWithStringEncoding:(NSStringEncoding)encoding {
     self = [super init];
     if (!self) {


### PR DESCRIPTION
Under iOS8, NSStream turns methods .stream{Status,Error} into 
readonly properties. This causes a warning about implicit ivar synthesis
vs. AFURLRequestSerialization "overrides" of these. Explicit synthesis
fixes warning.
