### PR TITLE
You should cancel operation for each UIControlState separately

### DIFF
--- a/UIKit+AFNetworking/UIButton+AFNetworking.h
+++ b/UIKit+AFNetworking/UIButton+AFNetworking.h
@@ -134,11 +134,13 @@
 /**
  Cancels any executing image operation for the receiver, if one exists.
  */
+- (void)cancelImageRequestOperation:(UIControlState)state;
 - (void)cancelImageRequestOperation;
 
 /**
  Cancels any executing background image operation for the receiver, if one exists.
  */
+- (void)cancelBackgroundImageRequestOperation:(UIControlState)state;
 - (void)cancelBackgroundImageRequestOperation;
 
 @end


### PR DESCRIPTION
If you are setting UIButton's image like this:

```
    [button setImageForState:UIControlStateNormal withURL:imageURL];
    [button setImageForState:UIControlStateHighlighted withURL:highlightedImageURL];
    [button setImageForState:UIControlStateSelected withURL:selectedImageURL];
```

The old code will cause UIButton only to download the last `UIControlStateSelected` image.
