### PR TITLE
FIX requestSerializer NSURLSessionConfiguration HTTPAdditionalHeaders

### DIFF
--- a/AFNetworking/AFURLRequestSerialization.h
+++ b/AFNetworking/AFURLRequestSerialization.h
@@ -127,6 +127,11 @@ typedef NS_ENUM(NSUInteger, AFHTTPRequestQueryStringSerializationStyle) {
 + (instancetype)serializer;
 
 /**
+ Creates and returns a serializer with default configuration forcing acceptLanguage and userAgent
+ */
++ (instancetype)serializerWithAcceptLanguage:(NSString *)acceptLanguage andUserAgent:(NSString *)userAgent;
+
+/**
  Sets the value for the HTTP headers set in request objects made by the HTTP client. If `nil`, removes the existing value for that header.
 
  @param field The HTTP header to set a default value for

--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -301,8 +301,17 @@ expectedTotalBytes:(int64_t)expectedTotalBytes {
 
     self.session = [NSURLSession sessionWithConfiguration:self.sessionConfiguration delegate:self delegateQueue:self.operationQueue];
 
-    self.responseSerializer = [AFJSONResponseSerializer serializer];
-
+    //requestSerializer, Overide default HTTPAdditionalHeaders / User-Agent if necessary
+    if ([[self.session.configuration HTTPAdditionalHeaders] objectForKey:@"Accept-Language"] ||
+        [[self.session.configuration HTTPAdditionalHeaders] objectForKey:@"User-Agent"]) {
+        self.requestSerializer = [AFHTTPRequestSerializer
+                                  serializerWithAcceptLanguage:[[self.session.configuration HTTPAdditionalHeaders] objectForKey:@"Accept-Language"]
+                                  andUserAgent:[[self.session.configuration HTTPAdditionalHeaders] objectForKey:@"User-Agent"]];
+        
+    } else {
+        self.requestSerializer = [AFHTTPRequestSerializer serializer];
+    }
+    
     self.securityPolicy = [AFSecurityPolicy defaultPolicy];
 
     self.reachabilityManager = [AFNetworkReachabilityManager sharedManager];


### PR DESCRIPTION
Default initialization of requestSerializer generates default headers "Accept-Language" and "User-Agent".
I'm using NSURLSessionConfiguration and this 2 two parameters are not overrided if they are already set in the request.

"If the same header appears in both this array and the request object (where applicable), the request object’s value takes precedence."

(according to the documentation : https://developer.apple.com/library/IOs/documentation/Foundation/Reference/NSURLSessionConfiguration_class/index.html#//apple_ref/occ/instp/NSURLSessionConfiguration/HTTPAdditionalHeaders)
