### PR TITLE
fix genstrings warning in UIAlertView+AFNetworking

### DIFF
--- a/UIKit+AFNetworking/UIAlertView+AFNetworking.m
+++ b/UIKit+AFNetworking/UIAlertView+AFNetworking.m
@@ -82,7 +82,7 @@ static void AFGetAlertViewTitleAndMessageFromError(NSError *error, NSString * __
 + (void)showAlertViewForRequestOperationWithErrorOnCompletion:(AFURLConnectionOperation *)operation
                                                      delegate:(id)delegate
 {
-    [self showAlertViewForRequestOperationWithErrorOnCompletion:operation delegate:delegate cancelButtonTitle:NSLocalizedStringFromTable(@"Dismiss", @"AFNetworking", @"UIAlert View Cancel Button Title") otherButtonTitles:nil, nil];
+    [self showAlertViewForRequestOperationWithErrorOnCompletion:operation delegate:delegate cancelButtonTitle:NSLocalizedStringFromTable(@"Dismiss", @"AFNetworking", @"UIAlertView Cancel Button Title") otherButtonTitles:nil, nil];
 }
 
 + (void)showAlertViewForRequestOperationWithErrorOnCompletion:(AFURLConnectionOperation *)operation


### PR DESCRIPTION
` find . -name \*.m | xargs genstrings -o .` generate the following warning: 

Warning: Key "Dismiss" used with multiple comments "UIAlert View Cancel Button Title" & "UIAlertView Cancel Button Title"