### PR TITLE
Update UIButton+AFNetworking.m

### DIFF
--- a/UIKit+AFNetworking/UIButton+AFNetworking.m
+++ b/UIKit+AFNetworking/UIButton+AFNetworking.m
@@ -167,6 +167,7 @@ static const char * af_backgroundImageRequestOperationKeyForState(UIControlState
                     [strongSelf setImage:responseObject forState:state];
                 }
             }
+            [[[strongSelf class] sharedImageCache] cacheImage:responseObject forRequest:urlRequest];
         } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
             if ([[urlRequest URL] isEqual:[operation.response URL]]) {
                 if (failure) {


### PR DESCRIPTION
Added call to sharedImageCache to cache the responseObject.  Previously the method would be checking for a cached value, but would often not find a previous image because it was not being cached in this method.
