### PR TITLE
Added new constructor to AFURLRequestSerialization

### DIFF
--- a/AFNetworking/AFURLRequestSerialization.h
+++ b/AFNetworking/AFURLRequestSerialization.h
@@ -132,6 +132,13 @@ typedef NS_ENUM(NSUInteger, AFHTTPRequestQueryStringSerializationStyle) {
 + (instancetype)serializer;
 
 /**
+ initializes a serializer with a specified encoding.
+ 
+ @param encoding the encoding to be used during serialization
+ */
+- (instancetype)initWithEncoding:(NSStringEncoding)encoding;
+
+/**
  Sets the value for the HTTP headers set in request objects made by the HTTP client. If `nil`, removes the existing value for that header.
 
  @param field The HTTP header to set a default value for

--- a/AFNetworking/AFURLRequestSerialization.m
+++ b/AFNetworking/AFURLRequestSerialization.m
@@ -194,6 +194,16 @@ static void *AFHTTPRequestSerializerObserverContext = &AFHTTPRequestSerializerOb
     return [[self alloc] init];
 }
 
+- (instancetype) initWithEncoding:(NSStringEncoding)encoding
+{
+    self = [self init];
+    if(self) {
+        self.stringEncoding = encoding;
+    }
+    
+    return self;
+}
+
 - (instancetype)init {
     self = [super init];
     if (!self) {


### PR DESCRIPTION
Added new constructor to AFURLRequestSerialization enabling it to use a custom NSStringEncoding.
AFURLRequestSerialization already supports variable NSStringEncoding, but there was no way to set it...