### PR TITLE
Retrieve data on response deserialisation error

### DIFF
--- a/AFNetworking/AFURLResponseSerialization.h
+++ b/AFNetworking/AFURLResponseSerialization.h
@@ -285,10 +285,18 @@ extern NSString * const AFURLResponseSerializationErrorDomain;
  These keys may exist in the user info dictionary, in addition to those defined for NSError.
 
  - `NSString * const AFNetworkingOperationFailingURLResponseErrorKey`
+ - `NSString * const AFNetworkingOperationFailingURLResponseOriginalDataErrorKey`
 
  ### Constants
 
  `AFNetworkingOperationFailingURLResponseErrorKey`
  The corresponding value is an `NSURLResponse` containing the response of the operation associated with an error. This key is only present in the `AFURLResponseSerializationErrorDomain`.
+ 
+ `AFNetworkingOperationFailingURLResponseOriginalDataErrorKey`
+ The corresponding value is an `NSData` containing the original data of the operation associated with an error. This key is only present in the `AFURLResponseSerializationErrorDomain`.
  */
 extern NSString * const AFNetworkingOperationFailingURLResponseErrorKey;
+
+extern NSString * const AFNetworkingOperationFailingURLResponseOriginalDataErrorKey;
+
+

--- a/AFNetworking/AFURLResponseSerialization.m
+++ b/AFNetworking/AFURLResponseSerialization.m
@@ -30,6 +30,7 @@
 
 NSString * const AFURLResponseSerializationErrorDomain = @"com.alamofire.error.serialization.response";
 NSString * const AFNetworkingOperationFailingURLResponseErrorKey = @"com.alamofire.serialization.response.error.response";
+NSString * const AFNetworkingOperationFailingURLResponseOriginalDataErrorKey = @"com.alamofire.serialization.response.error.data";
 
 static NSError * AFErrorWithUnderlyingError(NSError *error, NSError *underlyingError) {
     if (!error) {
@@ -116,7 +117,8 @@ static id AFJSONObjectByRemovingKeysWithNullValues(id JSONObject, NSJSONReadingO
                 NSDictionary *userInfo = @{
                                            NSLocalizedDescriptionKey: [NSString stringWithFormat:NSLocalizedStringFromTable(@"Request failed: unacceptable content-type: %@", @"AFNetworking", nil), [response MIMEType]],
                                            NSURLErrorFailingURLErrorKey:[response URL],
-                                           AFNetworkingOperationFailingURLResponseErrorKey: response
+                                           AFNetworkingOperationFailingURLResponseErrorKey: response,
+                                           AFNetworkingOperationFailingURLResponseOriginalDataErrorKey: data
                                            };
 
                 validationError = AFErrorWithUnderlyingError([NSError errorWithDomain:AFURLResponseSerializationErrorDomain code:NSURLErrorCannotDecodeContentData userInfo:userInfo], validationError);
@@ -129,7 +131,8 @@ static id AFJSONObjectByRemovingKeysWithNullValues(id JSONObject, NSJSONReadingO
             NSDictionary *userInfo = @{
                                        NSLocalizedDescriptionKey: [NSString stringWithFormat:NSLocalizedStringFromTable(@"Request failed: %@ (%ld)", @"AFNetworking", nil), [NSHTTPURLResponse localizedStringForStatusCode:response.statusCode], (long)response.statusCode],
                                        NSURLErrorFailingURLErrorKey:[response URL],
-                                       AFNetworkingOperationFailingURLResponseErrorKey: response
+                                       AFNetworkingOperationFailingURLResponseErrorKey: response,
+                                       AFNetworkingOperationFailingURLResponseOriginalDataErrorKey: data
                                        };
 
             validationError = AFErrorWithUnderlyingError([NSError errorWithDomain:AFURLResponseSerializationErrorDomain code:NSURLErrorBadServerResponse userInfo:userInfo], validationError);


### PR DESCRIPTION
Add new constant
`AFNetworkingOperationFailingURLResponseOriginalDataErrorKey` to
retrieve the original data from the request when the response is
considered  invalid
