### PR TITLE
There can be only one background session

### DIFF
--- a/AFNetworking/AFHTTPSessionManager.h
+++ b/AFNetworking/AFHTTPSessionManager.h
@@ -39,6 +39,8 @@
  
  Developers targeting iOS 7 or Mac OS X 10.9 or later that deal extensively with a web service are encouraged to subclass `AFHTTPSessionManager`, providing a class method that returns a shared singleton object on which authentication and other configuration can be shared across the application.
  
+ @warning If your app uses background sessions, you must create a shared singleton or otherwise retain the session manager for the intended duration of the background session.
+ 
  For developers targeting iOS 6 or Mac OS X 10.8 or earlier, `AFHTTPRequestOperationManager` may be used to similar effect.
 
  ## Methods to Override


### PR DESCRIPTION
This commit updates the documentation to more clearly state the expected usage of session managers that have background sessions. See https://github.com/AFNetworking/AFNetworking/issues/2370 for an example of confusion around this issue.
