### PR TITLE
moved readwrite properties inside an NSStream extension

### DIFF
--- a/AFNetworking/AFURLRequestSerialization.m
+++ b/AFNetworking/AFURLRequestSerialization.m
@@ -729,9 +729,13 @@ NSTimeInterval const kAFUploadStream3GSuggestedDelay = 0.2;
 
 #pragma mark -
 
+@interface NSStream ()
+@property (readwrite) NSStreamStatus streamStatus;
+@property (readwrite, copy) NSError *streamError;
+@end
+
+
 @interface AFMultipartBodyStream () <NSCopying>
-@property (readwrite, nonatomic, assign) NSStreamStatus streamStatus;
-@property (readwrite, nonatomic, strong) NSError *streamError;
 @property (readwrite, nonatomic, assign) NSStringEncoding stringEncoding;
 @property (readwrite, nonatomic, strong) NSMutableArray *HTTPBodyParts;
 @property (readwrite, nonatomic, strong) NSEnumerator *HTTPBodyPartEnumerator;
@@ -741,8 +745,6 @@ NSTimeInterval const kAFUploadStream3GSuggestedDelay = 0.2;
 @end
 
 @implementation AFMultipartBodyStream
-@synthesize streamStatus;
-@synthesize streamError;
 
 - (id)initWithStringEncoding:(NSStringEncoding)encoding {
     self = [super init];


### PR DESCRIPTION
Apparently the latest version of clang that ships with xcode 6 beta doesn't authorize to rewrite properties in categories if it's not a category from the origin class.

Leading to this kind of warnings: `auto property synthesis will not synthesize because it is readwrite but it will be synthesized readonly via another property`.

I've moved the culprit part inside an extension of `NSStream` to solve those compiling issues.
