### PR TITLE
Fix OS X 10.8 compatibility

### DIFF
--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -287,7 +287,7 @@ static NSString * const AFNSURLSessionTaskDidSuspendNotification = @"com.alamofi
 + (void)load {
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        if ([NSURLSessionDataTask class]) {
+        if ([NSURLSessionTask class]) {
             NSURLSessionDataTask *dataTask = [[NSURLSession sessionWithConfiguration:nil] dataTaskWithURL:nil];
             Class taskClass = [dataTask superclass];
 


### PR DESCRIPTION
We have to check for `[NSURLSessionTask class]` and not `[NSURLSessionDataTask class]`, otherwise it crashes on 10.8.

Should fix #2638 