### PR TITLE
Serialization subspec can't be used standalone

### DIFF
--- a/AFNetworking/AFURLConnectionOperation.h
+++ b/AFNetworking/AFURLConnectionOperation.h
@@ -307,41 +307,6 @@
 
 @end
 
-///----------------
-/// @name Constants
-///----------------
-
-/**
- ## User info dictionary keys
-
- These keys may exist in the user info dictionary, in addition to those defined for NSError.
-
- - `NSString * const AFNetworkingOperationFailingURLRequestErrorKey`
- - `NSString * const AFNetworkingOperationFailingURLResponseErrorKey`
-
- ### Constants
-
- `AFNetworkingOperationFailingURLRequestErrorKey`
- The corresponding value is an `NSURLRequest` containing the request of the operation associated with an error. This key is only present in the `AFNetworkingErrorDomain`.
-
- `AFNetworkingOperationFailingURLResponseErrorKey`
- The corresponding value is an `NSURLResponse` containing the response of the operation associated with an error. This key is only present in the `AFNetworkingErrorDomain`.
-
- ## Error Domains
-
- The following error domain is predefined.
-
- - `NSString * const AFNetworkingErrorDomain`
-
- ### Constants
-
- `AFNetworkingErrorDomain`
- AFNetworking errors. Error codes for `AFNetworkingErrorDomain` correspond to codes in `NSURLErrorDomain`.
- */
-extern NSString * const AFNetworkingErrorDomain;
-extern NSString * const AFNetworkingOperationFailingURLRequestErrorKey;
-extern NSString * const AFNetworkingOperationFailingURLResponseErrorKey;
-
 ///--------------------
 /// @name Notifications
 ///--------------------

--- a/AFNetworking/AFURLConnectionOperation.m
+++ b/AFNetworking/AFURLConnectionOperation.m
@@ -66,10 +66,6 @@ static dispatch_queue_t url_request_operation_completion_queue() {
 
 static NSString * const kAFNetworkingLockName = @"com.alamofire.networking.operation.lock";
 
-NSString * const AFNetworkingErrorDomain = @"AFNetworkingErrorDomain";
-NSString * const AFNetworkingOperationFailingURLRequestErrorKey = @"AFNetworkingOperationFailingURLRequestErrorKey";
-NSString * const AFNetworkingOperationFailingURLResponseErrorKey = @"AFNetworkingOperationFailingURLResponseErrorKey";
-
 NSString * const AFNetworkingOperationDidStartNotification = @"com.alamofire.networking.operation.start";
 NSString * const AFNetworkingOperationDidFinishNotification = @"com.alamofire.networking.operation.finish";
 

--- a/AFNetworking/AFURLRequestSerialization.h
+++ b/AFNetworking/AFURLRequestSerialization.h
@@ -360,6 +360,37 @@ extern NSTimeInterval const kAFUploadStream3GSuggestedDelay;
 ///----------------
 
 /**
+ ## User info dictionary keys
+ 
+ These keys may exist in the user info dictionary, in addition to those defined for NSError.
+ 
+ - `NSString * const AFNetworkingOperationFailingURLRequestErrorKey`
+ - `NSString * const AFNetworkingOperationFailingURLResponseErrorKey`
+ 
+ ### Constants
+ 
+ `AFNetworkingOperationFailingURLRequestErrorKey`
+ The corresponding value is an `NSURLRequest` containing the request of the operation associated with an error. This key is only present in the `AFNetworkingErrorDomain`.
+ 
+ `AFNetworkingOperationFailingURLResponseErrorKey`
+ The corresponding value is an `NSURLResponse` containing the response of the operation associated with an error. This key is only present in the `AFNetworkingErrorDomain`.
+ 
+ ## Error Domains
+ 
+ The following error domain is predefined.
+ 
+ - `NSString * const AFNetworkingErrorDomain`
+ 
+ ### Constants
+ 
+ `AFNetworkingErrorDomain`
+ AFNetworking errors. Error codes for `AFNetworkingErrorDomain` correspond to codes in `NSURLErrorDomain`.
+ */
+extern NSString * const AFNetworkingErrorDomain;
+extern NSString * const AFNetworkingOperationFailingURLRequestErrorKey;
+extern NSString * const AFNetworkingOperationFailingURLResponseErrorKey;
+
+/**
  ## Throttling Bandwidth for HTTP Request Input Streams
 
  @see -throttleBandwidthWithPacketSize:delay:

--- a/AFNetworking/AFURLRequestSerialization.m
+++ b/AFNetworking/AFURLRequestSerialization.m
@@ -28,7 +28,9 @@
 #import <CoreServices/CoreServices.h>
 #endif
 
-extern NSString * const AFNetworkingErrorDomain;
+NSString * const AFNetworkingErrorDomain = @"AFNetworkingErrorDomain";
+NSString * const AFNetworkingOperationFailingURLRequestErrorKey = @"AFNetworkingOperationFailingURLRequestErrorKey";
+NSString * const AFNetworkingOperationFailingURLResponseErrorKey = @"AFNetworkingOperationFailingURLResponseErrorKey";
 
 typedef NSString * (^AFQueryStringSerializationBlock)(NSURLRequest *request, NSDictionary *parameters, NSError *__autoreleasing *error);
 


### PR DESCRIPTION
It refers to `AFNetworkingErrorDomain` and `AFNetworkingOperationFailingURLResponseErrorKey` which aren't defined in the files included by the Serialization subspec.

As a quick fix I moved those two plus `AFNetworkingOperationFailingURLRequestErrorKey` (just to keep them together) into `AFURLConnectionOperation.[hm]`. All other references seem to come from specs that depend on Serialization, so everything's covered.

For what it's worth, `AFNetworkingErrorDomain` doesn't seem to be used outside the Serialization subspec, so it probably belongs there anyway. However `AFNetworkingOperationFailingURLResponseErrorKey` is only used once, so there might be some refactoring possible to move the keys back into the NSURLConnection subspec.

Here's a linker error for reference:

```
Undefined symbols for architecture i386:
  "_AFNetworkingErrorDomain", referenced from:
      -[AFStreamingMultipartFormData appendPartWithFileURL:name:fileName:mimeType:error:] in libPods.a(AFURLRequestSerialization.o)
      -[AFHTTPResponseSerializer validateResponse:data:error:] in libPods.a(AFURLResponseSerialization.o)
      -[AFJSONResponseSerializer responseObjectForResponse:data:error:] in libPods.a(AFURLResponseSerialization.o)
      -[AFXMLParserResponseSerializer responseObjectForResponse:data:error:] in libPods.a(AFURLResponseSerialization.o)
      -[AFPropertyListResponseSerializer responseObjectForResponse:data:error:] in libPods.a(AFURLResponseSerialization.o)
      -[AFImageResponseSerializer responseObjectForResponse:data:error:] in libPods.a(AFURLResponseSerialization.o)
      -[AFStreamingMultipartFormData appendPartWithFileURL:name:fileName:mimeType:error:] in libPods.a(AFURLRequestSerialization.o)
      -[AFHTTPResponseSerializer validateResponse:data:error:] in libPods.a(AFURLResponseSerialization.o)
      -[AFJSONResponseSerializer responseObjectForResponse:data:error:] in libPods.a(AFURLResponseSerialization.o)
      -[AFXMLParserResponseSerializer responseObjectForResponse:data:error:] in libPods.a(AFURLResponseSerialization.o)
      -[AFPropertyListResponseSerializer responseObjectForResponse:data:error:] in libPods.a(AFURLResponseSerialization.o)
      -[AFImageResponseSerializer responseObjectForResponse:data:error:] in libPods.a(AFURLResponseSerialization.o)
  "_AFNetworkingOperationFailingURLResponseErrorKey", referenced from:
      -[AFHTTPResponseSerializer validateResponse:data:error:] in libPods.a(AFURLResponseSerialization.o)
ld: symbol(s) not found for architecture i386
```
