### PR TITLE
Add NS_DESIGNATED_INITIALIZER for earlier versions of Xcode.

### DIFF
--- a/AFNetworking/AFHTTPRequestOperationManager.h
+++ b/AFNetworking/AFHTTPRequestOperationManager.h
@@ -36,6 +36,14 @@
 #import "AFSecurityPolicy.h"
 #import "AFNetworkReachabilityManager.h"
 
+#ifndef NS_DESIGNATED_INITIALIZER
+#if __has_attribute(objc_designated_initializer)
+#define NS_DESIGNATED_INITIALIZER __attribute__((objc_designated_initializer))
+#else
+#define NS_DESIGNATED_INITIALIZER
+#endif
+#endif
+
 /**
  `AFHTTPRequestOperationManager` encapsulates the common patterns of communicating with a web application over HTTP, including request creation, response serialization, network reachability monitoring, and security, as well as request operation management.
 

--- a/AFNetworking/AFHTTPSessionManager.h
+++ b/AFNetworking/AFHTTPSessionManager.h
@@ -32,6 +32,14 @@
 
 #import "AFURLSessionManager.h"
 
+#ifndef NS_DESIGNATED_INITIALIZER
+#if __has_attribute(objc_designated_initializer)
+#define NS_DESIGNATED_INITIALIZER __attribute__((objc_designated_initializer))
+#else
+#define NS_DESIGNATED_INITIALIZER
+#endif
+#endif
+
 /**
  `AFHTTPSessionManager` is a subclass of `AFURLSessionManager` with convenience methods for making HTTP requests. When a `baseURL` is provided, requests made with the `GET` / `POST` / et al. convenience methods can be made with relative paths.
 

--- a/AFNetworking/AFNetworkReachabilityManager.h
+++ b/AFNetworking/AFNetworkReachabilityManager.h
@@ -23,6 +23,14 @@
 #import <Foundation/Foundation.h>
 #import <SystemConfiguration/SystemConfiguration.h>
 
+#ifndef NS_DESIGNATED_INITIALIZER
+#if __has_attribute(objc_designated_initializer)
+#define NS_DESIGNATED_INITIALIZER __attribute__((objc_designated_initializer))
+#else
+#define NS_DESIGNATED_INITIALIZER
+#endif
+#endif
+
 typedef NS_ENUM(NSInteger, AFNetworkReachabilityStatus) {
     AFNetworkReachabilityStatusUnknown          = -1,
     AFNetworkReachabilityStatusNotReachable     = 0,

--- a/AFNetworking/AFURLConnectionOperation.h
+++ b/AFNetworking/AFURLConnectionOperation.h
@@ -27,6 +27,14 @@
 #import "AFURLResponseSerialization.h"
 #import "AFSecurityPolicy.h"
 
+#ifndef NS_DESIGNATED_INITIALIZER
+#if __has_attribute(objc_designated_initializer)
+#define NS_DESIGNATED_INITIALIZER __attribute__((objc_designated_initializer))
+#else
+#define NS_DESIGNATED_INITIALIZER
+#endif
+#endif
+
 /**
  `AFURLConnectionOperation` is a subclass of `NSOperation` that implements `NSURLConnection` delegate methods.
 

--- a/AFNetworking/AFURLSessionManager.h
+++ b/AFNetworking/AFURLSessionManager.h
@@ -27,6 +27,14 @@
 #import "AFSecurityPolicy.h"
 #import "AFNetworkReachabilityManager.h"
 
+#ifndef NS_DESIGNATED_INITIALIZER
+#if __has_attribute(objc_designated_initializer)
+#define NS_DESIGNATED_INITIALIZER __attribute__((objc_designated_initializer))
+#else
+#define NS_DESIGNATED_INITIALIZER
+#endif
+#endif
+
 /**
  `AFURLSessionManager` creates and manages an `NSURLSession` object based on a specified `NSURLSessionConfiguration` object, which conforms to `<NSURLSessionTaskDelegate>`, `<NSURLSessionDataDelegate>`, `<NSURLSessionDownloadDelegate>`, and `<NSURLSessionDelegate>`.
 


### PR DESCRIPTION
`NS_DESIGNATED_INITIALIZER` is not included in Xcode 5. Since AFNetworking doesn't have a common #import for all headers, I just inserted a definition for it into each file that uses it. A common header would be better, of course!

I'm submitting this primarily so that people using Xcode 5 can check it. I'm not anymore. You might want to add a common header instead, or even drop support for Xcode 5. Whatever. :) Something _like_ this is necessary if Xcode 5 compatibility is to be maintained.

See: http://stackoverflow.com/questions/24119896/ns-designated-initializer-expected-colon and issue #2555.