### PR TITLE
Network indicator no longer spins forever when using >1 session manager

### DIFF
--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -393,11 +393,16 @@ static NSString * const AFNSURLSessionTaskDidSuspendNotification = @"com.alamofi
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
+#pragma mark -
+
+- (NSString *)descriptionForAllTasks {
+    return [NSString stringWithFormat:@"%p", self];
+}
+
 - (void)taskDidResume:(NSNotification *)notification {
     NSURLSessionTask *task = notification.object;
     if ([task isKindOfClass:[NSURLSessionTask class]]) {
-        AFURLSessionManager *manager = [self delegateForTask:task].manager;
-        if ([manager isEqual:self]) {
+        if ([task.taskDescription isEqualToString:[self descriptionForAllTasks]]) {
             dispatch_async(dispatch_get_main_queue(), ^{
                 [[NSNotificationCenter defaultCenter] postNotificationName:AFNetworkingTaskDidResumeNotification object:task];
             });
@@ -408,8 +413,7 @@ static NSString * const AFNSURLSessionTaskDidSuspendNotification = @"com.alamofi
 - (void)taskDidSuspend:(NSNotification *)notification {
     NSURLSessionTask *task = notification.object;
     if ([task isKindOfClass:[NSURLSessionTask class]]) {
-        AFURLSessionManager *manager = [self delegateForTask:task].manager;
-        if ([manager isEqual:self]) {
+        if ([task.taskDescription isEqualToString:[self descriptionForAllTasks]]) {
             dispatch_async(dispatch_get_main_queue(), ^{
                 [[NSNotificationCenter defaultCenter] postNotificationName:AFNetworkingTaskDidSuspendNotification object:task];
             });
@@ -448,6 +452,7 @@ static NSString * const AFNSURLSessionTaskDidSuspendNotification = @"com.alamofi
     delegate.manager = self;
     delegate.completionHandler = completionHandler;
 
+    dataTask.taskDescription = [self descriptionForAllTasks];
     [self setDelegate:delegate forTask:dataTask];
 }
 
@@ -484,6 +489,7 @@ static NSString * const AFNSURLSessionTaskDidSuspendNotification = @"com.alamofi
         *progress = delegate.progress;
     }
 
+    uploadTask.taskDescription = [self descriptionForAllTasks];
     [self setDelegate:delegate forTask:uploadTask];
 }
 
@@ -506,6 +512,7 @@ static NSString * const AFNSURLSessionTaskDidSuspendNotification = @"com.alamofi
         *progress = delegate.progress;
     }
 
+    downloadTask.taskDescription = [self descriptionForAllTasks];
     [self setDelegate:delegate forTask:downloadTask];
 }
 


### PR DESCRIPTION
Issue details at #2476. Now matches tasks with `AFURLSessionManager`s by setting all tasks' `taskIdentifier`s to the stringified address of the manager.