### PR TITLE
Removing unnecessary code in UIImageView+AFNetworking.

### DIFF
--- a/UIKit+AFNetworking/UIImageView+AFNetworking.m
+++ b/UIKit+AFNetworking/UIImageView+AFNetworking.m
@@ -134,8 +134,6 @@
         } else {
             self.image = cachedImage;
         }
-
-        self.af_imageRequestOperation = nil;
     } else {
         if (placeholderImage) {
             self.image = placeholderImage;


### PR DESCRIPTION
There is no reason to set `af_imageRequestOperation` to nil as it was already nilled out in [cancelImageRequestOperation](https://github.com/imaks/AFNetworking/blob/remove-unnecessary-code/UIKit%2BAFNetworking/UIImageView%2BAFNetworking.m#L128).