### PR TITLE
check block is nil or not inside of dispatch_group_async

### DIFF
--- a/AFNetworking/AFHTTPRequestOperation.m
+++ b/AFNetworking/AFHTTPRequestOperation.m
@@ -120,7 +120,9 @@ static dispatch_group_t http_request_operation_completion_group() {
             if (self.error) {
                 if (failure) {
                     dispatch_group_async(self.completionGroup ?: http_request_operation_completion_group(), self.completionQueue ?: dispatch_get_main_queue(), ^{
-                        failure(self, self.error);
+                        if (failure) {
+                            failure(self, self.error);
+                        }
                     });
                 }
             } else {
@@ -128,13 +130,17 @@ static dispatch_group_t http_request_operation_completion_group() {
                 if (self.error) {
                     if (failure) {
                         dispatch_group_async(self.completionGroup ?: http_request_operation_completion_group(), self.completionQueue ?: dispatch_get_main_queue(), ^{
-                            failure(self, self.error);
+                            if (failure) {
+                                failure(self, self.error);
+                            }
                         });
                     }
                 } else {
                     if (success) {
                         dispatch_group_async(self.completionGroup ?: http_request_operation_completion_group(), self.completionQueue ?: dispatch_get_main_queue(), ^{
-                            success(self, responseObject);
+                            if (success) {
+                                success(self, responseObject);
+                            }
                         });
                     }
                 }


### PR DESCRIPTION
To prevent nil object, I checked inside of dispatch_group_async this is block nil or not.
This is solution if #2374 issue.
