### PR TITLE
fix for import as cocoa touch framework as module to a swift only project

### DIFF
--- a/AFNetworking/AFNetworkReachabilityManager.h
+++ b/AFNetworking/AFNetworkReachabilityManager.h
@@ -23,12 +23,6 @@
 #import <Foundation/Foundation.h>
 #import <SystemConfiguration/SystemConfiguration.h>
 
-#import <netinet/in.h>
-#import <netinet6/in6.h>
-#import <arpa/inet.h>
-#import <ifaddrs.h>
-#import <netdb.h>
-
 typedef NS_ENUM(NSInteger, AFNetworkReachabilityStatus) {
     AFNetworkReachabilityStatusUnknown          = -1,
     AFNetworkReachabilityStatusNotReachable     = 0,

--- a/AFNetworking/AFNetworkReachabilityManager.m
+++ b/AFNetworking/AFNetworkReachabilityManager.m
@@ -22,6 +22,12 @@
 
 #import "AFNetworkReachabilityManager.h"
 
+#import <netinet/in.h>
+#import <netinet6/in6.h>
+#import <arpa/inet.h>
+#import <ifaddrs.h>
+#import <netdb.h>
+
 NSString * const AFNetworkingReachabilityDidChangeNotification = @"com.alamofire.networking.reachability.change";
 NSString * const AFNetworkingReachabilityNotificationStatusItem = @"AFNetworkingReachabilityNotificationStatusItem";
 


### PR DESCRIPTION
This change resolves issue #2205

With the change you can create a Cocoa Touch Framework with Xcode 6 for AFNetworking and import the AFNetworking Framework into a Swift only Xcode Project without compiler errors.
You just need to make all headers public in the Build Phases section of the Cocoa Touch Framework.
