### PR TITLE
Allow pinning to public keys above the leaf

### DIFF
--- a/AFNetworking/AFSecurityPolicy.h
+++ b/AFNetworking/AFSecurityPolicy.h
@@ -42,12 +42,12 @@ typedef NS_ENUM(NSUInteger, AFSSLPinningMode) {
 @property (readonly, nonatomic, assign) AFSSLPinningMode SSLPinningMode;
 
 /**
- Whether to evaluate an entire SSL certificate chain, or just the leaf certificate. Defaults to `YES`.
+ Whether to evaluate an entire SSL certificate chain, or just the leaf certificate. Clears the property `validatesPartialCertificateChain` when set to `YES`. Defaults to `YES`.
  */
 @property (nonatomic, assign) BOOL validatesCertificateChain;
 
 /**
- Whether or not to trust servers when one or more certificates in the chain can be validated.  Defaults to `NO`.
+ Whether or not to trust servers when one or more certificates in the chain can be validated. Clears the property `validatesCertificateChain` when set to `YES`. Defaults to `NO`.
  */
 @property (nonatomic, assign) BOOL validatesPartialCertificateChain;
 

--- a/AFNetworking/AFSecurityPolicy.h
+++ b/AFNetworking/AFSecurityPolicy.h
@@ -47,6 +47,11 @@ typedef NS_ENUM(NSUInteger, AFSSLPinningMode) {
 @property (nonatomic, assign) BOOL validatesCertificateChain;
 
 /**
+ Whether or not to trust servers when one or more certificates in the chain can be validated.  Defaults to `NO`.
+ */
+@property (nonatomic, assign) BOOL validatesPartialCertificateChain;
+
+/**
  The certificates used to evaluate server trust according to the SSL pinning mode. By default, this property is set to any (`.cer`) certificates included in the app bundle.
  */
 @property (nonatomic, strong) NSArray *pinnedCertificates;

--- a/AFNetworking/AFSecurityPolicy.m
+++ b/AFNetworking/AFSecurityPolicy.m
@@ -223,6 +223,16 @@ static NSArray * AFPublicKeyTrustChainForServerTrust(SecTrustRef serverTrust) {
 
 #pragma mark -
 
+- (void)setValidatesCertificateChain:(BOOL)validatesCertificateChain {
+    _validatesCertificateChain = validatesCertificateChain;
+    _validatesPartialCertificateChain = !validatesCertificateChain;
+}
+
+- (void)setValidatesPartialCertificateChain:(BOOL)validatesPartialCertificateChain {
+    _validatesPartialCertificateChain = validatesPartialCertificateChain;
+    _validatesCertificateChain = !validatesPartialCertificateChain;
+}
+
 - (BOOL)evaluateServerTrust:(SecTrustRef)serverTrust {
     return [self evaluateServerTrust:serverTrust forDomain:nil];
 }
@@ -289,6 +299,12 @@ static NSArray * AFPublicKeyTrustChainForServerTrust(SecTrustRef serverTrust) {
                 for (id pinnedPublicKey in self.pinnedPublicKeys) {
                     if (AFSecKeyIsEqualToKey((__bridge SecKeyRef)trustChainPublicKey, (__bridge SecKeyRef)pinnedPublicKey)) {
                         trustedPublicKeyCount += 1;
+                        if (self.validatesPartialCertificateChain && trustedPublicKeyCount > 0) {
+                            break;
+                        }
+                    }
+                    if (self.validatesPartialCertificateChain && trustedPublicKeyCount > 0) {
+                        break;
                     }
                 }
             }

--- a/AFNetworking/AFSecurityPolicy.m
+++ b/AFNetworking/AFSecurityPolicy.m
@@ -225,12 +225,12 @@ static NSArray * AFPublicKeyTrustChainForServerTrust(SecTrustRef serverTrust) {
 
 - (void)setValidatesCertificateChain:(BOOL)validatesCertificateChain {
     _validatesCertificateChain = validatesCertificateChain;
-    _validatesPartialCertificateChain = !validatesCertificateChain;
+    _validatesPartialCertificateChain = validatesCertificateChain ? NO : _validatesPartialCertificateChain;
 }
 
 - (void)setValidatesPartialCertificateChain:(BOOL)validatesPartialCertificateChain {
     _validatesPartialCertificateChain = validatesPartialCertificateChain;
-    _validatesCertificateChain = !validatesPartialCertificateChain;
+    _validatesCertificateChain = validatesPartialCertificateChain ? NO : _validatesCertificateChain;
 }
 
 - (BOOL)evaluateServerTrust:(SecTrustRef)serverTrust {

--- a/AFNetworking/AFSecurityPolicy.m
+++ b/AFNetworking/AFSecurityPolicy.m
@@ -281,7 +281,7 @@ static NSArray * AFPublicKeyTrustChainForServerTrust(SecTrustRef serverTrust) {
         case AFSSLPinningModePublicKey: {
             NSUInteger trustedPublicKeyCount = 0;
             NSArray *publicKeys = AFPublicKeyTrustChainForServerTrust(serverTrust);
-            if (!self.validatesCertificateChain && [publicKeys count] > 0) {
+            if (!self.validatesCertificateChain && [publicKeys count] > 0 && !self.validatesPartialCertificateChain) {
                 publicKeys = @[[publicKeys firstObject]];
             }
 

--- a/Tests/Tests/AFSecurityPolicyTests.m
+++ b/Tests/Tests/AFSecurityPolicyTests.m
@@ -179,6 +179,22 @@ static SecTrustRef AFUTTrustWithCertificate(SecCertificateRef certificate) {
     CFRelease(trust);
 }
 
+- (void)testPublicKeyPartialChainPinningIsEnforcedForHTTPBinOrgPinnedCertificateAgainstHTTPBinOrgServerTrust {
+    AFSecurityPolicy *policy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModePublicKey];
+
+    SecTrustRef clientTrust = AFUTHTTPBinOrgServerTrust();
+    NSArray * allCertificates = AFCertificateTrustChainForServerTrust(clientTrust);
+    NSArray * certificates = @[ allCertificates.lastObject ];
+    CFRelease(clientTrust);
+    [policy setPinnedCertificates:certificates];
+    [policy setValidatesCertificateChain:NO];
+    [policy setValidatesPartialCertificateChain:YES];
+
+    SecTrustRef trust = AFUTHTTPBinOrgServerTrust();
+    XCTAssert([policy evaluateServerTrust:trust forDomain:@"httpbin.org"], @"HTTPBin.org Public Key Partial Chain Pinning Mode Failed");
+    CFRelease(trust);
+}
+
 - (void)testLeafCertificatePinningIsEnforcedForHTTPBinOrgPinnedCertificateAgainstHTTPBinOrgServerTrust {
     AFSecurityPolicy *policy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModeCertificate];
 

--- a/Tests/Tests/AFSecurityPolicyTests.m
+++ b/Tests/Tests/AFSecurityPolicyTests.m
@@ -195,6 +195,20 @@ static SecTrustRef AFUTTrustWithCertificate(SecCertificateRef certificate) {
     CFRelease(trust);
 }
 
+- (void)testSettingValidatesPartialCertificateChainFlagClearsTheValidatesCertificateChainFlag {
+    AFSecurityPolicy * policy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModePublicKey];
+    [policy setValidatesCertificateChain:YES];
+    [policy setValidatesPartialCertificateChain:YES];
+    XCTAssertFalse([policy validatesCertificateChain], @"validatesCertificateChain should be set to NO");
+}
+
+- (void)testSettingValidatesCertificateChainFlagClearsTheValidatesPartialCertificateChainFlag {
+    AFSecurityPolicy * policy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModePublicKey];
+    [policy setValidatesPartialCertificateChain:YES];
+    [policy setValidatesCertificateChain:YES];
+    XCTAssertFalse([policy validatesPartialCertificateChain], @"validatesPartialCertificateChain should be set to NO");
+}
+
 - (void)testLeafCertificatePinningIsEnforcedForHTTPBinOrgPinnedCertificateAgainstHTTPBinOrgServerTrust {
     AFSecurityPolicy *policy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModeCertificate];
 


### PR DESCRIPTION
Adds the Boolean property `validatesPartialCertificateChain` to `AFSecurityPolicy`.

When `validatesPartialCertificateChain` is set to `YES`, `evaluateServerTrust:forDomain:` will return YES if the public key in a pinned certificate matches any key in the server certificate's chain.

This permits clients to pin to multiple roots, or to pin to a specific server certificate and one or more root, among other examples.

All other functionality of `AFSecurityPolicy` remains unaffected.
