### PR TITLE
add UIImage support in AFHTTPRequestSerializer.

### DIFF
--- a/AFNetworking/AFURLRequestSerialization.h
+++ b/AFNetworking/AFURLRequestSerialization.h
@@ -118,13 +118,14 @@ typedef NS_ENUM(NSUInteger, AFMultipartFormDataImageSerializationStyle) {
 @property (nonatomic, assign) NSTimeInterval timeoutInterval;
 
 /**
- The style of UIImage to NSData, for multipartFormRequestWithMethod. The default style is AFMultipartFormDataImageJPEGStyle.
+ The style of Image to NSData, for multipartFormRequestWithMethod. The default style is AFMultipartFormDataImageJPEGStyle.
  @see AFHTTPRequestSerializer -multipartFormRequestWithMethod:
  */
 @property (nonatomic, assign) AFMultipartFormDataImageSerializationStyle imageStyle;
 
 /**
- The compressionQuality of UIImage to NSData, for multipartFormRequestWithMethod, only use on JPEG style. The default CompressionQuality is 0.8f.
+ The compressionQuality of Image to NSData, for multipartFormRequestWithMethod, only use on JPEG style. The default CompressionQuality is 0.8f.
+ The value is a float between 0.0 and 1.0, with 1.0 resulting in no compression and 0.0 resulting in the maximum compression possible
  @see AFHTTPRequestSerializer -multipartFormRequestWithMethod:
  */
 @property (nonatomic, assign) CGFloat JPEGImageStyleCompressionQuality;
@@ -239,6 +240,13 @@ forHTTPHeaderField:(NSString *)field;
                                 parameters:(id)parameters
                                      error:(NSError * __autoreleasing *)error;
 
+
+/**
+ Use -multipartFormRequestWithMethod:URLString:parameters:constructingBodyWithBlock:error: instead.
+ */
+- (NSMutableURLRequest *)multipartFormRequestWithMethod:(NSString *)method
+                                              URLString:(NSString *)URLString
+                                             parameters:(NSDictionary *)parameters;
 /**
  @deprecated This method has been deprecated. Use -multipartFormRequestWithMethod:URLString:parameters:constructingBodyWithBlock:error: instead.
  */

--- a/AFNetworking/AFURLRequestSerialization.h
+++ b/AFNetworking/AFURLRequestSerialization.h
@@ -56,6 +56,11 @@ typedef NS_ENUM(NSUInteger, AFHTTPRequestQueryStringSerializationStyle) {
     AFHTTPRequestQueryStringDefaultStyle = 0,
 };
 
+typedef NS_ENUM(NSUInteger, AFMultipartFormDataImageSerializationStyle) {
+    AFMultipartFormDataImageJPEGStyle = 0,
+    AFMultipartFormDataImagePNGStyle
+};
+
 @protocol AFMultipartFormData;
 
 /**
@@ -111,6 +116,18 @@ typedef NS_ENUM(NSUInteger, AFHTTPRequestQueryStringSerializationStyle) {
  @see NSMutableURLRequest -setTimeoutInterval:
  */
 @property (nonatomic, assign) NSTimeInterval timeoutInterval;
+
+/**
+ The style of UIImage to NSData, for multipartFormRequestWithMethod. The default style is AFMultipartFormDataImageJPEGStyle.
+ @see AFHTTPRequestSerializer -multipartFormRequestWithMethod:
+ */
+@property (nonatomic, assign) AFMultipartFormDataImageSerializationStyle imageStyle;
+
+/**
+ The compressionQuality of UIImage to NSData, for multipartFormRequestWithMethod, only use on JPEG style. The default CompressionQuality is 0.8f.
+ @see AFHTTPRequestSerializer -multipartFormRequestWithMethod:
+ */
+@property (nonatomic, assign) CGFloat JPEGImageStyleCompressionQuality;
 
 ///---------------------------------------
 /// @name Configuring HTTP Request Headers

--- a/AFNetworking/AFURLRequestSerialization.m
+++ b/AFNetworking/AFURLRequestSerialization.m
@@ -338,6 +338,13 @@ forHTTPHeaderField:(NSString *)field
 - (NSMutableURLRequest *)multipartFormRequestWithMethod:(NSString *)method
                                               URLString:(NSString *)URLString
                                              parameters:(NSDictionary *)parameters
+{
+    return [self multipartFormRequestWithMethod:method URLString:URLString parameters:parameters constructingBodyWithBlock:nil];
+}
+
+- (NSMutableURLRequest *)multipartFormRequestWithMethod:(NSString *)method
+                                              URLString:(NSString *)URLString
+                                             parameters:(NSDictionary *)parameters
                               constructingBodyWithBlock:(void (^)(id <AFMultipartFormData> formData))block
 {
     return [self multipartFormRequestWithMethod:method URLString:URLString parameters:parameters constructingBodyWithBlock:block error:nil];


### PR DESCRIPTION
add UIImage and NSImage support in AFHTTPRequestSerializer.
it can convert Image To NSData with fileName and mimeType.

in  multipartFormRequestWithMethod, UIImage will auto use fileName and mimeType
more convenient than constructingBodyWithBlock.