### PR TITLE
Added constructed response object in failureblock

### DIFF
--- a/AFNetworking/AFHTTPRequestOperation.h
+++ b/AFNetworking/AFHTTPRequestOperation.h
@@ -59,9 +59,9 @@
  This method should be overridden in subclasses in order to specify the response object passed into the success block.
  
  @param success The block to be executed on the completion of a successful request. This block has no return value and takes two arguments: the receiver operation and the object constructed from the response data of the request.
- @param failure The block to be executed on the completion of an unsuccessful request. This block has no return value and takes two arguments: the receiver operation and the error that occurred during the request.
+ @param failure The block to be executed on the completion of an unsuccessful request. This block has no return value and takes three arguments: the receiver operation, the error that occurred during the request and the object constructed from the response data of the request.
  */
 - (void)setCompletionBlockWithSuccess:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
-                              failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure;
+                              failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error,id responseObject))failure;
 
 @end

--- a/AFNetworking/AFHTTPRequestOperation.m
+++ b/AFNetworking/AFHTTPRequestOperation.m
@@ -105,7 +105,7 @@ static dispatch_group_t http_request_operation_completion_group() {
 #pragma mark - AFHTTPRequestOperation
 
 - (void)setCompletionBlockWithSuccess:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
-                              failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure
+                              failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error, id responseObject))failure
 {
     // completionBlock is manually nilled out in AFURLConnectionOperation to break the retain cycle.
 #pragma clang diagnostic push
@@ -120,7 +120,7 @@ static dispatch_group_t http_request_operation_completion_group() {
             if (self.error) {
                 if (failure) {
                     dispatch_group_async(self.completionGroup ?: http_request_operation_completion_group(), self.completionQueue ?: dispatch_get_main_queue(), ^{
-                        failure(self, self.error);
+                        failure(self, self.error, nil);
                     });
                 }
             } else {
@@ -128,7 +128,7 @@ static dispatch_group_t http_request_operation_completion_group() {
                 if (self.error) {
                     if (failure) {
                         dispatch_group_async(self.completionGroup ?: http_request_operation_completion_group(), self.completionQueue ?: dispatch_get_main_queue(), ^{
-                            failure(self, self.error);
+                            failure(self, self.error, responseObject);
                         });
                     }
                 } else {


### PR DESCRIPTION
Added the constructed response object to the failure response.

Sometimes we get an error and a body we need do something with. now we
can do both.
