### PR TITLE
Added a tag property to AFURLConnectionOperation

### DIFF
--- a/AFNetworking/AFURLConnectionOperation.h
+++ b/AFNetworking/AFURLConnectionOperation.h
@@ -205,6 +205,15 @@
  */
 @property (nonatomic, strong) NSDictionary *userInfo;
 
+///--------------------------
+/// @name Passing information
+///--------------------------
+
+/**
+ A tag that can be used to track different requests.
+ */
+@property (nonatomic) NSInteger tag;
+
 ///------------------------------------------------------
 /// @name Initializing an AFURLConnectionOperation Object
 ///------------------------------------------------------


### PR DESCRIPTION
Added a 'tag' property (NSInteger) to AFURLConnectionOperation to easily track different requests.

In our scenario, we have multiple AFHTTPRequestOperation's launched at the same time, and all of them have the same callbacks. We need a way to distinguish them easily, in order to process the output data. Adding a 'tag' property seems like an easy and efficient way to do that.

(A similar property was also found in the old ASIHTTPRequest)
