### PR TITLE
Fixes an issue with the request serializer silently handling an error

### DIFF
--- a/AFNetworking/AFURLRequestSerialization.m
+++ b/AFNetworking/AFURLRequestSerialization.m
@@ -440,7 +440,16 @@ static void *AFHTTPRequestSerializerObserverContext = &AFHTTPRequestSerializerOb
     if (parameters) {
         NSString *query = nil;
         if (self.queryStringSerialization) {
-            query = self.queryStringSerialization(request, parameters, error);
+            NSError *serializationError;
+            query = self.queryStringSerialization(request, parameters, &serializationError);
+
+            if (serializationError) {
+                if (error) {
+                    *error = serializationError;
+                }
+
+                return nil;
+            }
         } else {
             switch (self.queryStringSerializationStyle) {
                 case AFHTTPRequestQueryStringDefaultStyle:

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+= Master
+
+ * Fixes an issue with `AFHTTPRequestSerializer` returning a request and
+  silently handling an error from a `queryStringSerialization` block.
+
 = 2.3.1 (2014-06-13)
 
  * Fix issue with unsynthesized `streamStatus` & `streamError` properties

--- a/Tests/Tests/AFHTTPRequestSerializationTests.m
+++ b/Tests/Tests/AFHTTPRequestSerializationTests.m
@@ -117,4 +117,21 @@
     XCTAssertTrue([part.headers[@"Content-Type"] isEqualToString:@"application/x-x509-ca-cert"], @"MIME Type has not been obtained correctly (%@)", part.headers[@"Content-Type"]);
 }
 
+- (void)testQueryStringSerializationCanFailWithError {
+    AFHTTPRequestSerializer *serializer = [AFHTTPRequestSerializer serializer];
+
+    NSError *serializerError = [NSError errorWithDomain:@"TestDomain" code:0 userInfo:nil];
+
+    [serializer setQueryStringSerializationWithBlock:^NSString *(NSURLRequest *request, NSDictionary *parameters, NSError *__autoreleasing *error) {
+        *error = serializerError;
+        return nil;
+    }];
+
+    NSError *error;
+    NSURLRequest *request = [serializer requestWithMethod:@"GET" URLString:@"url" parameters:@{} error:&error];
+
+    expect(request).to.beNil();
+    expect(error).to.equal(serializerError);
+}
+
 @end


### PR DESCRIPTION
When a query string serialization block is set on `AFHTTPRequestSerializer`, if it was to fail with an error it would be silently handled and the serialization would still return an NSURLRequest.
