### PR TITLE
Add References Badge to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 </p>
 
 [![Build Status](https://travis-ci.org/AFNetworking/AFNetworking.svg)](https://travis-ci.org/AFNetworking/AFNetworking)
+[![Reference Status](https://www.versioneye.com/objective-c/afnetworking/reference_badge.svg)](https://www.versioneye.com/objective-c/afnetworking/references)
 
 AFNetworking is a delightful networking library for iOS and Mac OS X. It's built on top of the [Foundation URL Loading System](http://developer.apple.com/library/mac/#documentation/Cocoa/Conceptual/URLLoadingSystem/URLLoadingSystem.html), extending the powerful high-level networking abstractions built into Cocoa. It has a modular architecture with well-designed, feature-rich APIs that are a joy to use.
 


### PR DESCRIPTION
AFNetworking is the most referenced project in CocoaPods. The badge links to a page where you can see all projects who rely on AFNetworking. 
