### PR TITLE
UIRefreshControl should react over task with completed state

### DIFF
--- a/UIKit+AFNetworking/UIRefreshControl+AFNetworking.m
+++ b/UIKit+AFNetworking/UIRefreshControl+AFNetworking.m
@@ -41,18 +41,14 @@
     [notificationCenter removeObserver:self name:AFNetworkingTaskDidCompleteNotification object:nil];
 
     if (task) {
-        if (task.state == NSURLSessionTaskStateCompleted) {
-            [self endRefreshing];
-        } else {
-            if (task.state == NSURLSessionTaskStateRunning) {
-                [self beginRefreshing];
-            } else {
-                [self endRefreshing];
-            }
+        if (task.state == NSURLSessionTaskStateRunning) {
+            [self beginRefreshing];
 
             [notificationCenter addObserver:self selector:@selector(af_beginRefreshing) name:AFNetworkingTaskDidResumeNotification object:task];
             [notificationCenter addObserver:self selector:@selector(af_endRefreshing) name:AFNetworkingTaskDidCompleteNotification object:task];
             [notificationCenter addObserver:self selector:@selector(af_endRefreshing) name:AFNetworkingTaskDidSuspendNotification object:task];
+        } else {
+            [self endRefreshing];
         }
     }
 }


### PR DESCRIPTION
Calling

`[self.refreshControl setRefreshingWithStateOfTask:task];`

with a task of status `NSURLSessionTaskStateCompleted` should stop the refresh control.
