### PR TITLE
Image response serializer weirdness

### DIFF
--- a/AFNetworking/AFURLResponseSerialization.m
+++ b/AFNetworking/AFURLResponseSerialization.m
@@ -541,6 +541,8 @@ static UIImage * AFInflatedImageFromResponseWithDataAtScale(NSHTTPURLResponse *r
         return nil;
     }
 
+    UIImage *image = AFImageWithDataAtScale(data, scale);
+
     CGImageRef imageRef = NULL;
     CGDataProviderRef dataProvider = CGDataProviderCreateWithCFData((__bridge CFDataRef)data);
 
@@ -562,7 +564,6 @@ static UIImage * AFInflatedImageFromResponseWithDataAtScale(NSHTTPURLResponse *r
 
     CGDataProviderRelease(dataProvider);
 
-    UIImage *image = AFImageWithDataAtScale(data, scale);
     if (!imageRef) {
         if (image.images || !image) {
             return image;

--- a/Tests/AFNetworking Tests.xcodeproj/project.pbxproj
+++ b/Tests/AFNetworking Tests.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		64491A4B18AAF01600F35444 /* Rapid_SSL_CA.cer in Resources */ = {isa = PBXBuildFile; fileRef = 64491A4918AAF01600F35444 /* Rapid_SSL_CA.cer */; };
 		649154E918AAD260002E57F9 /* httpbinorg_11212014.cer in Resources */ = {isa = PBXBuildFile; fileRef = 649154E818AAD260002E57F9 /* httpbinorg_11212014.cer */; };
 		649154EA18AAD260002E57F9 /* httpbinorg_11212014.cer in Resources */ = {isa = PBXBuildFile; fileRef = 649154E818AAD260002E57F9 /* httpbinorg_11212014.cer */; };
+		677612021A42E300000896EA /* AFImageResponseSerializerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 677612011A42E300000896EA /* AFImageResponseSerializerTests.m */; };
 		6D86BAA5C6174E98AE719CE9 /* libPods-ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 55E73C267F33406A9F92476C /* libPods-ios.a */; };
 		77D65EBC1848A03C004CA024 /* AFPropertyListResponseSerializerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 77D65EBB1848A03C004CA024 /* AFPropertyListResponseSerializerTests.m */; };
 		77D65EBD1848A03C004CA024 /* AFPropertyListResponseSerializerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 77D65EBB1848A03C004CA024 /* AFPropertyListResponseSerializerTests.m */; };
@@ -107,6 +108,7 @@
 		64491A4618AAEFFF00F35444 /* Geotrust_Root_CA.cer */ = {isa = PBXFileReference; lastKnownFileType = file; path = Geotrust_Root_CA.cer; sourceTree = "<group>"; };
 		64491A4918AAF01600F35444 /* Rapid_SSL_CA.cer */ = {isa = PBXFileReference; lastKnownFileType = file; path = Rapid_SSL_CA.cer; sourceTree = "<group>"; };
 		649154E818AAD260002E57F9 /* httpbinorg_11212014.cer */ = {isa = PBXFileReference; lastKnownFileType = file; path = httpbinorg_11212014.cer; sourceTree = "<group>"; };
+		677612011A42E300000896EA /* AFImageResponseSerializerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFImageResponseSerializerTests.m; sourceTree = "<group>"; };
 		77D65EBB1848A03C004CA024 /* AFPropertyListResponseSerializerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFPropertyListResponseSerializerTests.m; sourceTree = "<group>"; };
 		943B1F40192E406C00304316 /* AFURLSessionManagerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFURLSessionManagerTests.m; sourceTree = "<group>"; };
 		95D45FB81CA3594FA8CF7430 /* Pods-ios.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ios.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ios/Pods-ios.debug.xcconfig"; sourceTree = "<group>"; };
@@ -260,6 +262,7 @@
 				F87382941948AC15000B7AFA /* AFHTTPSessionManagerTests.m */,
 				29CBFC3E17DF58000021AB75 /* AFHTTPRequestSerializationTests.m */,
 				F837FFAE195744A0009078A0 /* AFHTTPResponseSerializationTests.m */,
+				677612011A42E300000896EA /* AFImageResponseSerializerTests.m */,
 				29CBFC3B17DF541F0021AB75 /* AFJSONSerializationTests.m */,
 				77D65EBB1848A03C004CA024 /* AFPropertyListResponseSerializerTests.m */,
 				29CBFC5917DF61B30021AB75 /* AFSecurityPolicyTests.m */,
@@ -519,6 +522,7 @@
 				943B1F41192E406C00304316 /* AFURLSessionManagerTests.m in Sources */,
 				F837FFAF195744A0009078A0 /* AFHTTPResponseSerializationTests.m in Sources */,
 				29CBFC5A17DF61B30021AB75 /* AFSecurityPolicyTests.m in Sources */,
+				677612021A42E300000896EA /* AFImageResponseSerializerTests.m in Sources */,
 				29CBFC3F17DF58000021AB75 /* AFHTTPRequestSerializationTests.m in Sources */,
 				B6774DC918FBB49E0044DB17 /* AFNetworkActivityManagerTests.m in Sources */,
 				29CBFC3C17DF541F0021AB75 /* AFJSONSerializationTests.m in Sources */,

--- a/Tests/Tests/AFImageResponseSerializerTests.m
+++ b/Tests/Tests/AFImageResponseSerializerTests.m
@@ -28,7 +28,7 @@
 - (void)testImageResponseSerializer {
     NSMutableArray *images = [NSMutableArray array];
     for (int i=0; i<20; i++) {
-        NSURL *url = [NSURL URLWithString:@"http://i.ebayimg.com/00/s/NzY4WDEwMjQ=/z/OoIAAOSwAL9UkVnH/$_93.JPG"];
+        NSURL *url = [NSURL URLWithString:@"https://camo.githubusercontent.com/1560be050811ab73457e90aee62cd1cd257c7fb9/68747470733a2f2f7261772e6769746875622e636f6d2f41464e6574776f726b696e672f41464e6574776f726b696e672f6173736574732f61666e6574776f726b696e672d6c6f676f2e706e67"];
         NSURLRequest *request = [NSURLRequest requestWithURL:url];
         NSURLSessionDataTask *task = [self.session dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
             UIImage *image = [self.responseSerializer responseObjectForResponse:response data:data error:nil];

--- a/Tests/Tests/AFImageResponseSerializerTests.m
+++ b/Tests/Tests/AFImageResponseSerializerTests.m
@@ -1,0 +1,52 @@
+//
+//  AFImageResponseSerializerTests.m
+//  AFNetworking Tests
+//
+//  Created by Plunien, Johannes on 17/12/14.
+//  Copyright (c) 2014 AFNetworking. All rights reserved.
+//
+
+#import "AFTestCase.h"
+
+#import "AFURLResponseSerialization.h"
+
+@interface AFImageResponseSerializerTests : AFTestCase
+@property (readwrite, nonatomic, strong) AFImageResponseSerializer *responseSerializer;
+@property (readwrite, nonatomic, strong) NSURLSession *session;
+@end
+
+@implementation AFImageResponseSerializerTests
+
+- (void)setUp {
+    [super setUp];
+
+    self.responseSerializer = [AFImageResponseSerializer serializer];
+    self.responseSerializer.imageScale = 1.0f;
+    self.session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]];
+}
+
+- (void)testImageResponseSerializer {
+    NSMutableArray *images = [NSMutableArray array];
+    for (int i=0; i<20; i++) {
+        NSURL *url = [NSURL URLWithString:@"http://i.ebayimg.com/00/s/NzY4WDEwMjQ=/z/OoIAAOSwAL9UkVnH/$_93.JPG"];
+        NSURLRequest *request = [NSURLRequest requestWithURL:url];
+        NSURLSessionDataTask *task = [self.session dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+            UIImage *image = [self.responseSerializer responseObjectForResponse:response data:data error:nil];
+            [images addObject:image];
+        }];
+        [task resume];
+    }
+    expect(images.count).will.equal(20);
+
+    // Now I'd expect all images to be the same, but they are not. Add a break point here and check
+    // the images with quicklook and see yourself. Some of them are broken.
+    for (UIImage *image1 in images) {
+        for (UIImage *image2 in images) {
+            NSData *data1 = UIImagePNGRepresentation(image1);
+            NSData *data2 = UIImagePNGRepresentation(image2);
+            XCTAssertTrue([data1 isEqual:data2]);
+        }
+    }
+}
+
+@end


### PR DESCRIPTION
Hey @mattt,

first a disclaimer: This pull request is not supposed to be merged! I just kindly want to ask you, if you could have a look at it.

There are two commits. One adding a failing test. And another one fixing it. The fix is really weird and I honestly don't understand why it is fixing the issue.

Also, in our main project (eBay Kleinanzeigen), which is using AFNetworking, the malloc guard breakpoint points to https://github.com/AFNetworking/AFNetworking/blob/c3a929de8c9f6575ac5e62e0f9f14aa4ca39b93e/AFNetworking/AFURLResponseSerialization.m#L616

But I cannot reproduce that in the AFNetworking iOS Example, there the malloc guard breakpoint does not fire. But it's a different setup there anyway. It's using the category on UIImage, which is using AFHTTPRequestOperation etc.

Maybe I'm doing something completely wrong here in this NSURLSession + AFImageResponseSerializer setup? Any pointers are appreciated!

Thanks in advance,
plu