### PR TITLE
Added test and implementation for self signed cert against AFSSLPinningMo..

### DIFF
--- a/Tests/Tests/AFSecurityPolicyTests.m
+++ b/Tests/Tests/AFSecurityPolicyTests.m
@@ -514,10 +514,17 @@ static SecTrustRef AFUTTrustWithCertificate(SecCertificateRef certificate) {
     XCTAssert(policy.SSLPinningMode==AFSSLPinningModeNone, @"Default policy is not set to AFSSLPinningModePublicKey.");
 }
 
-- (void)testDefaultPolicyIsSetToNotAllowInvalidSSLCertificates {
-    AFSecurityPolicy *policy = [AFSecurityPolicy defaultPolicy];
+- (void)testDefaultPolicySetToNoneValidatesDomainFailsWithBadCertificate {
+    AFSecurityPolicy *policy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModeNone];
+    SecTrustRef trust = AFUTTrustWithCertificate(AFUTSelfSignedCertificateWithoutDomain());
+    XCTAssert([policy evaluateServerTrust:trust forDomain:nil] == NO, @"Unmatched certificate and pinning mode None should fail");
+    CFRelease(trust);
+}
 
-    XCTAssert(policy.allowInvalidCertificates == NO, @"Default policy should not allow invalid ssl certificates");
+- (void)testDefaultPolicyIsSetToAFSSLPinningModeNone {
+    AFSecurityPolicy *policy = [AFSecurityPolicy defaultPolicy];
+    
+    XCTAssert(policy.SSLPinningMode==AFSSLPinningModeNone, @"Default policy is not set to AFSSLPinningModeNone.");
 }
 
 - (void)testPolicyWithPinningModeIsSetToNotAllowInvalidSSLCertificates {


### PR DESCRIPTION
deNone

This change updates against a change made in 2.5.1 (from 2.5.0) which significantly changed the default behaviour to act much less securely than the previous implementation. Without this change it is trivial to perform MITM attacks on users running apps utilising this library (e.g. any coffee shop in the world could read everybody’s private messages).

This fixes #2590 and also seems to answer very sensible concerns raised in:
#2560
#2549
#2527
