### PR TITLE
UIButton+AFNetworking fix to resolve 32-bit compiler warning

### DIFF
--- a/UIKit+AFNetworking/UIButton+AFNetworking.m
+++ b/UIKit+AFNetworking/UIButton+AFNetworking.m
@@ -50,7 +50,7 @@
 #pragma mark -
 
 static const char * af_imageRequestOperationKeyForState(UIControlState state) {
-    return [[NSString stringWithFormat:@"af_imageRequestOperationKeyForState_%lu", (NSUInteger)state] cStringUsingEncoding:NSASCIIStringEncoding];
+    return [[NSString stringWithFormat:@"af_imageRequestOperationKeyForState_%lu", (unsigned long)state] cStringUsingEncoding:NSASCIIStringEncoding];
 }
 
 - (AFHTTPRequestOperation *)af_imageRequestOperationForState:(UIControlState)state {
@@ -66,7 +66,7 @@ static const char * af_imageRequestOperationKeyForState(UIControlState state) {
 #pragma mark -
 
 static const char * af_backgroundImageRequestOperationKeyForState(UIControlState state) {
-    return [[NSString stringWithFormat:@"af_backgroundImageRequestOperationKeyForState_%lu", (NSUInteger)state] cStringUsingEncoding:NSASCIIStringEncoding];
+    return [[NSString stringWithFormat:@"af_backgroundImageRequestOperationKeyForState_%lu", (unsigned long)state] cStringUsingEncoding:NSASCIIStringEncoding];
 }
 
 - (AFHTTPRequestOperation *)af_backgroundImageRequestOperationForState:(UIControlState)state {


### PR DESCRIPTION
Resolves 32-bit compiler warning about "Values of type 'NSUInteger' should not be used as format arguments; add an explicit cast to 'unsigned long' instead"

Issue #2283 references this as well
