### PR TITLE
Fix for NSProgress bug where two child NSProgress instances are added to...

### DIFF
--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -467,7 +467,12 @@ static NSString * const AFNSURLSessionTaskDidSuspendNotification = @"com.alamofi
         }
     }
 
-    delegate.progress = [NSProgress progressWithTotalUnitCount:totalUnitCount];
+    if (delegate.progress) {
+        delegate.progress.totalUnitCount = totalUnitCount;
+    } else {
+        delegate.progress = [NSProgress progressWithTotalUnitCount:totalUnitCount];
+    }
+
     delegate.progress.pausingHandler = ^{
         [uploadTask suspend];
     };


### PR DESCRIPTION
When using a parent NSProgress, I saw odd behaviour. I discovered there were two NSProgress children added to the NSProgress parent instead of the expected one.

The commit message describes what is going on:
AFURLSessionManagerTaskDelegate creates a NSProgress in its initializer. However, -[AFURLSessionManager addDelegateForUploadTask:progress:completionHandler:] assigns a new NSProgress to the delegates progress property.
When using -[NSProgress becomeCurrentWithPendingUnitCount:] two NSProgress children are added, as two are created in the current parent's context.

The fix is simple, only creating a new NSProgress if one is not already assigned to the delegate (which is never the case in the current code, but this way the change is future proof for changes in the delegate).
