### PR TITLE
[issue #2638] Fixes 10.8 / iOS 6 _OBJC_CLASS_$_NSURLSessionDataTask crash

### DIFF
--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -284,10 +284,10 @@ static NSString * const AFNSURLSessionTaskDidSuspendNotification = @"com.alamofi
 
 @implementation NSURLSessionTask (_AFStateObserving)
 
-+ (void)load {
++ (void)initialize {
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        if ([NSURLSessionDataTask class]) {
+        if ([NSURLSessionTask class]) {
             NSURLSessionDataTask *dataTask = [[NSURLSession sessionWithConfiguration:nil] dataTaskWithURL:nil];
             Class taskClass = [dataTask superclass];
 


### PR DESCRIPTION
Changes posted in https://github.com/AFNetworking/AFNetworking/issues/2638#issuecomment-94174154
