### PR TITLE
Added a configuration property in AFSecurityPolicy that allows to skip a...

### DIFF
--- a/AFNetworking/AFSecurityPolicy.h
+++ b/AFNetworking/AFSecurityPolicy.h
@@ -47,6 +47,11 @@ typedef NS_ENUM(NSUInteger, AFSSLPinningMode) {
 @property (nonatomic, assign) BOOL validatesCertificateChain;
 
 /**
+ Number of certificates that will not be verified in the certificate chain, starting from the leaf certificate. Defaults to `0`.
+ */
+@property (nonatomic, assign) NSUInteger skipLeafCertificates;
+
+/**
  The certificates used to evaluate server trust according to the SSL pinning mode. By default, this property is set to any (`.cer`) certificates included in the app bundle.
  */
 @property (nonatomic, strong) NSArray *pinnedCertificates;

--- a/AFNetworking/AFSecurityPolicy.m
+++ b/AFNetworking/AFSecurityPolicy.m
@@ -199,6 +199,7 @@ static NSArray * AFPublicKeyTrustChainForServerTrust(SecTrustRef serverTrust) {
 
     self.validatesCertificateChain = YES;
     self.validatesDomainName = YES;
+    self.skipLeafCertificates = 0;
 
     return self;
 }
@@ -269,8 +270,9 @@ static NSArray * AFPublicKeyTrustChainForServerTrust(SecTrustRef serverTrust) {
                 return YES;
             }
 
-            NSUInteger trustedCertificateCount = 0;
-            for (NSData *trustChainCertificate in serverCertificates) {
+            NSUInteger trustedCertificateCount = self.skipLeafCertificates;
+            for (NSUInteger idx = self.skipLeafCertificates; idx < serverCertificates.count; idx++) {
+                NSData *trustChainCertificate * serverCertificates[idx];
                 if ([self.pinnedCertificates containsObject:trustChainCertificate]) {
                     trustedCertificateCount++;
                 }


### PR DESCRIPTION
In our own project, we wanted to use pinned certificates, but we wanted, too, to have the flexibility to update the leaf certificate without the need of publishing a new ios app with the new certificate. So we wanted to verify all the certificates in the certificate chain without validating the last one (the leaf).

The modification I did allows to skip the verification of some certificates in the certificate chain, starting from the leaf.

I hope that this can be helpful for someone else.

Best regards,

Ivan Oliver