### PR TITLE
Fix for possible deadlock

### DIFF
--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -348,8 +348,8 @@ expectedTotalBytes:(int64_t)expectedTotalBytes {
     NSParameterAssert(task);
     NSParameterAssert(delegate);
 
-    [self.lock lock];
     [task addObserver:self forKeyPath:NSStringFromSelector(@selector(state)) options:NSKeyValueObservingOptionOld |NSKeyValueObservingOptionNew context:AFTaskStateChangedContext];
+    [self.lock lock];
     self.mutableTaskDelegatesKeyedByTaskIdentifier[@(task.taskIdentifier)] = delegate;
     [self.lock unlock];
 }
@@ -422,8 +422,8 @@ expectedTotalBytes:(int64_t)expectedTotalBytes {
 - (void)removeDelegateForTask:(NSURLSessionTask *)task {
     NSParameterAssert(task);
 
-    [self.lock lock];
     [task removeObserver:self forKeyPath:NSStringFromSelector(@selector(state)) context:AFTaskStateChangedContext];
+    [self.lock lock];
     [self.mutableTaskDelegatesKeyedByTaskIdentifier removeObjectForKey:@(task.taskIdentifier)];
     [self.lock unlock];
 }


### PR DESCRIPTION
The deadlock could be caused due to KVO subscription under the lock. The scenario is as follows:
1. AFURLSessionManager gets a callback and enters critical section with the following stacktrace:
   __psynch_mutexwait + 24
   _pthread_mutex_lock + 304
   -[NSRecursiveLock lock] + 10
   -[NSObject(NSKeyValueObserverRegistration) removeObserver:forKeyPath:] + 114
   -[NSObject(NSKeyValueObserverRegistration) removeObserver:forKeyPath:context:] + 210
   -[AFURLSessionManager removeDelegateForTask:](AFURLSessionManager.m:365)
   -[AFURLSessionManager URLSession:task:didCompleteWithError:](AFURLSessionManager.m:771)
   __55-[__NSCFURLSession delegate_task:didCompleteWithError:]_block_invoke + 48
   ...
2. Meanwhile, in different thread client code tries to create download task, and client has some KVO subscription/unsubscription in stack frame:
   __psynch_mutexwait + 24
   _pthread_mutex_lock + 304
   -[NSLock lock] + 108
   -[AFURLSessionManager setDelegate:forTask:](AFURLSessionManager.m:355)
   -[AFURLSessionManager downloadTaskWithTask:progress:destination:completionHandler:](AFURLSessionManager.m:561)
   -[AFURLSessionManager downloadTaskWithRequest:progress:destination:completionHandler:](AFURLSessionManager.m:525)
   ...
   [KVO operation somewhere, it has acquired NSRecursiveLock that is blocked in prev frame]
   ...
3. We're in deadlock state: callback thread has acquired AFURLSessionManager's lock and waits for KVO lock, while client code has acquired KVO lock and waits for AFURLSessionManager's lock.

Resolution: you shouldn't put KVO subscription/unsubscription under the lock without good reasoning.
