### PR TITLE
Added test and implementation for self signed cert against default secur...

### DIFF
--- a/AFNetworking/AFSecurityPolicy.m
+++ b/AFNetworking/AFSecurityPolicy.m
@@ -254,14 +254,21 @@ static NSArray * AFPublicKeyTrustChainForServerTrust(SecTrustRef serverTrust) {
 
     SecTrustSetPolicies(serverTrust, (__bridge CFArrayRef)policies);
 
-    if (self.SSLPinningMode != AFSSLPinningModeNone && !AFServerTrustIsValid(serverTrust) && !self.allowInvalidCertificates) {
+    if(self.SSLPinningMode == AFSSLPinningModeNone) {
+        if(self.allowInvalidCertificates || AFServerTrustIsValid(serverTrust)){
+            return YES;
+        } else {
+            return NO;
+        }
+    } else if(!AFServerTrustIsValid(serverTrust) && !self.allowInvalidCertificates) {
         return NO;
     }
-
+    
     NSArray *serverCertificates = AFCertificateTrustChainForServerTrust(serverTrust);
     switch (self.SSLPinningMode) {
         case AFSSLPinningModeNone:
-            return YES;
+        default:
+            return NO;
         case AFSSLPinningModeCertificate: {
             NSMutableArray *pinnedCertificates = [NSMutableArray array];
             for (NSData *certificateData in self.pinnedCertificates) {

--- a/Tests/Tests/AFSecurityPolicyTests.m
+++ b/Tests/Tests/AFSecurityPolicyTests.m
@@ -508,10 +508,17 @@ static SecTrustRef AFUTTrustWithCertificate(SecCertificateRef certificate) {
     CFRelease(trust);
 }
 
-- (void)testDefaultPolicyIsSetToAFSSLPinningModePublicKey {
+- (void)testDefaultPolicyIsSetToAFSSLPinningModeNone {
     AFSecurityPolicy *policy = [AFSecurityPolicy defaultPolicy];
 
-    XCTAssert(policy.SSLPinningMode==AFSSLPinningModeNone, @"Default policy is not set to AFSSLPinningModePublicKey.");
+    XCTAssert(policy.SSLPinningMode==AFSSLPinningModeNone, @"Default policy is not set to AFSSLPinningModeNone.");
+}
+
+- (void)testDefaultPolicyFailsToEvaluateServerTrustFromSelfSignedCertificate {
+    AFSecurityPolicy *policy = [AFSecurityPolicy defaultPolicy];
+    SecTrustRef trust = AFUTTrustWithCertificate(AFUTSelfSignedCertificateWithoutDomain());
+    XCTAssert([policy evaluateServerTrust:trust forDomain:nil] == NO, @"Unmatched certificate and pinning mode None should fail");
+    CFRelease(trust);
 }
 
 - (void)testDefaultPolicyIsSetToNotAllowInvalidSSLCertificates {


### PR DESCRIPTION
...ity

This change updates against a change made in 2.5.1 (from 2.5.0) which significantly changed the default behaviour to act much less securely than the previous implementation. Without this change it is trivial to perform MITM attacks on users running apps utilising this library (e.g. any coffee shop in the world could read everybody’s private messages).

This fixes #2590 and also seems to answer very sensible concerns raised in:
#2560
#2549
#2527