### PR TITLE
Fix iOS Example App Detail Label

### DIFF
--- a/Example/Classes/Views/PostTableViewCell.m
+++ b/Example/Classes/Views/PostTableViewCell.m
@@ -57,11 +57,17 @@
 }
 
 + (CGFloat)heightForCellWithPost:(Post *)post {
+    CGFloat desiredHeight = fmaxf(70.0f, (float)[self detailTextHeight:post.text] + 45.0f);
+
+    return desiredHeight;
+}
+
++ (CGFloat)detailTextHeight:(NSString *)text {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    CGSize sizeToFit = [post.text sizeWithFont:[UIFont systemFontOfSize:12.0f] constrainedToSize:CGSizeMake(220.0f, CGFLOAT_MAX) lineBreakMode:NSLineBreakByWordWrapping];
+    CGSize sizeToFit = [text sizeWithFont:[UIFont systemFontOfSize:12.0f] constrainedToSize:CGSizeMake(240.0f, CGFLOAT_MAX) lineBreakMode:NSLineBreakByWordWrapping];
 #pragma clang diagnostic pop
-    return fmaxf(70.0f, (float)sizeToFit.height + 45.0f);
+    return sizeToFit.height;
 }
 
 #pragma mark - UIView
@@ -70,10 +76,11 @@
     [super layoutSubviews];
     
     self.imageView.frame = CGRectMake(10.0f, 10.0f, 50.0f, 50.0f);
-    self.textLabel.frame = CGRectMake(70.0f, 10.0f, 240.0f, 20.0f);
+    self.textLabel.frame = CGRectMake(70.0f, 6.0f, 240.0f, 20.0f);
     
     CGRect detailTextLabelFrame = CGRectOffset(self.textLabel.frame, 0.0f, 25.0f);
-    detailTextLabelFrame.size.height = [[self class] heightForCellWithPost:self.post] - 45.0f;
+    CGFloat calculatedHeight = [[self class] detailTextHeight:self.post.text];
+    detailTextLabelFrame.size.height = calculatedHeight;
     self.detailTextLabel.frame = detailTextLabelFrame;
 }
 


### PR DESCRIPTION
The iOS test app currently:
1. Doesn't top align the username with the profile image
2. Has inconsistent padding around the detail text label
#### Old Spacing

![old spacing](https://cloud.githubusercontent.com/assets/48065/5194545/6d7aadf6-74c3-11e4-9e5d-deb0a7f375eb.png)
#### Fixed Spacing

![fixed spacing](https://cloud.githubusercontent.com/assets/48065/5194520/1ab203d0-74c3-11e4-93d9-df60c8c1dcb6.png)
