### PR TITLE
Display all of variable arguments which are specified as otherButtonTitles

### DIFF
--- a/UIKit+AFNetworking/UIAlertView+AFNetworking.m
+++ b/UIKit+AFNetworking/UIAlertView+AFNetworking.m
@@ -62,6 +62,13 @@ static void AFGetAlertViewTitleAndMessageFromError(NSError *error, NSString * __
                                 cancelButtonTitle:(NSString *)cancelButtonTitle
                                 otherButtonTitles:(NSString *)otherButtonTitles, ... NS_REQUIRES_NIL_TERMINATION
 {
+    va_list otherTitleList;
+    va_start(otherTitleList, otherButtonTitles);
+    UIAlertView *alertView = [[UIAlertView alloc] initWithTitle:nil message:nil delegate:delegate cancelButtonTitle:cancelButtonTitle otherButtonTitles:nil, nil];
+    for(NSString *otherTitle = otherButtonTitles; otherTitle != nil; otherTitle = va_arg(otherTitleList, NSString *)){
+        [alertView addButtonWithTitle:otherTitle];
+    }
+    va_end(otherTitleList);
     __block id observer = [[NSNotificationCenter defaultCenter] addObserverForName:AFNetworkingTaskDidCompleteNotification object:task queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notification) {
 
         NSError *error = notification.userInfo[AFNetworkingTaskDidCompleteErrorKey];
@@ -69,7 +76,9 @@ static void AFGetAlertViewTitleAndMessageFromError(NSError *error, NSString * __
             NSString *title, *message;
             AFGetAlertViewTitleAndMessageFromError(error, &title, &message);
 
-            [[[UIAlertView alloc] initWithTitle:title message:message delegate:delegate cancelButtonTitle:cancelButtonTitle otherButtonTitles:otherButtonTitles, nil] show];
+            [alertView setTitle:title];
+            [alertView setMessage:message];
+            [alertView show];
         }
 
         [[NSNotificationCenter defaultCenter] removeObserver:observer name:AFNetworkingTaskDidCompleteNotification object:notification.object];
@@ -90,6 +99,13 @@ static void AFGetAlertViewTitleAndMessageFromError(NSError *error, NSString * __
                                             cancelButtonTitle:(NSString *)cancelButtonTitle
                                             otherButtonTitles:(NSString *)otherButtonTitles, ... NS_REQUIRES_NIL_TERMINATION
 {
+    va_list otherTitleList;
+    va_start(otherTitleList, otherButtonTitles);
+    UIAlertView *alertView = [[UIAlertView alloc] initWithTitle:nil message:nil delegate:delegate cancelButtonTitle:cancelButtonTitle otherButtonTitles:nil, nil];
+    for(NSString *otherTitle = otherButtonTitles; otherTitle != nil; otherTitle = va_arg(otherTitleList, NSString *)){
+        [alertView addButtonWithTitle:otherTitle];
+    }
+    va_end(otherTitleList);
     __block id observer = [[NSNotificationCenter defaultCenter] addObserverForName:AFNetworkingOperationDidFinishNotification object:operation queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notification) {
 
         if (notification.object && [notification.object isKindOfClass:[AFURLConnectionOperation class]]) {
@@ -98,7 +114,9 @@ static void AFGetAlertViewTitleAndMessageFromError(NSError *error, NSString * __
                 NSString *title, *message;
                 AFGetAlertViewTitleAndMessageFromError(error, &title, &message);
 
-                [[[UIAlertView alloc] initWithTitle:title message:message delegate:delegate cancelButtonTitle:cancelButtonTitle otherButtonTitles:otherButtonTitles, nil] show];
+                [alertView setTitle:title];
+                [alertView setMessage:message];
+                [alertView show];
             }
         }
 


### PR DESCRIPTION
I found a minor problem at following methods which are in category extension class for UIAlertView.
 * ``` + (void)showAlertViewForTaskWithErrorOnCompletion:(NSURLSessionTask *)task
                                         delegate:(id)delegate
                                cancelButtonTitle:(NSString *)cancelButtonTitle
                                otherButtonTitles:(NSString *)otherButtonTitle, ... ```
 * ``` + (void)showAlertViewForRequestOperationWithErrorOnCompletion:(AFURLConnectionOperation *)operation
                                                     delegate:(id)delegate
                                            cancelButtonTitle:(NSString *)cancelButtonTitle
                                            otherButtonTitles:(NSString *)otherButtonTitle, ...```  

For instance, if the ```otherButtonTitles, ...``` variable argument is set to ```@"Button1", @"Button2", @"Button3", nil``` , the alertView should be displayed like this.  

![UIAlertView (set to Button1, Button2, Button3 as otherButtonTitle)](https://cloud.githubusercontent.com/assets/5053240/5236802/07d1c9d8-7894-11e4-9aba-0f90f579d2e6.png)

However,  these methods display only first of variable arguments (``` @"Button1" ```) like this.
![Specify Button1, Button2, Button3..but showed Button1 only](https://cloud.githubusercontent.com/assets/5053240/5615604/fabbf7aa-953f-11e4-92cb-9bdd130f3718.png)

The reason of this, these method deliver the argument which is recieved  as "```otherButtonTitles```" to UIAlertView's function as it is.
Variable arguments cannot be delivered  to another method.
So I attempt to separate them for each argument by using ```va_start, va_arg, va_end``` API and set these separated arguments to title of ```UIAlertView```.
Hope you like this proposal :smile: 