### PR TITLE
Added rss+xml content type to AFURLResponseSerialization.m..

### DIFF
--- a/AFNetworking/AFURLResponseSerialization.m
+++ b/AFNetworking/AFURLResponseSerialization.m
@@ -325,7 +325,7 @@ static id AFJSONObjectByRemovingKeysWithNullValues(id JSONObject, NSJSONReadingO
         return nil;
     }
 
-    self.acceptableContentTypes = [[NSSet alloc] initWithObjects:@"application/xml", @"text/xml", nil];
+    self.acceptableContentTypes = [[NSSet alloc] initWithObjects:@"application/xml", @"text/xml", @"application/rss+xml", nil];
 
     return self;
 }
@@ -370,7 +370,7 @@ static id AFJSONObjectByRemovingKeysWithNullValues(id JSONObject, NSJSONReadingO
         return nil;
     }
 
-    self.acceptableContentTypes = [[NSSet alloc] initWithObjects:@"application/xml", @"text/xml", nil];
+    self.acceptableContentTypes = [[NSSet alloc] initWithObjects:@"application/xml", @"text/xml", @"application/rss+xml", nil];
 
     return self;
 }


### PR DESCRIPTION
Added @"application/rss+xml" to NSSet of acceptableContentTypes for AFXMLDocumentResponseSerializer and AFXMLParserResponseSerializer.

One specific RSS feed I wanted to parse fails to create a NSXMLParse using AFXMLParseResponseSerializer because they tag their data with the "rss+xml" content type:

http://www.fda.gov/AboutFDA/ContactFDA/StayInformed/RSSFeeds/TDS/rss.xml

If you feed the data from the site directly to a NSXMLParser, it has no problem parsing it. But, AFXMLParserResponseSerializer was failing to return a NSXMLParser because the "rss+xml" data type wasn't recognized.
