### PR TITLE
Update .cocoadocs.yml

### DIFF
--- a/.cocoadocs.yml
+++ b/.cocoadocs.yml
@@ -1,6 +1,6 @@
 highlight-color: "#F89915"
 highlight-dark-color: "#E23B1B"
-darker-color: "#FFF1DE"
+darker-color: "#D8A688"
 darker-dark-color: "#E93D1C"
 background-color: "#E9DFDB"
 alt-link-color: "#E23B1B"


### PR DESCRIPTION
![screen shot 2014-10-14 at 11 54 58 am](https://cloud.githubusercontent.com/assets/49038/4632044/77dd4f80-53ba-11e4-9549-e23d1ad14da0.png)

The header is hard to read on [CocoaDocs](http://cocoadocs.org/docsets/AFNetworking/2.4.1/), so I've darkened the colour. In the above example the twitter handle, and the license text are the new colour. Everything else is how it is now.
