### PR TITLE
Fix AFConnectionOperation outputStream leak if no response is received

### DIFF
--- a/AFNetworking/AFURLConnectionOperation.m
+++ b/AFNetworking/AFURLConnectionOperation.m
@@ -466,6 +466,7 @@ static inline BOOL AFStateTransitionIsValid(AFOperationState fromState, AFOperat
             [self.outputStream scheduleInRunLoop:runLoop forMode:runLoopMode];
         }
         
+        [self.outputStream open];
         [self.connection start];
     }
     [self.lock unlock];
@@ -642,8 +643,6 @@ totalBytesExpectedToWrite:(NSInteger)totalBytesExpectedToWrite
 didReceiveResponse:(NSURLResponse *)response
 {
     self.response = response;
-    
-    [self.outputStream open];
 }
 
 - (void)connection:(NSURLConnection __unused *)connection


### PR DESCRIPTION
I noticed a memory leak when my app was performing AFHTTPRequestOperations while a server was down - the outputStream instances for these operation objects are never dealloc'd when the operations fail and no response is received.

The issue is that the outputStream is never explicitly unscheduled from the runloop, but rather the AFConnectionOperation relies on calling 'close' to do all of the cleanup. 

Even though the apple documentation states that calling 'close' should implicitly unschedule an NSStream from its run loop, apparently this doesn't happen if the stream was never 'open'. In the current codebase the outputStream is only open if a response is received. I moved this call to open the stream as soon as it is scheduled on a run loop.

Here is a minimal snippet to drop into a single-page-view-controller project to reproduce:

``` objective-c
#import "AFNetworking.h"
#import "ViewController.h"

@interface ViewController ()
@property (nonatomic) AFHTTPRequestOperationManager *http;
@end

@implementation ViewController

- (void)viewDidLoad
{
    [super viewDidLoad];
    NSURL *failingURL = [NSURL URLWithString:@"http://127.0.0.1:3456"];
    self.http = [[AFHTTPRequestOperationManager alloc] initWithBaseURL:failingURL];
    [self doFailingRequest];
}

- (void)doFailingRequest
{
    __weak ViewController *weakSelf = self;
    [self.http GET:@"/" parameters:nil success:^(AFHTTPRequestOperation *operation, id responseObject) {
        NSLog(@"Success ?? should not happen in this example");
    } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
        NSLog(@"Failure, requesting again");
        [weakSelf doFailingRequest];
    }];
}

@end
```
##### Before the fix:

![before_fix](https://cloud.githubusercontent.com/assets/380187/3475434/f518ee48-02f0-11e4-805e-e8f019bce9ce.png)
##### After the fix:

![after_fix](https://cloud.githubusercontent.com/assets/380187/3475435/fa318bce-02f0-11e4-83bc-e356c3aa4838.png)
