### PR TITLE
UIButton+AFNetworking. The methods that asynchronously download images have started to properly report on the failures.

### DIFF
--- a/UIKit+AFNetworking/UIButton+AFNetworking.m
+++ b/UIKit+AFNetworking/UIButton+AFNetworking.m
@@ -199,7 +199,7 @@ static const char * af_backgroundImageRequestOperationKeyForState(UIControlState
             }
             [[[strongSelf class] sharedImageCache] cacheImage:responseObject forRequest:urlRequest];
         } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
-            if ([[urlRequest URL] isEqual:[operation.response URL]]) {
+            if ([[urlRequest URL] isEqual:[operation.request URL]]) {
                 if (failure) {
                     failure(error);
                 }
@@ -265,7 +265,7 @@ static const char * af_backgroundImageRequestOperationKeyForState(UIControlState
             }
             [[[strongSelf class] sharedImageCache] cacheImage:responseObject forRequest:urlRequest];
         } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
-            if ([[urlRequest URL] isEqual:[operation.response URL]]) {
+            if ([[urlRequest URL] isEqual:[operation.request URL]]) {
                 if (failure) {
                     failure(error);
                 }


### PR DESCRIPTION
I've found a pair of typos that prevented the UIButtons from reporting on the failed image downloads; both of them have been corrected.