### PR TITLE
return early if download task not created

### DIFF
--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -671,6 +671,11 @@ static NSString * const AFNSURLSessionTaskDidSuspendNotification = @"com.alamofi
     dispatch_sync(url_session_manager_creation_queue(), ^{
         downloadTask = [self.session downloadTaskWithRequest:request];
     });
+    
+    if (!downloadTask)
+    {
+        return nil;
+    }
 
     [self addDelegateForDownloadTask:downloadTask progress:progress destination:destination completionHandler:completionHandler];
 


### PR DESCRIPTION
This happens sometimes in my testing on iOS 7.1 (using a real device, with a valid request)

I see that you have fixed a similar issue in the taskWithTask methods, so have fixed in the same way.
I haven't been using the upload tasks, but they could probably benefit from the same protection.

Without the early NULL, I hit an assertion failure in setDelegate:forTask:
