### PR TITLE
Faster JSON NULL removal

### DIFF
--- a/AFNetworking/AFURLResponseSerialization.m
+++ b/AFNetworking/AFURLResponseSerialization.m
@@ -57,26 +57,38 @@ static BOOL AFErrorOrUnderlyingErrorHasCodeInDomain(NSError *error, NSInteger co
     return NO;
 }
 
-static id AFJSONObjectByRemovingKeysWithNullValues(id JSONObject, NSJSONReadingOptions readingOptions) {
+static id AFJSONObjectByRemovingKeysWithNullValues(id JSONObject, BOOL mutableContainers) {
     if ([JSONObject isKindOfClass:[NSArray class]]) {
-        NSMutableArray *mutableArray = [NSMutableArray arrayWithCapacity:[(NSArray *)JSONObject count]];
-        for (id value in (NSArray *)JSONObject) {
-            [mutableArray addObject:AFJSONObjectByRemovingKeysWithNullValues(value, readingOptions)];
+        NSMutableArray *mutableArray = JSONObject;
+        NSArray *immutableArray = [JSONObject copy];
+        __block BOOL changedArray = NO;
+        [immutableArray enumerateObjectsUsingBlock:^(id value, NSUInteger idx, BOOL *stop) {
+            id neueValue = AFJSONObjectByRemovingKeysWithNullValues(value, mutableContainers);
+            if (neueValue != value) {
+                [mutableArray replaceObjectAtIndex:idx withObject:neueValue];
+                changedArray = YES;
+            }
+        }];
+        if (mutableContainers) {
+            return mutableArray;
+        } else {
+            return changedArray ? [NSArray arrayWithArray:mutableArray] : immutableArray;
         }
-
-        return (readingOptions & NSJSONReadingMutableContainers) ? mutableArray : [NSArray arrayWithArray:mutableArray];
     } else if ([JSONObject isKindOfClass:[NSDictionary class]]) {
-        NSMutableDictionary *mutableDictionary = [NSMutableDictionary dictionaryWithDictionary:JSONObject];
+        NSMutableDictionary *mutableDictionary = JSONObject;
         for (id <NSCopying> key in [(NSDictionary *)JSONObject allKeys]) {
             id value = [(NSDictionary *)JSONObject objectForKey:key];
             if (!value || [value isEqual:[NSNull null]]) {
                 [mutableDictionary removeObjectForKey:key];
             } else if ([value isKindOfClass:[NSArray class]] || [value isKindOfClass:[NSDictionary class]]) {
-                [mutableDictionary setObject:AFJSONObjectByRemovingKeysWithNullValues(value, readingOptions) forKey:key];
+                id neueValue = AFJSONObjectByRemovingKeysWithNullValues(value, mutableContainers);
+                if (value != neueValue) {
+                    [mutableDictionary setObject:neueValue forKey:key];
+                }
             }
         }
 
-        return (readingOptions & NSJSONReadingMutableContainers) ? mutableDictionary : [NSDictionary dictionaryWithDictionary:mutableDictionary];
+        return mutableContainers ? mutableDictionary : [NSDictionary dictionaryWithDictionary:mutableDictionary];
     }
 
     return JSONObject;
@@ -258,7 +270,11 @@ static id AFJSONObjectByRemovingKeysWithNullValues(id JSONObject, NSJSONReadingO
 
             if (data) {
                 if ([data length] > 0) {
-                    responseObject = [NSJSONSerialization JSONObjectWithData:data options:self.readingOptions error:&serializationError];
+                    NSJSONReadingOptions readingOptions = self.readingOptions;
+                    if (self.removesKeysWithNullValues) {
+                        readingOptions |= NSJSONReadingMutableContainers;
+                    }
+                    responseObject = [NSJSONSerialization JSONObjectWithData:data options:readingOptions error:&serializationError];
                 } else {
                     return nil;
                 }
@@ -274,7 +290,7 @@ static id AFJSONObjectByRemovingKeysWithNullValues(id JSONObject, NSJSONReadingO
     }
 
     if (self.removesKeysWithNullValues && responseObject) {
-        responseObject = AFJSONObjectByRemovingKeysWithNullValues(responseObject, self.readingOptions);
+        responseObject = AFJSONObjectByRemovingKeysWithNullValues(responseObject, (self.readingOptions & NSJSONReadingMutableContainers));
     }
 
     if (error) {

--- a/Tests/AFNetworking Tests.xcodeproj/xcshareddata/xcbaselines/2902D28B17DF4E2900C81C5A.xcbaseline/1AB03575-E87D-4721-BE3D-861013D589BA.plist
+++ b/Tests/AFNetworking Tests.xcodeproj/xcshareddata/xcbaselines/2902D28B17DF4E2900C81C5A.xcbaseline/1AB03575-E87D-4721-BE3D-861013D589BA.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>classNames</key>
+	<dict>
+		<key>AFJSONResponseSerializationTests</key>
+		<dict>
+			<key>testResponseSerializerPerformance</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.32</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/Tests/AFNetworking Tests.xcodeproj/xcshareddata/xcbaselines/2902D28B17DF4E2900C81C5A.xcbaseline/Info.plist
+++ b/Tests/AFNetworking Tests.xcodeproj/xcshareddata/xcbaselines/2902D28B17DF4E2900C81C5A.xcbaseline/Info.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>runDestinationsByUUID</key>
+	<dict>
+		<key>1AB03575-E87D-4721-BE3D-861013D589BA</key>
+		<dict>
+			<key>localComputer</key>
+			<dict>
+				<key>busSpeedInMHz</key>
+				<integer>100</integer>
+				<key>cpuCount</key>
+				<integer>1</integer>
+				<key>cpuKind</key>
+				<string>Intel Core i7</string>
+				<key>cpuSpeedInMHz</key>
+				<integer>3000</integer>
+				<key>logicalCPUCoresPerPackage</key>
+				<integer>4</integer>
+				<key>modelCode</key>
+				<string>MacBookPro10,2</string>
+				<key>physicalCPUCoresPerPackage</key>
+				<integer>2</integer>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.macosx</string>
+			</dict>
+			<key>targetArchitecture</key>
+			<string>x86_64</string>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/Tests/Tests/AFJSONSerializationTests.m
+++ b/Tests/Tests/AFJSONSerializationTests.m
@@ -134,4 +134,21 @@ static NSData * AFJSONTestData() {
     XCTAssertNotNil(error, @"Serialization error should not be nil");
 }
 
+- (void)testResponseSerializerPerformance
+{
+    NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:self.baseURL statusCode:200 HTTPVersion:@"1.1" headerFields:@{@"Content-Type": @"text/json"}];
+    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:@{
+                                                                 @"aKey" : [NSNull null],
+                                                                 @"bKey": @2,
+                                                                 @"cKey": @[@{@"aKey":[NSNull null], @"bKey": @2}, @{@"aKey":[NSNull null], @"bKey": @2}, @{@"aKey":[NSNull null], @"bKey": @2}]
+                                                                 }options:0 error:NULL];
+    self.responseSerializer.removesKeysWithNullValues = YES;
+    //self.responseSerializer.readingOptions = NSJSONReadingMutableContainers;
+    [self measureBlock:^{
+        for (int i = 0; i < 10000; i++) {
+            [self.responseSerializer responseObjectForResponse:response data:jsonData error:NULL];
+        }
+    }];
+}
+
 @end


### PR DESCRIPTION
By initially creating the containers as mutable, the object creation is now 1 time for best case scenario (when consumer wants mutable containers) and 2 for the worst (when the consumer wants immutable containers), as opposed to before where the cases were 2 and 3 respectively.

Also added a performance test for this.