### PR TITLE
Added block for using custom certificate validation

### DIFF
--- a/AFNetworking/AFSecurityPolicy.h
+++ b/AFNetworking/AFSecurityPolicy.h
@@ -23,6 +23,8 @@
 #import <Foundation/Foundation.h>
 #import <Security/Security.h>
 
+typedef BOOL(^AFCertificateChainValidation)(NSArray *serverCertificates);
+
 typedef NS_ENUM(NSUInteger, AFSSLPinningMode) {
     AFSSLPinningModeNone,
     AFSSLPinningModePublicKey,
@@ -45,6 +47,11 @@ typedef NS_ENUM(NSUInteger, AFSSLPinningMode) {
  Whether to evaluate an entire SSL certificate chain, or just the leaf certificate. Defaults to `YES`.
  */
 @property (nonatomic, assign) BOOL validatesCertificateChain;
+
+/**
+ Block that can be used if custom validation of the certificate chain is needed. If not set, normal certificate chain validation is performed.
+ */
+@property (nonatomic, strong) AFCertificateChainValidation certificateChainValidation;
 
 /**
  The certificates used to evaluate server trust according to the SSL pinning mode. By default, this property is set to any (`.cer`) certificates included in the app bundle.

--- a/AFNetworking/AFSecurityPolicy.m
+++ b/AFNetworking/AFSecurityPolicy.m
@@ -265,6 +265,10 @@ static NSArray * AFPublicKeyTrustChainForServerTrust(SecTrustRef serverTrust) {
                 return NO;
             }
 
+            if(self.certificateChainValidation != nil) {
+                return self.certificateChainValidation(serverCertificates);
+            }
+            
             if (!self.validatesCertificateChain) {
                 return YES;
             }

--- a/Tests/Tests/AFSecurityPolicyTests.m
+++ b/Tests/Tests/AFSecurityPolicyTests.m
@@ -550,4 +550,23 @@ static SecTrustRef AFUTTrustWithCertificate(SecCertificateRef certificate) {
     XCTAssertNil(policy.pinnedCertificates, @"Default certificate array should be empty for default policy.");
 }
 
+- (void)testCustomCertificateChainValidation{
+    AFSecurityPolicy *policy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModeCertificate];
+    policy.certificateChainValidation = ^BOOL(NSArray* certificates){
+        return YES;
+    };
+    SecTrustRef trust = AFUTTrustWithCertificate(AFUTAddTrustExternalRootCertificate());
+    XCTAssert([policy evaluateServerTrust:trust forDomain:nil] == YES, @"Custom certificate validation should be able to validate");
+}
+
+- (void)testCustomCertificateChainValidationFails{
+    AFSecurityPolicy *policy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModeCertificate];
+    policy.certificateChainValidation = ^BOOL(NSArray* certificates){
+        return NO;
+    };
+    SecTrustRef trust = AFUTTrustWithCertificate(AFUTAddTrustExternalRootCertificate());
+    XCTAssert([policy evaluateServerTrust:trust forDomain:nil] == NO, @"Custom certificate validation should not validate");
+}
+
+
 @end


### PR DESCRIPTION
We need this feature, as our customer wants to validate the root certificate or the intermediate certificate. As it is now, we can only validate the leaf, or the entire chain.