### PR TITLE
Fix AFImageWithDataAtScale destroying animation images

### DIFF
--- a/AFNetworking/AFURLResponseSerialization.m
+++ b/AFNetworking/AFURLResponseSerialization.m
@@ -533,6 +533,11 @@ static id AFJSONObjectByRemovingKeysWithNullValues(id JSONObject, NSJSONReadingO
 static UIImage * AFImageWithDataAtScale(NSData *data, CGFloat scale) {
     UIImage *image = [[UIImage alloc] initWithData:data];
 
+    // initWithCGImage will destroy animated images
+    if (image.images) {
+        return image;
+    }
+    
     return [[UIImage alloc] initWithCGImage:[image CGImage] scale:scale orientation:image.imageOrientation];
 }
 


### PR DESCRIPTION
AFImageWithDataAtScale destroys animated UIImages because initWithCGImage only uses the first frame.  This patch fixes the issue, though perhaps there is some way to scale each individual frame which would could be a huge CPU/mem drag. 