### PR TITLE
fix for broken test

### DIFF
--- a/Tests/AFNetworking Tests.xcodeproj/project.pbxproj
+++ b/Tests/AFNetworking Tests.xcodeproj/project.pbxproj
@@ -54,6 +54,8 @@
 		CBBDB16D1A798AB500D412EE /* COMODO_RSA_Certification_Authority.cer in Resources */ = {isa = PBXBuildFile; fileRef = CBBDB1681A798AB500D412EE /* COMODO_RSA_Certification_Authority.cer */; };
 		CBBDB16E1A798AB500D412EE /* COMODO_RSA_Domain_Validation_Secure_Server_CA.cer in Resources */ = {isa = PBXBuildFile; fileRef = CBBDB1691A798AB500D412EE /* COMODO_RSA_Domain_Validation_Secure_Server_CA.cer */; };
 		CBBDB16F1A798AB500D412EE /* COMODO_RSA_Domain_Validation_Secure_Server_CA.cer in Resources */ = {isa = PBXBuildFile; fileRef = CBBDB1691A798AB500D412EE /* COMODO_RSA_Domain_Validation_Secure_Server_CA.cer */; };
+		DE533FCE1ACCF34200C62CFB /* AFNetworkReachabilityManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DE533FCD1ACCF34200C62CFB /* AFNetworkReachabilityManagerTests.m */; };
+		DE533FCF1ACCF34200C62CFB /* AFNetworkReachabilityManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DE533FCD1ACCF34200C62CFB /* AFNetworkReachabilityManagerTests.m */; };
 		F837FFAF195744A0009078A0 /* AFHTTPResponseSerializationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F837FFAE195744A0009078A0 /* AFHTTPResponseSerializationTests.m */; };
 		F837FFB0195744A0009078A0 /* AFHTTPResponseSerializationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F837FFAE195744A0009078A0 /* AFHTTPResponseSerializationTests.m */; };
 		F87382951948AC15000B7AFA /* AFHTTPSessionManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F87382941948AC15000B7AFA /* AFHTTPSessionManagerTests.m */; };
@@ -120,6 +122,7 @@
 		CBBDB1671A798AB500D412EE /* AddTrust_External_CA_Root.cer */ = {isa = PBXFileReference; lastKnownFileType = file; path = AddTrust_External_CA_Root.cer; sourceTree = "<group>"; };
 		CBBDB1681A798AB500D412EE /* COMODO_RSA_Certification_Authority.cer */ = {isa = PBXFileReference; lastKnownFileType = file; path = COMODO_RSA_Certification_Authority.cer; sourceTree = "<group>"; };
 		CBBDB1691A798AB500D412EE /* COMODO_RSA_Domain_Validation_Secure_Server_CA.cer */ = {isa = PBXFileReference; lastKnownFileType = file; path = COMODO_RSA_Domain_Validation_Secure_Server_CA.cer; sourceTree = "<group>"; };
+		DE533FCD1ACCF34200C62CFB /* AFNetworkReachabilityManagerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFNetworkReachabilityManagerTests.m; sourceTree = "<group>"; };
 		F837FFAE195744A0009078A0 /* AFHTTPResponseSerializationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFHTTPResponseSerializationTests.m; sourceTree = "<group>"; };
 		F87382941948AC15000B7AFA /* AFHTTPSessionManagerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFHTTPSessionManagerTests.m; sourceTree = "<group>"; };
 		F8C6F281174D2C6200B154D5 /* Icon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = Icon.png; path = ../Example/Icon.png; sourceTree = "<group>"; };
@@ -268,6 +271,7 @@
 				29CBFC5917DF61B30021AB75 /* AFSecurityPolicyTests.m */,
 				B6774DC818FBB49E0044DB17 /* AFNetworkActivityManagerTests.m */,
 				943B1F40192E406C00304316 /* AFURLSessionManagerTests.m */,
+				DE533FCD1ACCF34200C62CFB /* AFNetworkReachabilityManagerTests.m */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -527,6 +531,7 @@
 				29CBFC5A17DF61B30021AB75 /* AFSecurityPolicyTests.m in Sources */,
 				29CBFC3F17DF58000021AB75 /* AFHTTPRequestSerializationTests.m in Sources */,
 				B6774DC918FBB49E0044DB17 /* AFNetworkActivityManagerTests.m in Sources */,
+				DE533FCE1ACCF34200C62CFB /* AFNetworkReachabilityManagerTests.m in Sources */,
 				29CBFC3C17DF541F0021AB75 /* AFJSONSerializationTests.m in Sources */,
 				77D65EBC1848A03C004CA024 /* AFPropertyListResponseSerializerTests.m in Sources */,
 				2902D29C17DF4E3700C81C5A /* AFTestCase.m in Sources */,
@@ -544,6 +549,7 @@
 				29CBFC4017DF58000021AB75 /* AFHTTPRequestSerializationTests.m in Sources */,
 				29CBFC3D17DF541F0021AB75 /* AFJSONSerializationTests.m in Sources */,
 				77D65EBD1848A03C004CA024 /* AFPropertyListResponseSerializerTests.m in Sources */,
+				DE533FCF1ACCF34200C62CFB /* AFNetworkReachabilityManagerTests.m in Sources */,
 				2902D29D17DF4E3800C81C5A /* AFTestCase.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Tests/Tests/AFNetworkReachabilityManagerTests.m
+++ b/Tests/Tests/AFNetworkReachabilityManagerTests.m
@@ -1,0 +1,110 @@
+// AFNetworkReachabilityManagerTests.h
+//
+// Copyright (c) 2013-2015 AFNetworking (http://afnetworking.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "AFTestCase.h"
+
+#import "AFNetworkReachabilityManager.h"
+
+@interface AFNetworkReachabilityManagerTests : AFTestCase
+@property (nonatomic, strong) AFNetworkReachabilityManager *networkReachability;
+@property (nonatomic, strong) AFNetworkReachabilityManager *localhostReachability;
+@end
+
+@implementation AFNetworkReachabilityManagerTests
+
+- (void)setUp {
+    [super setUp];
+    
+    //both of these manager objects should always be reachable when the tests are run
+    self.networkReachability = [AFNetworkReachabilityManager sharedManager];
+    self.localhostReachability = [AFNetworkReachabilityManager managerForDomain:@"localhost"];
+}
+
+- (void)testNetworkReachabilityStartsInUnknownState {
+    XCTAssertEqual(self.networkReachability.networkReachabilityStatus, AFNetworkReachabilityStatusUnknown,
+                   @"Reachability should start in an unknown state");
+}
+
+- (void)testLocalhostReachabilityStartsInUnknownState {
+    XCTAssertEqual(self.localhostReachability.networkReachabilityStatus, AFNetworkReachabilityStatusUnknown,
+                   @"Reachability should start in an unknown state");
+}
+
+- (void)verifyReachabilityNotificationWithManager:(AFNetworkReachabilityManager *)reachability {
+    [self
+     expectationForNotification:AFNetworkingReachabilityDidChangeNotification
+                              object:nil
+                             handler:^BOOL(NSNotification *notification) {
+                                 AFNetworkReachabilityStatus status;
+                                 status = [notification.userInfo[AFNetworkingReachabilityNotificationStatusItem] integerValue];
+                                 XCTAssert(reachability.isReachable,
+                                           @"Expected network to be reachable but got '%@'",
+                                           AFStringFromNetworkReachabilityStatus(status));
+                                 
+                                 return YES;
+                             }];
+    
+    [reachability startMonitoring];
+    
+    [self waitForExpectationsWithTimeout:10 handler:nil];
+}
+
+- (void)testNetworkReachabilityNotification {
+    [self verifyReachabilityNotificationWithManager:self.networkReachability];
+}
+
+- (void)testLocalhostReachabilityNotification {
+    [self verifyReachabilityNotificationWithManager:self.localhostReachability];
+}
+
+//- (void)testNetworkReachability {
+//    XCTAssertFalse(reachability.isReachable);
+//
+//    [self expectationForNotification:AFNetworkingReachabilityDidChangeNotification
+//                              object:nil
+//                             handler:^BOOL(NSNotification *notification) {
+//                                 AFNetworkReachabilityStatus status;
+//                                 status = [notification.userInfo[AFNetworkingReachabilityNotificationStatusItem] integerValue];
+//                                 NSLog(@"%@", AFStringFromNetworkReachabilityStatus(status));
+//                                 
+//                                 XCTAssert(reachability.isReachable);
+//                                
+//                                 return YES;
+//                             }];
+//    
+//    XCTestExpectation *expectation = [self expectationWithDescription:@""];
+//    
+//    [reachability setReachabilityStatusChangeBlock:^(AFNetworkReachabilityStatus status) {
+//        NSLog(@"%@", AFStringFromNetworkReachabilityStatus(status));
+//        
+//        BOOL reachable = (status == AFNetworkReachabilityStatusReachableViaWiFi
+//                          || status == AFNetworkReachabilityStatusReachableViaWWAN);
+//        XCTAssert(reachable);
+//        [expectation fulfill];
+//    }];
+//    
+//    [reachability startMonitoring];
+//    
+//    [self waitForExpectationsWithTimeout:10 handler:nil];
+//}
+
+@end

--- a/Tests/Tests/AFSecurityPolicyTests.m
+++ b/Tests/Tests/AFSecurityPolicyTests.m
@@ -536,7 +536,7 @@ static SecTrustRef AFUTTrustWithCertificate(SecCertificateRef certificate) {
 - (void)testPolicyWithPinningModeIsSetToValidatesDomainName {
     AFSecurityPolicy *policy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModeNone];
 
-    XCTAssert(policy.validatesDomainName == NO, @"policyWithPinningMode: should not allow invalid ssl certificates by default.");
+    XCTAssert(policy.validatesDomainName == YES, @"policyWithPinningMode: should validate domain names by default.");
 }
 
 - (void)testThatSSLPinningPolicyClassMethodContainsDefaultCertificates{


### PR DESCRIPTION
It appears to be a copy paste error from the test above (
line 533 of `testPolicyWithPinningModeIsSetToNotAllowInvalidSSLCertificates`).