### PR TITLE
Fix AFNetworkActivityIndicatorManager for iOS 7...dubiously

### DIFF
--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -272,19 +272,27 @@ static inline void af_swizzleSelector(Class class, SEL originalSelector, SEL swi
     }
 }
 
+static inline void af_addMethod(Class class, SEL selector, Method method) {
+    class_addMethod(class, @selector(af_resume),  method_getImplementation(method),  method_getTypeEncoding(method));
+}
+
 static NSString * const AFNSURLSessionTaskDidResumeNotification  = @"com.alamofire.networking.nsurlsessiontask.resume";
 static NSString * const AFNSURLSessionTaskDidSuspendNotification = @"com.alamofire.networking.nsurlsessiontask.suspend";
 
-@interface NSURLSessionTask (_AFStateObserving)
+@interface NSURLSessionDataTask (_AFStateObserving)
 @end
 
-@implementation NSURLSessionTask (_AFStateObserving)
+@implementation NSURLSessionDataTask (_AFStateObserving)
 
 + (void)load {
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        af_swizzleSelector([self class], @selector(resume), @selector(af_resume));
-        af_swizzleSelector([self class], @selector(suspend), @selector(af_suspend));
+        NSURLSessionDataTask *dataTask = [[NSURLSession sessionWithConfiguration:nil] dataTaskWithURL:nil];
+        Class taskClass = [dataTask superclass];
+        af_addMethod(taskClass, @selector(af_resume),  class_getInstanceMethod(self, @selector(af_resume)));
+        af_addMethod(taskClass, @selector(af_suspend), class_getInstanceMethod(self, @selector(af_suspend)));
+        af_swizzleSelector(taskClass, @selector(resume), @selector(af_resume));
+        af_swizzleSelector(taskClass, @selector(suspend), @selector(af_suspend));
     });
 }
 
@@ -402,7 +410,7 @@ static NSString * const AFNSURLSessionTaskDidSuspendNotification = @"com.alamofi
 
 - (void)taskDidResume:(NSNotification *)notification {
     NSURLSessionTask *task = notification.object;
-    if ([task isKindOfClass:[NSURLSessionTask class]]) {
+    if ([task respondsToSelector:@selector(taskDescription)]) {
         if ([task.taskDescription isEqualToString:self.taskDescriptionForSessionTasks]) {
             dispatch_async(dispatch_get_main_queue(), ^{
                 [[NSNotificationCenter defaultCenter] postNotificationName:AFNetworkingTaskDidResumeNotification object:task];
@@ -413,7 +421,7 @@ static NSString * const AFNSURLSessionTaskDidSuspendNotification = @"com.alamofi
 
 - (void)taskDidSuspend:(NSNotification *)notification {
     NSURLSessionTask *task = notification.object;
-    if ([task isKindOfClass:[NSURLSessionTask class]]) {
+    if ([task respondsToSelector:@selector(taskDescription)]) {
         if ([task.taskDescription isEqualToString:self.taskDescriptionForSessionTasks]) {
             dispatch_async(dispatch_get_main_queue(), ^{
                 [[NSNotificationCenter defaultCenter] postNotificationName:AFNetworkingTaskDidSuspendNotification object:task];


### PR DESCRIPTION
This is a re-opening of #2459, as requested by @mattt [here](https://github.com/AFNetworking/AFNetworking/pull/2459#issuecomment-74393321).

----

The AFNetworkActivityIndicatorManager is broken for iOS 7, as of #2411. (See #2458.)

This swizzle-fix for #1477 used to assume that all `NSURLSessionTask` instances had a superclass named `NSURLSessionTask`. Unfortunately, that is not true on iOS 7 devices.

We still need to somehow swizzle a superclass of all `NSURLSessionTask`s, though. On iOS 7, one of those superclasses is `__NSCFLocalSessionTask`, which is `NSURLSessionDataTask`'s superclass. This is a way to do it without explicitly mentioning or calling any private API.

However, it does end up adding and swizzling methods on `__NSCFLocalSessionTask`. Is this legal? I hope so, but ultimately, I don't know.