### PR TITLE
Fixed wrong image displayed on reusable views when no placeHolderImage set and request failed

### DIFF
--- a/UIKit+AFNetworking/UIImageView+AFNetworking.m
+++ b/UIKit+AFNetworking/UIImageView+AFNetworking.m
@@ -137,9 +137,7 @@
 
         self.af_imageRequestOperation = nil;
     } else {
-        if (placeholderImage) {
-            self.image = placeholderImage;
-        }
+        self.image = (placeholderImage ? placeholderImage : nil);
         
         __weak __typeof(self)weakSelf = self;
         self.af_imageRequestOperation = [[AFHTTPRequestOperation alloc] initWithRequest:urlRequest];


### PR DESCRIPTION
This happens when you're using reusable views like Tableview or CollectionView, if you don't set a placeHolder and the request fail you will see a wrong image from a different reused cell. 
