### PR TITLE
Move details of XML and JSON parsing into separate virtual methods

### DIFF
--- a/AFNetworking/AFURLResponseSerialization.h
+++ b/AFNetworking/AFURLResponseSerialization.h
@@ -132,6 +132,16 @@
  */
 + (instancetype)serializerWithReadingOptions:(NSJSONReadingOptions)readingOptions;
 
+/**
+ Virtual method that provides the opportunity to replace the default JSON Parser
+ 
+ @param data The binary data to parse as JSON.
+ @param error An error object
+ */
+
+-(id)generateJSONResponseObject:(NSData *)data error:(NSError *__autoreleasing *)serializationError;
+
+
 @end
 
 #pragma mark -
@@ -146,6 +156,13 @@
  */
 @interface AFXMLParserResponseSerializer : AFHTTPResponseSerializer
 
+/**
+ Virtual method that provides the opportunity to replace the default JSON Parser
+ 
+ @param data The binary data parse as XML.
+ */
+
+-(id)generateXMLResponseObject:(NSData *)data;
 @end
 
 #pragma mark -

--- a/AFNetworking/AFURLResponseSerialization.m
+++ b/AFNetworking/AFURLResponseSerialization.m
@@ -258,7 +258,7 @@ static id AFJSONObjectByRemovingKeysWithNullValues(id JSONObject, NSJSONReadingO
 
             if (data) {
                 if ([data length] > 0) {
-                    responseObject = [NSJSONSerialization JSONObjectWithData:data options:self.readingOptions error:&serializationError];
+                    responseObject = [self generateJSONResponseObject:data error:&serializationError];
                 } else {
                     return nil;
                 }
@@ -282,6 +282,12 @@ static id AFJSONObjectByRemovingKeysWithNullValues(id JSONObject, NSJSONReadingO
     }
 
     return responseObject;
+}
+
+-(id)generateJSONResponseObject:(NSData *)data
+                          error:(NSError *__autoreleasing *)serializationError
+{
+     return [NSJSONSerialization JSONObjectWithData:data options:self.readingOptions error:serializationError];
 }
 
 #pragma mark - NSSecureCoding
@@ -350,8 +356,15 @@ static id AFJSONObjectByRemovingKeysWithNullValues(id JSONObject, NSJSONReadingO
         }
     }
 
+    return [self generateXMLResponseObject:data];
+}
+
+
+-(id)generateXMLResponseObject:(NSData *)data
+{
     return [[NSXMLParser alloc] initWithData:data];
 }
+
 
 @end
 


### PR DESCRIPTION
It is not possible today to inherit from AFJSONResponseSerializer and to
easily replace the JSON parser with something else (i.e. SwiftyJSON). This
PR moves the details of XML and JSON parsing (i.e. the exact class) into
separate methods that can be overloaded so that the actual JSON parsing
can be done with another library.