### PR TITLE
include responseObject in error object

### DIFF
--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -184,6 +184,17 @@ didCompleteWithError:(NSError *)error
 
             if (responseObject) {
                 userInfo[AFNetworkingTaskDidCompleteSerializedResponseKey] = responseObject;
+                
+                if (serializationError) {
+                    NSDictionary* userInfo =  ({
+                        NSMutableDictionary* d = serializationError.userInfo.mutableCopy;
+                        d[AFNetworkingTaskDidCompleteSerializedResponseKey] = responseObject;
+                        d;
+                    })
+                    serializationError = [NSError errorWithDomain: serializationError.domain
+                                                             code: serializationError.code
+                                                         userInfo: userInfo];
+                }
             }
 
             if (serializationError) {

--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -190,7 +190,7 @@ didCompleteWithError:(NSError *)error
                         NSMutableDictionary* d = serializationError.userInfo.mutableCopy;
                         d[AFNetworkingTaskDidCompleteSerializedResponseKey] = responseObject;
                         d;
-                    })
+                    });
                     serializationError = [NSError errorWithDomain: serializationError.domain
                                                              code: serializationError.code
                                                          userInfo: userInfo];


### PR DESCRIPTION
an HTTP service may respond with a 400 series status, but contain useful error information in the body as JSON.
in this case, the default behavior of JSONResponseSerializer is to treat any non 200 series response as an error, and fill it's `error` AND `responseObject` _out_ parameters.

my issue comes with the layer introduced by the `GET:parameters:success:failure:` family of methods, which i want to use, but which assume that any errors, including those non 200s, means we shouldn't care about the responseObject.

i'm not sure that my solution here is best, but in the app i'm working on, i got my desired result by overriding behavior in my subclass as follows:
```objc
-(NSURLSessionDataTask*) dataTaskWithRequest:(NSURLRequest*) request
                           completionHandler:(void (^)(NSURLResponse*, id, NSError*)) completionHandler
{
    return [super dataTaskWithRequest: request
                    completionHandler:
            ^(NSURLResponse* response, id responseObject, NSError* error) {
                if (error != nil && responseObject != nil) {
                    error = [NSError errorWithDomain: error.domain
                                                code: error.code
                                            userInfo: ({
                        NSMutableDictionary* userInfo = [error.userInfo mutableCopy];
                        userInfo[AFNetworkingTaskDidCompleteSerializedResponseKey] = responseObject;
                        userInfo;
                    })];
                }
                
                if (completionHandler)
                    completionHandler(response, responseObject, error);
            }];
}
```

i'm pretty sure this is a legitimate use case, but i welcome any advise here