### PR TITLE
[Issue #2382] AFURLResponseSerializer MIME Type validation fails when using custom/camel-case content types

### DIFF
--- a/AFNetworking/AFURLResponseSerialization.m
+++ b/AFNetworking/AFURLResponseSerialization.m
@@ -112,7 +112,7 @@ static id AFJSONObjectByRemovingKeysWithNullValues(id JSONObject, NSJSONReadingO
     NSError *validationError = nil;
 
     if (response && [response isKindOfClass:[NSHTTPURLResponse class]]) {
-        if (self.acceptableContentTypes && ![self.acceptableContentTypes containsObject:[response MIMEType]]) {
+        if (self.acceptableContentTypes && ![self acceptableContentTypesContainsCaseSensitiveMimeType:[response MIMEType]]) {
             if ([data length] > 0) {
                 NSMutableDictionary *mutableUserInfo = [@{
                                                           NSLocalizedDescriptionKey: [NSString stringWithFormat:NSLocalizedStringFromTable(@"Request failed: unacceptable content-type: %@", @"AFNetworking", nil), [response MIMEType]],
@@ -195,6 +195,22 @@ static id AFJSONObjectByRemovingKeysWithNullValues(id JSONObject, NSJSONReadingO
     serializer.acceptableContentTypes = [self.acceptableContentTypes copyWithZone:zone];
 
     return serializer;
+}
+
+#pragma mark - Helpers
+
+-(BOOL)acceptableContentTypesContainsCaseSensitiveMimeType:(NSString *)mimeType
+{
+    BOOL containsObject = NO;
+    for(id item in self.acceptableContentTypes)
+    {
+        if( [[(NSString *) item lowercaseString] isEqualToString:mimeType] )
+        {
+            containsObject = YES;
+            break;
+        }
+    }
+    return containsObject;
 }
 
 @end


### PR DESCRIPTION
Added helper method to AFURLResponseSerializer > validateResponse:data:error: for case-insensitive check if acceptableContentTypes contains [response MIMEType]. validateResponse:data:error: would return responseIsValid=NO if custom camel-case content types were used as [response MIMEType] returns the lower-case only version of the MIME type.
