### PR TITLE
type of property responseSerializer

### DIFF
--- a/AFNetworking/AFHTTPRequestOperation.h
+++ b/AFNetworking/AFHTTPRequestOperation.h
@@ -42,7 +42,7 @@
 
  @warning `responseSerializer` must not be `nil`. Setting a response serializer will clear out any cached value 
  */
-@property (nonatomic, strong) AFHTTPResponseSerializer <AFURLResponseSerialization> * responseSerializer;
+@property (nonatomic, strong) id <AFURLResponseSerialization> responseSerializer;
 
 /**
  An object constructed by the `responseSerializer` from the response and response data. Returns `nil` unless the operation `isFinished`, has a `response`, and has `responseData` with non-zero content length. If an error occurs during serialization, `nil` will be returned, and the `error` property will be populated with the serialization error.

--- a/AFNetworking/AFHTTPRequestOperation.m
+++ b/AFNetworking/AFHTTPRequestOperation.m
@@ -70,7 +70,7 @@ static dispatch_group_t http_request_operation_completion_group() {
     return self;
 }
 
-- (void)setResponseSerializer:(AFHTTPResponseSerializer <AFURLResponseSerialization> *)responseSerializer {
+- (void)setResponseSerializer:(id <AFURLResponseSerialization> )responseSerializer {
     NSParameterAssert(responseSerializer);
 
     [self.lock lock];
@@ -180,7 +180,7 @@ static dispatch_group_t http_request_operation_completion_group() {
         return nil;
     }
 
-    self.responseSerializer = [decoder decodeObjectOfClass:[AFHTTPResponseSerializer class] forKey:NSStringFromSelector(@selector(responseSerializer))];
+    self.responseSerializer = [decoder decodeObjectForKey:NSStringFromSelector(@selector(responseSerializer))];
 
     return self;
 }


### PR DESCRIPTION
responseSerializer must adopt the protocol AFURLResponseSerialization, but should not be a subclass of AFHTTPResponseSerializer
