### PR TITLE
moved [super pause] from last to first.

### DIFF
--- a/AFNetworking/AFHTTPRequestOperation.m
+++ b/AFNetworking/AFHTTPRequestOperation.m
@@ -151,6 +151,7 @@ static dispatch_group_t http_request_operation_completion_group() {
 #pragma mark - AFURLRequestOperation
 
 - (void)pause {
+    [super pause];
     u_int64_t offset = 0;
     if ([self.outputStream propertyForKey:NSStreamFileCurrentOffsetKey]) {
         offset = [(NSNumber *)[self.outputStream propertyForKey:NSStreamFileCurrentOffsetKey] unsignedLongLongValue];
@@ -164,8 +165,6 @@ static dispatch_group_t http_request_operation_completion_group() {
     }
     [mutableURLRequest setValue:[NSString stringWithFormat:@"bytes=%llu-", offset] forHTTPHeaderField:@"Range"];
     self.request = mutableURLRequest;
-
-    [super pause];
 }
 
 #pragma mark - NSecureCoding
@@ -199,7 +198,7 @@ static dispatch_group_t http_request_operation_completion_group() {
     operation.responseSerializer = [self.responseSerializer copyWithZone:zone];
     operation.completionQueue = self.completionQueue;
     operation.completionGroup = self.completionGroup;
-    
+
     return operation;
 }
 


### PR DESCRIPTION
When `NSStreamDataWrittenToMemoryStreamKey` is accessed, I got BAD_ACCESS
Exception randomly in `pause` method.
If `[super pause]` is called at first in `pause` method, can prevent this Exception.

Signed-off-by: Kyungkoo Kang kyungkoo.kang@yahoo.com
