### PR TITLE
Bugfix: Incorrect ordering of reachability states (#2618)

### DIFF
--- a/AFNetworking/AFNetworkReachabilityManager.m
+++ b/AFNetworking/AFNetworkReachabilityManager.m
@@ -194,17 +194,16 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {
     SCNetworkReachabilitySetCallback(self.networkReachability, AFNetworkReachabilityCallback, &context);
     SCNetworkReachabilityScheduleWithRunLoop(self.networkReachability, CFRunLoopGetMain(), kCFRunLoopCommonModes);
 
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0),^{
+    dispatch_async(dispatch_get_main_queue(), ^{
         SCNetworkReachabilityFlags flags;
         SCNetworkReachabilityGetFlags(self.networkReachability, &flags);
         AFNetworkReachabilityStatus status = AFNetworkReachabilityStatusForFlags(flags);
-        dispatch_async(dispatch_get_main_queue(), ^{
-            callback(status);
 
-            NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
-            NSDictionary *userInfo = @{ AFNetworkingReachabilityNotificationStatusItem: @(status) };
-            [notificationCenter postNotificationName:AFNetworkingReachabilityDidChangeNotification object:nil userInfo:userInfo];
-        });
+        callback(status);
+
+        NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
+        NSDictionary *userInfo = @{ AFNetworkingReachabilityNotificationStatusItem: @(status) };
+        [notificationCenter postNotificationName:AFNetworkingReachabilityDidChangeNotification object:nil userInfo:userInfo];
     });
 }
 

--- a/AFNetworking/AFNetworkReachabilityManager.m
+++ b/AFNetworking/AFNetworkReachabilityManager.m
@@ -77,13 +77,9 @@ static void AFNetworkReachabilityCallback(SCNetworkReachabilityRef __unused targ
         block(status);
     }
 
-
-    dispatch_async(dispatch_get_main_queue(), ^{
-        NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
-        NSDictionary *userInfo = @{ AFNetworkingReachabilityNotificationStatusItem: @(status) };
-        [notificationCenter postNotificationName:AFNetworkingReachabilityDidChangeNotification object:nil userInfo:userInfo];
-    });
-
+    NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
+    NSDictionary *userInfo = @{ AFNetworkingReachabilityNotificationStatusItem: @(status) };
+    [notificationCenter postNotificationName:AFNetworkingReachabilityDidChangeNotification object:nil userInfo:userInfo];
 }
 
 static const void * AFNetworkReachabilityRetainCallback(const void *info) {

--- a/AFNetworking/AFNetworkReachabilityManager.m
+++ b/AFNetworking/AFNetworkReachabilityManager.m
@@ -195,15 +195,17 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {
     SCNetworkReachabilityScheduleWithRunLoop(self.networkReachability, CFRunLoopGetMain(), kCFRunLoopCommonModes);
 
     dispatch_async(dispatch_get_main_queue(), ^{
-        SCNetworkReachabilityFlags flags;
-        SCNetworkReachabilityGetFlags(self.networkReachability, &flags);
-        AFNetworkReachabilityStatus status = AFNetworkReachabilityStatusForFlags(flags);
+        if (self.networkReachabilityStatus == AFNetworkReachabilityStatusUnknown) {
+            SCNetworkReachabilityFlags flags;
+            SCNetworkReachabilityGetFlags(self.networkReachability, &flags);
+            AFNetworkReachabilityStatus status = AFNetworkReachabilityStatusForFlags(flags);
 
-        callback(status);
+            callback(status);
 
-        NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
-        NSDictionary *userInfo = @{ AFNetworkingReachabilityNotificationStatusItem: @(status) };
-        [notificationCenter postNotificationName:AFNetworkingReachabilityDidChangeNotification object:nil userInfo:userInfo];
+            NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
+            NSDictionary *userInfo = @{ AFNetworkingReachabilityNotificationStatusItem: @(status) };
+            [notificationCenter postNotificationName:AFNetworkingReachabilityDidChangeNotification object:nil userInfo:userInfo];
+        }
     });
 }
 


### PR DESCRIPTION
This fixes a reachability regression in 2.5.2 #2618

The background queue usage in the initial reachability status check was causing the reachability states to be reported out of order.  The hop onto the background queue caused the first value checked (0) to be reported after the runloop checked value (2).

I'm not sure how ok you are with things changing, so I made 3 commits for each change I think should be made. Pick the ones you want, I tested that 1 resolves the issue, 2 should also guard against the issue, and 3 is a small cleanup.

1) Remove the background queue for the initial check. There's no valid reason to use a background thread here, since all reporting and probing of reachability occurs on the main thread.
2) Check `networkReachabilityStatus` in the initial check and only trigger if it's `AFNetworkReachabilityStatusUnknown`.
3) Remove the `dispatch_async` call in `AFNetworkReachabilityCallback`. The callback and the notification were not split up across operations anywhere else, and it's purpose was not clear. This doesn't fix the bug, or really matter, but it confused me.

Thanks!

Brian