### PR TITLE
Guard for unsupported features of iOS 8 extensions

### DIFF
--- a/UIKit+AFNetworking/AFNetworkActivityIndicatorManager.m
+++ b/UIKit+AFNetworking/AFNetworkActivityIndicatorManager.m
@@ -114,7 +114,9 @@ static NSURLRequest * AFNetworkRequestFromNotification(NSNotification *notificat
 }
 
 - (void)updateNetworkActivityIndicatorVisibility {
+#if !defined(AF_APP_EXTENSIONS)
     [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:[self isNetworkActivityIndicatorVisible]];
+#endif
 }
 
 - (void)setActivityCount:(NSInteger)activityCount {

--- a/UIKit+AFNetworking/UIAlertView+AFNetworking.h
+++ b/UIKit+AFNetworking/UIAlertView+AFNetworking.h
@@ -24,7 +24,7 @@
 
 #import <Availability.h>
 
-#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
+#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && !defined(AF_APP_EXTENSIONS)
 
 #import <UIKit/UIKit.h>
 

--- a/UIKit+AFNetworking/UIAlertView+AFNetworking.m
+++ b/UIKit+AFNetworking/UIAlertView+AFNetworking.m
@@ -22,7 +22,7 @@
 
 #import "UIAlertView+AFNetworking.h"
 
-#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
+#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && !defined(AF_APP_EXTENSIONS)
 
 #import "AFURLConnectionOperation.h"
 


### PR DESCRIPTION
See Issue #2119.

It seems that a couple of references to unsupported APIs in extensions were missed. I'd really appreciate a fix because I can't properly build my extension at the moment.

Credit goes to @jpmhouston.