### PR TITLE
Updated Rakefile to run multiple OS versions of unit tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,13 +8,20 @@ namespace :test do
 
   desc "Run the AFNetworking Tests for iOS"
   task :ios => :prepare do
-    run_tests('iOS Tests', 'iphonesimulator')
+    simulators = get_ios_simulators
+    destinations = Array.new
+    simulators.each {|version, available_simulators| 
+      destinations.push("platform=iOS Simulator,OS=#{available_simulators[:runtime]},name=#{available_simulators[:device_names][0]}")
+      puts "Will run tests for iOS Simulator on iOS #{available_simulators[:runtime]} using #{available_simulators[:device_names][0]}"
+    }
+      
+    run_tests('iOS Tests', 'iphonesimulator', destinations)
     tests_failed('iOS') unless $?.success?
   end
 
   desc "Run the AFNetworking Tests for Mac OS X"
   task :osx => :prepare do
-    run_tests('OS X Tests', 'macosx')
+    run_tests('OS X Tests', 'macosx', ['platform=OS X,arch=x86_64'])
     tests_failed('OSX') unless $?.success?
   end
 end
@@ -30,8 +37,9 @@ task :default => 'test'
 
 private
 
-def run_tests(scheme, sdk)
-  sh("xcodebuild -workspace AFNetworking.xcworkspace -scheme '#{scheme}' -sdk '#{sdk}' -configuration Release clean test | xcpretty -c ; exit ${PIPESTATUS[0]}") rescue nil
+def run_tests(scheme, sdk, destinations)
+  destinations = destinations.map! { |destination| "-destination \'#{destination}\'" }.join(' ')
+  sh("xcodebuild -workspace AFNetworking.xcworkspace -scheme '#{scheme}' -sdk '#{sdk}' #{destinations} -configuration Release clean test | xcpretty -c ; exit ${PIPESTATUS[0]}") rescue nil
 end
 
 def is_mavericks_or_above
@@ -46,5 +54,32 @@ end
 
 def red(string)
  "\033[0;31m! #{string}"
+end
+
+def get_ios_simulators
+  device_section_regex = /== Devices ==(.*?)(?=(?===)|\z)/m
+  runtime_section_regex = /== Runtimes ==(.*?)(?=(?===)|\z)/m
+  runtime_version_regex  = /iOS (.*) \((.*) - .*?\)/
+  xcrun_output = `xcrun simctl list`
+  puts "Available iOS Simulators: \n#{xcrun_output}"
+  
+  simulators = Hash.new
+  runtimes_section = xcrun_output.scan(runtime_section_regex)[0]
+  runtimes_section[0].scan(runtime_version_regex) {|result|
+    simulators[result[0]] = Hash.new
+    simulators[result[0]][:runtime] = result[1]
+  }
+  
+  device_section = xcrun_output.scan(device_section_regex)[0]
+  version_regex = /-- iOS (.*?) --(.*?)(?=(?=-- .*? --)|\z)/m
+  simulator_name_regex = /(.*) \([A-F0-9-]*\) \(.*\)/
+  device_section[0].scan(version_regex) {|result| 
+    simulators[result[0]][:device_names] = Array.new
+    result[1].scan(simulator_name_regex) { |device_name_result| 
+      device_name = device_name_result[0].strip
+      simulators[result[0]][:device_names].push(device_name)
+    }
+   }
+   return simulators
 end
 


### PR DESCRIPTION
#2702 helped me discover our unit tests aren't running on all of the available simulators installed on Travis.

This PR attempts to rectify that by using the `-destination` parameter for Xcode build. You can get the list of available simulators on a machine by using `xcrun simctl list`, and I have some regex to pull out a simulator for each OS version.

This may still occasionally cause Travis to fail because of the issues with the reachability tests that are fixed in #2702. 

cc @cnoon @mattt  @kylef 
