### PR TITLE
Fix old file names in file header comments.

### DIFF
--- a/AFNetworking/AFSecurityPolicy.h
+++ b/AFNetworking/AFSecurityPolicy.h
@@ -1,4 +1,4 @@
-// AFSecurity.h
+// AFSecurityPolicy.h
 //
 // Copyright (c) 2013-2014 AFNetworking (http://afnetworking.com)
 //

--- a/AFNetworking/AFSecurityPolicy.m
+++ b/AFNetworking/AFSecurityPolicy.m
@@ -1,4 +1,4 @@
-// AFSecurity.m
+// AFSecurityPolicy.m
 //
 // Copyright (c) 2013-2014 AFNetworking (http://afnetworking.com)
 //

--- a/AFNetworking/AFURLRequestSerialization.h
+++ b/AFNetworking/AFURLRequestSerialization.h
@@ -1,4 +1,4 @@
-// AFSerialization.h
+// AFURLRequestSerialization.h
 //
 // Copyright (c) 2013-2014 AFNetworking (http://afnetworking.com)
 //

--- a/AFNetworking/AFURLRequestSerialization.m
+++ b/AFNetworking/AFURLRequestSerialization.m
@@ -1,4 +1,4 @@
-// AFSerialization.h
+// AFURLRequestSerialization.m
 //
 // Copyright (c) 2013-2014 AFNetworking (http://afnetworking.com)
 //

--- a/AFNetworking/AFURLResponseSerialization.h
+++ b/AFNetworking/AFURLResponseSerialization.h
@@ -1,4 +1,4 @@
-// AFSerialization.h
+// AFURLResponseSerialization.h
 //
 // Copyright (c) 2013-2014 AFNetworking (http://afnetworking.com)
 //

--- a/AFNetworking/AFURLResponseSerialization.m
+++ b/AFNetworking/AFURLResponseSerialization.m
@@ -1,4 +1,4 @@
-// AFSerialization.h
+// AFURLResponseSerialization.m
 //
 // Copyright (c) 2013-2014 AFNetworking (http://afnetworking.com)
 //


### PR DESCRIPTION
Cleanup old filenames in comments leftover from ancient history.
