### PR TITLE
Subspec for App Extension to define AF_APP_EXTENSIONS

### DIFF
--- a/AFNetworking.podspec
+++ b/AFNetworking.podspec
@@ -12,17 +12,8 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '6.0'
   s.osx.deployment_target = '10.8'
 
-  s.default_subspec = 'Core'
-
-  s.subspec 'Core' do |ss|
-    ss.public_header_files = 'AFNetworking/*.h'
-    ss.source_files = 'AFNetworking/AFNetworking.h'
-  end
-
-  s.subspec 'AppExtension' do |ss|
-    ss.dependency 'Core'
-    ss.prefix_header_contents = '#define AF_APP_EXTENSIONS 1'
-  end
+  s.public_header_files = 'AFNetworking/*.h'
+  s.source_files = 'AFNetworking/AFNetworking.h'
 
   s.subspec 'AppExtension' do |ss|
     ss.prefix_header_contents = '#define AF_APP_EXTENSIONS 1'

--- a/AFNetworking.podspec
+++ b/AFNetworking.podspec
@@ -15,6 +15,10 @@ Pod::Spec.new do |s|
   s.public_header_files = 'AFNetworking/*.h'
   s.source_files = 'AFNetworking/AFNetworking.h'
 
+  s.subspec 'AppExtension' do |ss|
+    ss.prefix_header_contents = '#define AF_APP_EXTENSIONS 1'
+  end
+
   s.subspec 'Serialization' do |ss|
     ss.source_files = 'AFNetworking/AFURL{Request,Response}Serialization.{h,m}'
     ss.ios.frameworks = 'MobileCoreServices', 'CoreGraphics'

--- a/AFNetworking.podspec
+++ b/AFNetworking.podspec
@@ -12,8 +12,17 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '6.0'
   s.osx.deployment_target = '10.8'
 
-  s.public_header_files = 'AFNetworking/*.h'
-  s.source_files = 'AFNetworking/AFNetworking.h'
+  s.default_subspec = 'Core'
+
+  s.subspec 'Core' do |ss|
+    ss.public_header_files = 'AFNetworking/*.h'
+    ss.source_files = 'AFNetworking/AFNetworking.h'
+  end
+
+  s.subspec 'AppExtension' do |ss|
+    ss.dependency 'Core'
+    ss.prefix_header_contents = '#define AF_APP_EXTENSIONS 1'
+  end
 
   s.subspec 'AppExtension' do |ss|
     ss.prefix_header_contents = '#define AF_APP_EXTENSIONS 1'


### PR DESCRIPTION
I added empty subspec for App Extension with  ``` #define AF_APP_EXTENSIONS 1```
So in you podfile you can just add some lines to fix extension compilation:

```ruby
target 'YourExtensionTargetName' do
    pod 'AFNetworking/AppExtension'
end

pod 'AFNetworking'
```