### PR TITLE
Added a NSError category with convenience methods for AFNetworking

### DIFF
--- a/AFNetworking.podspec
+++ b/AFNetworking.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.source_files = 'AFNetworking/AFNetworking.h'
 
   s.subspec 'Serialization' do |ss|
-    ss.source_files = 'AFNetworking/AFURL{Request,Response}Serialization.{h,m}'
+    ss.source_files = 'AFNetworking/AFURL{Request,Response}Serialization.{h,m}', 'AFNetworking/NSError+AFNetworking.{h,m}'
     ss.ios.frameworks = 'MobileCoreServices', 'CoreGraphics'
     ss.osx.frameworks = 'CoreServices'
   end

--- a/AFNetworking.xcworkspace/contents.xcworkspacedata
+++ b/AFNetworking.xcworkspace/contents.xcworkspacedata
@@ -7,6 +7,12 @@
       <FileRef
          location = "group:AFNetworking.h">
       </FileRef>
+      <FileRef
+         location = "group:NSError+AFNetworking.h">
+      </FileRef>
+      <FileRef
+         location = "group:NSError+AFNetworking.m">
+      </FileRef>
       <Group
          location = "container:"
          name = "NSURLConnection">

--- a/AFNetworking/NSError+AFNetworking.h
+++ b/AFNetworking/NSError+AFNetworking.h
@@ -1,17 +1,17 @@
-// AFNetworking.h
+// NSError+AFNetworking.h
 //
-// Copyright (c) 2013 AFNetworking (http://afnetworking.com/)
-// 
+// Copyright (c) 2013-2015 AFNetworking (http://afnetworking.com)
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -21,26 +21,19 @@
 // THE SOFTWARE.
 
 #import <Foundation/Foundation.h>
-#import <Availability.h>
 
-#ifndef _AFNETWORKING_
-    #define _AFNETWORKING_
+@interface NSError (AFNetworking)
 
-    #import "AFURLRequestSerialization.h"
-    #import "AFURLResponseSerialization.h"
-    #import "AFSecurityPolicy.h"
-    #import "AFNetworkReachabilityManager.h"
+/*!
+ *  HTTP Status Code that was returned from network
+ */
+@property (nonatomic, readonly) NSInteger networkStatusCode;
 
-    #import "NSError+AFNetworking.h"
+@property (nonatomic, readonly) NSData *responseData;
+@property (nonatomic, readonly) NSString *responseString;
+@property (nonatomic, readonly) NSString *requestURL;
 
-    #import "AFURLConnectionOperation.h"
-    #import "AFHTTPRequestOperation.h"
-    #import "AFHTTPRequestOperationManager.h"
+@property (nonatomic, readonly) NSURLResponse *response;
+@property (nonatomic, readonly) NSURLRequest *request;
 
-#if ( ( defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && __MAC_OS_X_VERSION_MAX_ALLOWED >= 1090) || \
-      ( defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 70000 ) )
-    #import "AFURLSessionManager.h"
-    #import "AFHTTPSessionManager.h"
-#endif
-
-#endif /* _AFNETWORKING_ */
+@end

--- a/AFNetworking/NSError+AFNetworking.m
+++ b/AFNetworking/NSError+AFNetworking.m
@@ -1,0 +1,96 @@
+// NSError+AFNetworking.m
+//
+// Copyright (c) 2013-2015 AFNetworking (http://afnetworking.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "NSError+AFNetworking.h"
+#import "AFURLRequestSerialization.h"
+
+@implementation NSError (AFNetworking)
+
+- (NSInteger)networkStatusCode
+{
+    NSURLResponse* response = [self response];
+    
+    if ([response isKindOfClass:[NSHTTPURLResponse class]])
+    {
+        NSHTTPURLResponse* urlResponse = (NSHTTPURLResponse *)response;
+        
+        return urlResponse.statusCode;
+    }
+    
+    return 0;
+}
+
+- (NSURLRequest *)request
+{
+    return [self objectInUserInfo:AFNetworkingOperationFailingURLRequestErrorKey withError:self];
+}
+
+- (NSURLResponse *)response
+{
+    return [self objectInUserInfo:AFNetworkingOperationFailingURLResponseErrorKey withError:self];
+}
+
+- (NSData *)responseData
+{
+    return [self objectInUserInfo:AFNetworkingOperationFailingURLResponseDataErrorKey withError:self];
+}
+
+- (NSString *)responseString
+{
+    return [[NSString alloc] initWithData:[self objectInUserInfo:AFNetworkingOperationFailingURLResponseDataErrorKey withError:self] encoding:NSUTF8StringEncoding];
+}
+
+- (NSString *)requestURL
+{
+    NSURLResponse* response = [self response];
+    
+    if ([response isKindOfClass:[NSHTTPURLResponse class]])
+    {
+        NSHTTPURLResponse* urlResponse = (NSHTTPURLResponse *)response;
+        
+        return urlResponse.URL.absoluteString;
+    }
+    else
+    {
+        return (self.originalError.userInfo[NSURLErrorFailingURLStringErrorKey]) ? self.originalError.userInfo[NSURLErrorFailingURLStringErrorKey] : nil;
+    }
+}
+
+#pragma mark - Helpers
+
+- (id)objectInUserInfo:(NSString *)key withError:(NSError *)error
+{
+    if (error.userInfo[key])
+    {
+        return error.userInfo[key];
+    }
+    
+    //
+    // Check for underlying error
+    //
+    
+    NSError* underlyingError = error.userInfo[NSUnderlyingErrorKey];
+    
+    return (underlyingError.userInfo[key]) ? underlyingError.userInfo[key] : nil;
+}
+
+@end

--- a/AFNetworking/NSError+AFNetworking.m
+++ b/AFNetworking/NSError+AFNetworking.m
@@ -72,7 +72,7 @@
     }
     else
     {
-        return (self.originalError.userInfo[NSURLErrorFailingURLStringErrorKey]) ? self.originalError.userInfo[NSURLErrorFailingURLStringErrorKey] : nil;
+        return (self.userInfo[NSURLErrorFailingURLStringErrorKey]) ? self.userInfo[NSURLErrorFailingURLStringErrorKey] : nil;
     }
 }
 

--- a/AFNetworking/NSError+AFNetworking.m
+++ b/AFNetworking/NSError+AFNetworking.m
@@ -22,6 +22,7 @@
 
 #import "NSError+AFNetworking.h"
 #import "AFURLRequestSerialization.h"
+#import "AFURLResponseSerialization.h"
 
 @implementation NSError (AFNetworking)
 


### PR DESCRIPTION
To make extracting information from `NSError` generated by `AFNetworking` much easier, a category was added to `NSError` that contains multiple convenience methods for data retrieval.