### PR TITLE
Replaced double allocation by a single one.

### DIFF
--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -161,6 +161,7 @@ didCompleteWithError:(NSError *)error
         userInfo[AFNetworkingTaskDidCompleteAssetPathKey] = self.downloadFileURL;
     } else if (self.mutableData) {
         data = [NSData dataWithData:self.mutableData];
+        self.mutableData = nil;
         userInfo[AFNetworkingTaskDidCompleteResponseDataKey] = data;
     }
 

--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -159,11 +159,13 @@ didCompleteWithError:(NSError *)error
 
     if (self.downloadFileURL) {
         userInfo[AFNetworkingTaskDidCompleteAssetPathKey] = self.downloadFileURL;
+        if (!error) {
+            data = [self.mutableData copy];
+        }
     } else if (self.mutableData) {
-        data = [NSData dataWithData:self.mutableData];
-        self.mutableData = nil;
-        userInfo[AFNetworkingTaskDidCompleteResponseDataKey] = data;
+        userInfo[AFNetworkingTaskDidCompleteResponseDataKey] = data = [self.mutableData copy];
     }
+    self.mutableData = nil;
 
     if (error) {
         userInfo[AFNetworkingTaskDidCompleteErrorKey] = error;

--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -155,10 +155,13 @@ didCompleteWithError:(NSError *)error
     __block NSMutableDictionary *userInfo = [NSMutableDictionary dictionary];
     userInfo[AFNetworkingTaskDidCompleteResponseSerializerKey] = manager.responseSerializer;
 
+    NSData *data = nil;
+
     if (self.downloadFileURL) {
         userInfo[AFNetworkingTaskDidCompleteAssetPathKey] = self.downloadFileURL;
     } else if (self.mutableData) {
-        userInfo[AFNetworkingTaskDidCompleteResponseDataKey] = [NSData dataWithData:self.mutableData];
+        data = [NSData dataWithData:self.mutableData];
+        userInfo[AFNetworkingTaskDidCompleteResponseDataKey] = data;
     }
 
     if (error) {
@@ -176,7 +179,7 @@ didCompleteWithError:(NSError *)error
     } else {
         dispatch_async(url_session_manager_processing_queue(), ^{
             NSError *serializationError = nil;
-            responseObject = [manager.responseSerializer responseObjectForResponse:task.response data:[NSData dataWithData:self.mutableData] error:&serializationError];
+            responseObject = [manager.responseSerializer responseObjectForResponse:task.response data:data error:&serializationError];
 
             if (self.downloadFileURL) {
                 responseObject = self.downloadFileURL;


### PR DESCRIPTION
These small changes saves precious memory. Particularly useful when dealing with large files.