### PR TITLE
[Request Serialization] Add `valueForHTTPHeaderField:`

### DIFF
--- a/AFNetworking/AFURLRequestSerialization.h
+++ b/AFNetworking/AFURLRequestSerialization.h
@@ -132,8 +132,15 @@ typedef NS_ENUM(NSUInteger, AFHTTPRequestQueryStringSerializationStyle) {
  @param field The HTTP header to set a default value for
  @param value The value set as default for the specified header, or `nil`
  */
-- (void)setValue:(NSString *)value
-forHTTPHeaderField:(NSString *)field;
+- (void)setValue:(NSString *)value forHTTPHeaderField:(NSString *)field;
+
+/**
+ Returns the value for the HTTP headers set in the request serializer.
+
+ @param field The HTTP header to retrieve the default value for
+ @return The value set as default for the specified header, or `nil`
+ */
+- (NSString *)valueForHTTPHeaderField:(NSString *)field;
 
 /**
  Sets the "Authorization" HTTP header set in request objects made by the HTTP client to a basic authentication value with Base64-encoded username and password. This overwrites any existing value for this header.

--- a/AFNetworking/AFURLRequestSerialization.m
+++ b/AFNetworking/AFURLRequestSerialization.m
@@ -260,6 +260,10 @@ static void *AFHTTPRequestSerializerObserverContext = &AFHTTPRequestSerializerOb
 	[self.mutableHTTPRequestHeaders setValue:value forKey:field];
 }
 
+- (NSString *)valueForHTTPHeaderField:(NSString *)field {
+    return [self.mutableHTTPRequestHeaders valueForKey:field];
+}
+
 - (void)setAuthorizationHeaderFieldWithUsername:(NSString *)username password:(NSString *)password {
 	NSString *basicAuthCredentials = [NSString stringWithFormat:@"%@:%@", username, password];
     [self setValue:[NSString stringWithFormat:@"Basic %@", AFBase64EncodedStringFromString(basicAuthCredentials)] forHTTPHeaderField:@"Authorization"];

--- a/Tests/Tests/AFHTTPRequestSerializationTests.m
+++ b/Tests/Tests/AFHTTPRequestSerializationTests.m
@@ -117,4 +117,18 @@
     XCTAssertTrue([part.headers[@"Content-Type"] isEqualToString:@"application/x-x509-ca-cert"], @"MIME Type has not been obtained correctly (%@)", part.headers[@"Content-Type"]);
 }
 
+#pragma mark - Headers
+
+- (void)testThatValueForHTTPHeaderFieldReturnsSetValue {
+    [self.requestSerializer setValue:@"Actual Value" forHTTPHeaderField:@"Set-Header"];
+    NSString *value = [self.requestSerializer valueForHTTPHeaderField:@"Set-Header"];
+
+    expect(value).to.equal(@"Actual Value");
+}
+
+- (void)testThatValueForHTTPHeaderFieldReturnsNilForUnsetHeader {
+    NSString *value = [self.requestSerializer valueForHTTPHeaderField:@"Unset-Header"];
+    expect(value).to.beNil();
+}
+
 @end


### PR DESCRIPTION
Since we have `setValue:forHTTPHeaderField:` it makes sense to have a similar method to retrieve them.
