### PR TITLE
Fix detection of reachability via WWAN versus WiFi

### DIFF
--- a/AFNetworking/AFNetworkReachabilityManager.m
+++ b/AFNetworking/AFNetworkReachabilityManager.m
@@ -65,7 +65,7 @@ static AFNetworkReachabilityStatus AFNetworkReachabilityStatusForFlags(SCNetwork
         status = AFNetworkReachabilityStatusNotReachable;
     }
 #if	TARGET_OS_IPHONE
-    else if ((flags & kSCNetworkReachabilityFlagsIsWWAN) != 0) {
+    else if ((flags & kSCNetworkReachabilityFlagsIsWWAN)) {
         status = AFNetworkReachabilityStatusReachableViaWWAN;
     }
 #endif


### PR DESCRIPTION
The AFNetworkReachabilityManager callback never returned a reachability of WiFi even if the device was clearly on WiFi. Fix comparison of results of bitwise AND of network reachability flags for kSCNetworkReachabilityFlagsIsWWAN.
