### PR TITLE
fix bug that when outputstream is unavailable should break the While recycle and return error

### DIFF
--- a/AFNetworking/AFURLConnectionOperation.m
+++ b/AFNetworking/AFURLConnectionOperation.m
@@ -668,7 +668,7 @@ didReceiveResponse:(NSURLResponse *)response
             break;
         }
 
-        if (self.outputStream.streamError) {
+        if (self.outputStream.streamError || ![self.outputStream hasSpaceAvailable]) {
             [self.connection cancel];
             [self performSelector:@selector(connection:didFailWithError:) withObject:self.connection withObject:self.outputStream.streamError];
             return;


### PR DESCRIPTION
fix bug that when outputstream is unavailable should break the While recycle and return error