### PR TITLE
_AFStateObserving Swizzling Implementation is Wrong

### DIFF
--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -255,68 +255,121 @@ expectedTotalBytes:(int64_t)expectedTotalBytes {
 
 #pragma mark -
 
-/*
- A workaround for issues related to key-value observing the `state` of an `NSURLSessionTask`.
-
- See https://github.com/AFNetworking/AFNetworking/issues/1477
+/**
+ *  A workaround for issues related to key-value observing the `state` of an `NSURLSessionTask`.
+ *
+ *  See:
+ *  - https://github.com/AFNetworking/AFNetworking/issues/1477
+ *  - https://github.com/AFNetworking/AFNetworking/issues/2638
+ *  - https://github.com/AFNetworking/AFNetworking/pull/2702
  */
 
 static inline void af_swizzleSelector(Class class, SEL originalSelector, SEL swizzledSelector) {
     Method originalMethod = class_getInstanceMethod(class, originalSelector);
     Method swizzledMethod = class_getInstanceMethod(class, swizzledSelector);
-    if (class_addMethod(class, originalSelector, method_getImplementation(swizzledMethod), method_getTypeEncoding(swizzledMethod))) {
-        class_replaceMethod(class, swizzledSelector, method_getImplementation(originalMethod), method_getTypeEncoding(originalMethod));
-    } else {
-        method_exchangeImplementations(originalMethod, swizzledMethod);
-    }
+    method_exchangeImplementations(originalMethod, swizzledMethod);
 }
 
-static inline void af_addMethod(Class class, SEL selector, Method method) {
-    class_addMethod(class, selector,  method_getImplementation(method),  method_getTypeEncoding(method));
+static inline BOOL af_addMethod(Class class, SEL selector, Method method) {
+    return class_addMethod(class, selector,  method_getImplementation(method),  method_getTypeEncoding(method));
 }
 
 static NSString * const AFNSURLSessionTaskDidResumeNotification  = @"com.alamofire.networking.nsurlsessiontask.resume";
 static NSString * const AFNSURLSessionTaskDidSuspendNotification = @"com.alamofire.networking.nsurlsessiontask.suspend";
 
-@interface NSURLSessionTask (_AFStateObserving)
+@interface _AFURLSessionTaskSwizzling : NSObject
+
 @end
 
-@implementation NSURLSessionTask (_AFStateObserving)
+@implementation _AFURLSessionTaskSwizzling
 
-+ (void)initialize {
-    if ([NSURLSessionTask class]) {
-        NSURLSessionDataTask *dataTask = [[NSURLSession sessionWithConfiguration:nil] dataTaskWithURL:nil];
-        Class taskClass = [dataTask superclass];
++ (void)load {
+    /**
+     WARNING: Trouble Ahead
+     https://github.com/AFNetworking/AFNetworking/pull/2702
+     */
 
-        af_addMethod(taskClass, @selector(af_resume),  class_getInstanceMethod(self, @selector(af_resume)));
-        af_addMethod(taskClass, @selector(af_suspend), class_getInstanceMethod(self, @selector(af_suspend)));
-        af_swizzleSelector(taskClass, @selector(resume), @selector(af_resume));
-        af_swizzleSelector(taskClass, @selector(suspend), @selector(af_suspend));
-
-        [dataTask cancel];
+    if (NSClassFromString(@"NSURLSessionTask")) {
+        /**
+         iOS 7 and iOS 8 differ in NSURLSessionTask implementation, which makes the next bit of code a bit tricky.
+         Many Unit Tests have been built to validate as much of this behavior has possible.
+         Here is what we know:
+            - NSURLSessionTasks are implemented with class clusters, meaning the class you request from the API isn't actually the type of class you will get back.
+            - Simply referencing `[NSURLSessionTask class]` will not work. You need to ask an `NSURLSession` to actually create an object, and grab the class from there.
+            - On iOS 7, `localDataTask` is a `__NSCFLocalDataTask`, which inherits from `__NSCFLocalSessionTask`, which inherits from `__NSCFURLSessionTask`.
+            - On iOS 8, `localDataTask` is a `__NSCFLocalDataTask`, which inherits from `__NSCFLocalSessionTask`, which inherits from `NSURLSessionTask`.
+            - On iOS 7, `__NSCFLocalSessionTask` and `__NSCFURLSessionTask` are the only two classes that have their own implementations of `resume` and `suspend`, and `__NSCFLocalSessionTask` DOES NOT CALL SUPER. This means both classes need to be swizzled.
+            - On iOS 8, `NSURLSessionTask` is the only class that implements `resume` and `suspend`. This means this is the only class that needs to be swizzled.
+            - Because `NSURLSessionTask` is not involved in the class hierarchy for every version of iOS, its easier to add the swizzled methods to a dummy class and manage them there.
+        
+         Some Assumptions:
+            - No implementations of `resume` or `suspend` call super. If this were to change in a future version of iOS, we'd need to handle it.
+            - No background task classes override `resume` or `suspend`
+         
+         The current solution:
+            1) Grab an instance of `__NSCFLocalDataTask` by asking an instance of `NSURLSession` for a data task.
+            2) Grab a pointer to the original implementation of `af_resume`
+            3) Check to see if the current class has an implementation of resume. If so, continue to step 4.
+            4) Grab the super class of the current class.
+            5) Grab a pointer for the current class to the current implementation of `resume`.
+            6) Grab a pointer for the super class to the current implementation of `resume`.
+            7) If the current class implementation of `resume` is not equal to the super class implementation of `resume` AND the current implementation of `resume` is not equal to the original implementation of `af_resume`, THEN swizzle the methods
+            8) Set the current class to the super class, and repeat steps 3-8
+         */
+        NSURLSessionDataTask *localDataTask = [[NSURLSession sessionWithConfiguration:nil] dataTaskWithURL:nil];
+        IMP originalAFResumeIMP = method_getImplementation(class_getInstanceMethod([_AFURLSessionTaskSwizzling class], @selector(af_resume)));
+        Class currentClass = [localDataTask class];
+        
+        while (class_getInstanceMethod(currentClass, @selector(resume))) {
+            Class superClass = [currentClass superclass];
+            IMP classResumeIMP = method_getImplementation(class_getInstanceMethod(currentClass, @selector(resume)));
+            IMP superclassResumeIMP = method_getImplementation(class_getInstanceMethod(superClass, @selector(resume)));
+            if (classResumeIMP != superclassResumeIMP &&
+                originalAFResumeIMP != classResumeIMP) {
+                [self swizzleResumeAndSuspendMethodForClass:currentClass];
+            }
+            currentClass = [currentClass superclass];
+        }
+        
+        [localDataTask cancel];
     }
 }
 
-#pragma mark -
++ (void)swizzleResumeAndSuspendMethodForClass:(Class)class {
+    Method afResumeMethod = class_getInstanceMethod(self, @selector(af_resume));
+    Method afSuspendMethod = class_getInstanceMethod(self, @selector(af_suspend));
+    
+    af_addMethod(class, @selector(af_resume), afResumeMethod);
+    af_addMethod(class, @selector(af_suspend), afSuspendMethod);
+    
+    af_swizzleSelector(class, @selector(resume), @selector(af_resume));
+    af_swizzleSelector(class, @selector(suspend), @selector(af_suspend));
+}
+
+- (NSURLSessionTaskState)state {
+    NSAssert(NO, @"State method should never be called in the actual dummy class");
+    return NSURLSessionTaskStateCanceling;
+}
 
 - (void)af_resume {
-    NSURLSessionTaskState state = self.state;
+    NSAssert([self respondsToSelector:@selector(state)], @"Does not respond to state");
+    NSURLSessionTaskState state = [self state];
     [self af_resume];
-
+    
     if (state != NSURLSessionTaskStateRunning) {
         [[NSNotificationCenter defaultCenter] postNotificationName:AFNSURLSessionTaskDidResumeNotification object:self];
     }
 }
 
 - (void)af_suspend {
-    NSURLSessionTaskState state = self.state;
+    NSAssert([self respondsToSelector:@selector(state)], @"Does not respond to state");
+    NSURLSessionTaskState state = [self state];
     [self af_suspend];
-
+    
     if (state != NSURLSessionTaskStateSuspended) {
         [[NSNotificationCenter defaultCenter] postNotificationName:AFNSURLSessionTaskDidSuspendNotification object:self];
     }
 }
-
 @end
 
 #pragma mark -

--- a/Tests/AFNetworking Tests.xcodeproj/project.pbxproj
+++ b/Tests/AFNetworking Tests.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		29CBFC7717DF697C0021AB75 /* HTTPBinOrgServerTrustChain in Resources */ = {isa = PBXBuildFile; fileRef = 29CBFC7517DF697C0021AB75 /* HTTPBinOrgServerTrustChain */; };
 		29CBFC8717DF74C60021AB75 /* ADNNetServerTrustChain in Resources */ = {isa = PBXBuildFile; fileRef = 29CBFC8617DF74C60021AB75 /* ADNNetServerTrustChain */; };
 		29CBFC8817DF74C60021AB75 /* ADNNetServerTrustChain in Resources */ = {isa = PBXBuildFile; fileRef = 29CBFC8617DF74C60021AB75 /* ADNNetServerTrustChain */; };
+		29EAB0D71AFC148200C2C460 /* AFURLSessionManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 943B1F40192E406C00304316 /* AFURLSessionManagerTests.m */; };
 		36DE264E18053E930062F4E3 /* adn_0.cer in Resources */ = {isa = PBXBuildFile; fileRef = 36DE264B18053E930062F4E3 /* adn_0.cer */; };
 		36DE264F18053E930062F4E3 /* adn_1.cer in Resources */ = {isa = PBXBuildFile; fileRef = 36DE264C18053E930062F4E3 /* adn_1.cer */; };
 		36DE265018053E930062F4E3 /* adn_2.cer in Resources */ = {isa = PBXBuildFile; fileRef = 36DE264D18053E930062F4E3 /* adn_2.cer */; };
@@ -545,6 +546,7 @@
 			files = (
 				F837FFB0195744A0009078A0 /* AFHTTPResponseSerializationTests.m in Sources */,
 				36DE2652180544600062F4E3 /* AFHTTPRequestOperationTests.m in Sources */,
+				29EAB0D71AFC148200C2C460 /* AFURLSessionManagerTests.m in Sources */,
 				36DE26511805445B0062F4E3 /* AFSecurityPolicyTests.m in Sources */,
 				29CBFC4017DF58000021AB75 /* AFHTTPRequestSerializationTests.m in Sources */,
 				29CBFC3D17DF541F0021AB75 /* AFJSONSerializationTests.m in Sources */,

--- a/Tests/Tests/AFURLSessionManagerTests.m
+++ b/Tests/Tests/AFURLSessionManagerTests.m
@@ -19,19 +19,43 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#import <objc/runtime.h>
+
 #import "AFTestCase.h"
 
 #import "AFURLSessionManager.h"
 
 @interface AFURLSessionManagerTests : AFTestCase
-@property (readwrite, nonatomic, strong) AFURLSessionManager *manager;
+@property (readwrite, nonatomic, strong) AFURLSessionManager *localManager;
+@property (readwrite, nonatomic, strong) AFURLSessionManager *backgroundManager;
 @end
+
 
 @implementation AFURLSessionManagerTests
 
 - (void)setUp {
     [super setUp];
-    self.manager = [[AFURLSessionManager alloc] init];
+    self.localManager = [[AFURLSessionManager alloc] init];
+    
+    //Unfortunately, iOS 7 throws an exception when trying to create a background URL Session inside this test target, which means our tests here can only run on iOS 8+
+    //Travis actually needs the try catch here. Just doing if ([NSURLSessionConfiguration respondsToSelector:@selector(backgroundSessionWithIdentifier)]) wasn't good enough.
+    @try {
+        NSString *identifier = [NSString stringWithFormat:@"com.afnetworking.tests.urlsession.%@", [[NSUUID UUID] UUIDString]];
+        NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:identifier];
+        self.backgroundManager = [[AFURLSessionManager alloc] initWithSessionConfiguration:configuration];
+    }
+    @catch (NSException *exception) {
+
+    }
+}
+
+- (void)tearDown {
+    [super tearDown];
+    [self.localManager invalidateSessionCancelingTasks:YES];
+    self.localManager = nil;
+    
+    [self.backgroundManager invalidateSessionCancelingTasks:YES];
+    self.backgroundManager = nil;
 }
 
 #pragma mark -
@@ -42,7 +66,7 @@
     [overallProgress becomeCurrentWithPendingUnitCount:80];
     NSProgress *uploadProgress = nil;
 
-    [self.manager uploadTaskWithRequest:[NSURLRequest requestWithURL:self.baseURL]
+    [self.localManager uploadTaskWithRequest:[NSURLRequest requestWithURL:self.baseURL]
                                fromData:[NSData data]
                                  progress:&uploadProgress
                         completionHandler:nil];
@@ -63,7 +87,7 @@
     [overallProgress becomeCurrentWithPendingUnitCount:80];
     NSProgress *downloadProgress = nil;
 
-    [self.manager downloadTaskWithRequest:[NSURLRequest requestWithURL:self.baseURL]
+    [self.localManager downloadTaskWithRequest:[NSURLRequest requestWithURL:self.baseURL]
                                  progress:&downloadProgress
                               destination:nil
                         completionHandler:nil];
@@ -77,5 +101,267 @@
 
     expect(overallProgress.fractionCompleted).to.equal(0.8);
 }
+
+#pragma mark - Issue #2702 Tests
+// The following tests are all releated to issue #2702
+
+- (void)testDidResumeNotificationIsReceivedByLocalDataTaskAfterResume {
+    NSURLSessionDataTask *task = [self.localManager dataTaskWithRequest:[self _delayURLRequest]
+                                                 completionHandler:nil];
+    [self _testResumeNotificationForTask:task];
+}
+
+- (void)testDidSuspendNotificationIsReceivedByLocalDataTaskAfterSuspend {
+    NSURLSessionDataTask *task = [self.localManager dataTaskWithRequest:[self _delayURLRequest]
+                                                 completionHandler:nil];
+    [self _testSuspendNotificationForTask:task];
+}
+
+- (void)testDidResumeNotificationIsReceivedByBackgroundDataTaskAfterResume {
+    if (self.backgroundManager) {
+        NSURLSessionDataTask *task = [self.backgroundManager dataTaskWithRequest:[self _delayURLRequest]
+                                                               completionHandler:nil];
+        [self _testResumeNotificationForTask:task];
+    }
+}
+
+- (void)testDidSuspendNotificationIsReceivedByBackgroundDataTaskAfterSuspend {
+    if (self.backgroundManager) {
+        NSURLSessionDataTask *task = [self.backgroundManager dataTaskWithRequest:[self _delayURLRequest]
+                                                               completionHandler:nil];
+        [self _testSuspendNotificationForTask:task];
+    }
+}
+
+- (void)testDidResumeNotificationIsReceivedByLocalUploadTaskAfterResume {
+    NSURLSessionUploadTask *task = [self.localManager uploadTaskWithRequest:[self _delayURLRequest]
+                                                              fromData:[NSData data]
+                                                              progress:nil
+                                                     completionHandler:nil];
+    [self _testResumeNotificationForTask:task];
+}
+
+- (void)testDidSuspendNotificationIsReceivedByLocalUploadTaskAfterSuspend {
+    NSURLSessionUploadTask *task = [self.localManager uploadTaskWithRequest:[self _delayURLRequest]
+                                                              fromData:[NSData data]
+                                                              progress:nil
+                                                     completionHandler:nil];
+    [self _testSuspendNotificationForTask:task];
+}
+
+- (void)testDidResumeNotificationIsReceivedByBackgroundUploadTaskAfterResume {
+    if (self.backgroundManager) {
+        NSURLSessionUploadTask *task = [self.backgroundManager uploadTaskWithRequest:[self _delayURLRequest]
+                                                                            fromFile:nil
+                                                                            progress:nil
+                                                                   completionHandler:nil];
+        [self _testResumeNotificationForTask:task];
+    }
+}
+
+- (void)testDidSuspendNotificationIsReceivedByBackgroundUploadTaskAfterSuspend {
+    if (self.backgroundManager) {
+        NSURLSessionUploadTask *task = [self.backgroundManager uploadTaskWithRequest:[self _delayURLRequest]
+                                                                            fromFile:nil
+                                                                            progress:nil
+                                                                   completionHandler:nil];
+        [self _testSuspendNotificationForTask:task];
+    }
+}
+
+- (void)testDidResumeNotificationIsReceivedByLocalDownloadTaskAfterResume {
+    NSURLSessionDownloadTask *task = [self.localManager downloadTaskWithRequest:[self _delayURLRequest]
+                                                                progress:nil
+                                                             destination:nil
+                                                       completionHandler:nil];
+    [self _testResumeNotificationForTask:task];
+}
+
+- (void)testDidSuspendNotificationIsReceivedByLocalDownloadTaskAfterSuspend {
+    NSURLSessionDownloadTask *task = [self.localManager downloadTaskWithRequest:[self _delayURLRequest]
+                                                                progress:nil
+                                                             destination:nil
+                                                       completionHandler:nil];
+    [self _testSuspendNotificationForTask:task];
+}
+
+- (void)testDidResumeNotificationIsReceivedByBackgroundDownloadTaskAfterResume {
+    if (self.backgroundManager) {
+        NSURLSessionDownloadTask *task = [self.backgroundManager downloadTaskWithRequest:[self _delayURLRequest]
+                                                                                progress:nil
+                                                                             destination:nil
+                                                                       completionHandler:nil];
+        [self _testResumeNotificationForTask:task];
+    }
+}
+
+- (void)testDidSuspendNotificationIsReceivedByBackgroundDownloadTaskAfterSuspend {
+    if (self.backgroundManager) {
+        NSURLSessionDownloadTask *task = [self.backgroundManager downloadTaskWithRequest:[self _delayURLRequest]
+                                                                                progress:nil
+                                                                             destination:nil
+                                                                       completionHandler:nil];
+        [self _testSuspendNotificationForTask:task];
+    }
+}
+
+- (void)testSwizzlingIsProperlyConfiguredForDummyClass {
+    IMP originalAFResumeIMP = [self _originalAFResumeImplementation];
+    IMP originalAFSuspendIMP = [self _originalAFSuspendImplementation];
+    XCTAssert(originalAFResumeIMP, @"Swizzled af_resume Method Not Found");
+    XCTAssert(originalAFSuspendIMP, @"Swizzled af_suspend Method Not Found");
+    XCTAssertNotEqual(originalAFResumeIMP, originalAFSuspendIMP, @"af_resume and af_suspend should not be equal");
+}
+
+- (void)testSwizzlingIsWorkingAsExpectedForForegroundDataTask {
+    NSURLSessionTask *task = [self.localManager dataTaskWithRequest:[self _delayURLRequest]
+                                             completionHandler:nil];
+    [self _testSwizzlingForTask:task];
+    [task cancel];
+}
+
+- (void)testSwizzlingIsWorkingAsExpectedForForegroundUpload {
+    NSURLSessionTask *task = [self.localManager uploadTaskWithRequest:[self _delayURLRequest]
+                                                        fromData:[NSData data]
+                                                        progress:nil
+                                               completionHandler:nil];
+    [self _testSwizzlingForTask:task];
+    [task cancel];
+}
+
+- (void)testSwizzlingIsWorkingAsExpectedForForegroundDownload {
+    NSURLSessionTask *task = [self.localManager downloadTaskWithRequest:[self _delayURLRequest]
+                                                          progress:nil
+                                                       destination:nil
+                                                 completionHandler:nil];
+    [self _testSwizzlingForTask:task];
+    [task cancel];
+}
+
+- (void)testSwizzlingIsWorkingAsExpectedForBackgroundDataTask {
+    //iOS 7 doesn't let us use a background manager in these tests, so reference these
+    //classes directly. There are tests below to confirm background manager continues
+    //to return the exepcted classes going forward. If those fail in a future iOS version,
+    //it should point us to a problem here.
+    [self _testSwizzlingForTaskClass:NSClassFromString(@"__NSCFBackgroundDataTask")];
+}
+
+- (void)testSwizzlingIsWorkingAsExpectedForBackgroundUploadTask {
+    //iOS 7 doesn't let us use a background manager in these tests, so reference these
+    //classes directly. There are tests below to confirm background manager continues
+    //to return the exepcted classes going forward. If those fail in a future iOS version,
+    //it should point us to a problem here.
+    [self _testSwizzlingForTaskClass:NSClassFromString(@"__NSCFBackgroundUploadTask")];
+}
+
+- (void)testSwizzlingIsWorkingAsExpectedForBackgroundDownloadTask {
+    //iOS 7 doesn't let us use a background manager in these tests, so reference these
+    //classes directly. There are tests below to confirm background manager continues
+    //to return the exepcted classes going forward. If those fail in a future iOS version,
+    //it should point us to a problem here.
+    [self _testSwizzlingForTaskClass:NSClassFromString(@"__NSCFBackgroundDownloadTask")];
+}
+
+- (void)testBackgroundManagerReturnsExpectedClassForDataTask {
+    if (self.backgroundManager) {
+        NSURLSessionTask *task = [self.backgroundManager dataTaskWithRequest:[self _delayURLRequest]
+                                                           completionHandler:nil];
+        XCTAssert([NSStringFromClass([task class]) isEqualToString:@"__NSCFBackgroundDataTask"]);
+    } else {
+        NSLog(@"Unable to run %@ because self.backgroundManager is nil", NSStringFromSelector(_cmd));
+    }
+}
+
+- (void)testBackgroundManagerReturnsExpectedClassForUploadTask {
+    if (self.backgroundManager) {
+        NSURLSessionTask *task = [self.backgroundManager uploadTaskWithRequest:[self _delayURLRequest]
+                                                                      fromFile:nil
+                                                                      progress:nil
+                                                             completionHandler:nil];
+        XCTAssert([NSStringFromClass([task class]) isEqualToString:@"__NSCFBackgroundUploadTask"]);
+    } else {
+        NSLog(@"Unable to run %@ because self.backgroundManager is nil", NSStringFromSelector(_cmd));
+    }
+}
+
+- (void)testBackgroundManagerReturnsExpectedClassForDownloadTask {
+    if (self.backgroundManager) {
+        NSURLSessionTask *task = [self.backgroundManager downloadTaskWithRequest:[self _delayURLRequest]
+                                                                        progress:nil
+                                                                     destination:nil
+                                                               completionHandler:nil];
+        XCTAssert([NSStringFromClass([task class]) isEqualToString:@"__NSCFBackgroundDownloadTask"]);
+    } else {
+        NSLog(@"Unable to run %@ because self.backgroundManager is nil", NSStringFromSelector(_cmd));
+    }
+}
+
+#pragma mark - private
+
+- (void)_testResumeNotificationForTask:(NSURLSessionTask *)task {
+    [self expectationForNotification:AFNetworkingTaskDidResumeNotification
+                              object:nil
+                             handler:nil];
+    [task resume];
+    [task suspend];
+    [task resume];
+    [self waitForExpectationsWithTimeout:2.0 handler:nil];
+    [task cancel];
+}
+
+- (void)_testSuspendNotificationForTask:(NSURLSessionTask *)task {
+    [self expectationForNotification:AFNetworkingTaskDidSuspendNotification
+                              object:nil
+                             handler:nil];
+    [task resume];
+    [task suspend];
+    [task resume];
+    [self waitForExpectationsWithTimeout:2.0 handler:nil];
+    [task cancel];
+}
+
+- (NSURLRequest *)_delayURLRequest {
+    return [NSURLRequest requestWithURL:[self.baseURL URLByAppendingPathComponent:@"delay/1"]];
+}
+
+- (IMP)_implementationForTask:(NSURLSessionTask  *)task selector:(SEL)selector {
+    return [self _implementationForClass:[task class] selector:selector];
+}
+
+- (IMP)_implementationForClass:(Class)class selector:(SEL)selector {
+    return method_getImplementation(class_getInstanceMethod(class, selector));
+}
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundeclared-selector"
+- (IMP)_originalAFResumeImplementation {
+    return method_getImplementation(class_getInstanceMethod(NSClassFromString(@"_AFURLSessionTaskSwizzling"), @selector(af_resume)));
+}
+
+- (IMP)_originalAFSuspendImplementation {
+    return method_getImplementation(class_getInstanceMethod(NSClassFromString(@"_AFURLSessionTaskSwizzling"), @selector(af_suspend)));
+}
+
+- (void)_testSwizzlingForTask:(NSURLSessionTask *)task {
+    [self _testSwizzlingForTaskClass:[task class]];
+}
+
+- (void)_testSwizzlingForTaskClass:(Class)class {
+    IMP originalAFResumeIMP = [self _originalAFResumeImplementation];
+    IMP originalAFSuspendIMP = [self _originalAFSuspendImplementation];
+    
+    IMP taskResumeImp = [self _implementationForClass:class selector:@selector(resume)];
+    IMP taskSuspendImp = [self _implementationForClass:class selector:@selector(suspend)];
+    XCTAssertEqual(originalAFResumeIMP, taskResumeImp, @"resume has not been properly swizzled for %@", NSStringFromClass(class));
+    XCTAssertEqual(originalAFSuspendIMP, taskSuspendImp, @"suspend has not been properly swizzled for %@", NSStringFromClass(class));
+    
+    IMP taskAFResumeImp = [self _implementationForClass:class selector:@selector(af_resume)];
+    IMP taskAFSuspendImp = [self _implementationForClass:class selector:@selector(af_suspend)];
+    XCTAssert(taskAFResumeImp != NULL, @"af_resume is nil. Something has not been been swizzled right for %@", NSStringFromClass(class));
+    XCTAssertNotEqual(taskAFResumeImp, taskResumeImp, @"af_resume has not been properly swizzled for %@", NSStringFromClass(class));
+    XCTAssert(taskAFSuspendImp != NULL, @"af_suspend is nil. Something has not been been swizzled right for %@", NSStringFromClass(class));
+    XCTAssertNotEqual(taskAFSuspendImp, taskSuspendImp, @"af_suspend has not been properly swizzled for %@", NSStringFromClass(class));
+}
+#pragma clang diagnostic pop
 
 @end


### PR DESCRIPTION
The `_AFStateObserving` category on `NSURLSessionTask` was recently changed (2.5.3) to remove a `dispatch_once` block.  I'm not sure what the intent of this change was, but one of the side effects is that the swizzling gets run multiple times (for every initialized subclass of `NSURLSessionTask`) and effectively "flip flops" the implementations of the original methods with the swizzled methods.

If this gets called an odd number of times, it happens to work.  However, if it gets called an even number of times, the net result is that the swizzled methods are never run.

If I log the classes this method is called on, here's the result I see when I first use a data task:

```
2015-05-06 14:17:00.788 class=__NSCFLocalDataTask, taskClass=__NSCFLocalSessionTask
2015-05-06 14:17:00.793 class=__NSCFLocalSessionTask, taskClass=__NSCFLocalSessionTask
2015-05-06 14:17:00.795 class=NSURLSessionTask, taskClass=__NSCFLocalSessionTask
2015-05-06 14:17:00.805 class=__NSCFLocalUploadTask, taskClass=__NSCFLocalSessionTask
2015-05-06 14:17:00.809 class=NSURLSessionDataTask, taskClass=__NSCFLocalSessionTask
```

So, this works fine for a while.  However, if I eventually _also_ use an upload task, I see this also:

```
2015-05-06 14:19:51.903 class=NSURLSessionUploadTask, taskClass=__NSCFLocalSessionTask
```

This last call swizzles the methods a sixth time, resulting in `resume`/`suspend` being set back to their original implementations.  