### PR TITLE
Ensure AFHTTPRequestOperation's copyWithZone: calls the parent implementation

### DIFF
--- a/AFNetworking/AFHTTPRequestOperation.m
+++ b/AFNetworking/AFHTTPRequestOperation.m
@@ -194,7 +194,7 @@ static dispatch_group_t http_request_operation_completion_group() {
 #pragma mark - NSCopying
 
 - (id)copyWithZone:(NSZone *)zone {
-    AFHTTPRequestOperation *operation = [[[self class] allocWithZone:zone] initWithRequest:self.request];
+    AFHTTPRequestOperation *operation = [super copyWithZone:zone];
 
     operation.responseSerializer = [self.responseSerializer copyWithZone:zone];
     operation.completionQueue = self.completionQueue;


### PR DESCRIPTION
AFURLConnectionOperation implements NSCopying, so we need to call the parent's version of copyWithZone: to ensure the object is properly copied.
