### PR TITLE
Fix canceling an operation not causing isFinished to return true

### DIFF
--- a/AFNetworking/AFURLConnectionOperation.m
+++ b/AFNetworking/AFURLConnectionOperation.m
@@ -486,6 +486,7 @@ static inline BOOL AFStateTransitionIsValid(AFOperationState fromState, AFOperat
 
 - (void)cancel {
     [self.lock lock];
+    self.state = AFOperationFinishedState;
     if (![self isFinished] && ![self isCancelled]) {
         [super cancel];
 


### PR DESCRIPTION
Search throttling was behaving strange in an app I'm working on. I later found out that this was because in my network data fetching method I was checking if there was an ongoing request by doing `fetchRequest?.finished == false`. However I later found out that when I called my method after calling `fetchRequest?.cancel()` it was still thinking there was an ongoing request because fetchRequest?.finished was equal to false. So I changed my check to `fetchRequest?.finished == false && fetchRequest?.cancelled == false` and it works now.

However, Apple's documentation of NSOperation clearly states:

"In addition to simply exiting when an operation is cancelled, it is also important that you move a cancelled operation to the appropriate final state. Specifically, if you manage the values for the finished and executing properties yourself (perhaps because you are implementing a concurrent operation), you must update those properties accordingly. Specifically, you must change the value returned by finished to YES and the value returned by executing to NO. You must make these changes even if the operation was cancelled before it started executing."