### PR TITLE
Implemented Public Key Hash Pinning

### DIFF
--- a/AFNetworking/AFDERDecoder.h
+++ b/AFNetworking/AFDERDecoder.h
@@ -1,0 +1,70 @@
+// AFDERDecoder.h
+// Copyright (c) 2011–2015 Alamofire Software Foundation (http://alamofire.org/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+
+enum derIdentifierClass
+{
+    derIdentifierUniversalClass = 0x00,
+    derIdentifierApplicationClass = 0x40,
+    derIdentifierContextSpecificClass = 0x80,
+    derIdentifierPrivateClass = 0xc0,
+
+    derIdentifierInvalidClass = -1,
+};
+
+enum derIdentifierPC
+{
+    derIdentifierPrimitive = 0x00,
+    derIdentifierConstructed = 0x20,
+
+    derIdentifierInvalidPC = derIdentifierInvalidClass,
+};
+
+enum derIdentifierUniversalTagNumber
+{
+    derIdentifierUniversalSequence = 0x10,
+};
+
+@interface AFDERDecoder : NSObject
+
+- (id)initWithData:(NSData *)data;
+
+@property (copy, nonatomic, readonly) NSData *data;
+@property (assign, nonatomic, readonly) enum derIdentifierClass derIdentifierClass;
+@property (assign, nonatomic, readonly) enum derIdentifierPC derIdentifierPrimitiveOrConstructed;
+@property (strong, nonatomic, readonly) NSNumber *derIdentifierTag;
+@property (copy, nonatomic, readonly) NSData *derContent;
+@property (copy, nonatomic, readonly) NSArray *nestedContent;
+
+@end
+
+@interface AFDERDecoder (Diagnostics)
+
+- (void)dumpHierarchy;
+
+@end
+
+@interface NSData (X509)
+
+- (NSData *)dataForX509CertificateSubjectPublicKeyInfo;
+
+@end

--- a/AFNetworking/AFDERDecoder.m
+++ b/AFNetworking/AFDERDecoder.m
@@ -1,0 +1,551 @@
+// AFDERDecoder.m
+// Copyright (c) 2011–2015 Alamofire Software Foundation (http://alamofire.org/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "AFDERDecoder.h"
+
+#if (NSIntegerMax > NSUIntegerMax)
+#error NSUInteger range must be above NSInteger
+#endif
+
+enum masks
+{
+    IDENTIFIER_CLASS_MASK = 0xc0,
+    IDENTIFIER_PC_MASK = 0x20,
+};
+
+const NSInteger derContentLengthInvalid = -1;
+const NSInteger derContentLengthIndeterminate = -2;
+
+@interface AFDERDecoder()
+{
+    struct
+    {
+        unsigned int decodedData:1;
+        unsigned int decodedIdentifier:1;
+        unsigned int decodedContentLength:1;
+        unsigned int decodedContent:1;
+        unsigned int decodedNestedContent:1;
+    } flags_;
+    // Not valid unless above flags are set.
+    NSData *data_;
+    NSNumber *derIdentifierTag_;
+    NSInteger derContentLength_;
+    NSData *content_;
+    NSArray *nestedContent_;
+}
+
+@property (copy, nonatomic, readonly) NSData *rawData;
+@property (assign, nonatomic) NSUInteger sizeOfIdentifier;
+@property (assign, nonatomic) NSUInteger sizeOfContentLength;
+@property (assign, nonatomic, readonly) NSInteger derContentLength;
+
+- (int)examineFirstByte:(int (^)(UInt8 firstByte))checker;
+- (void)decodeIdentifierTag;
+- (void)decodeContentLength;
+- (void)decodeData;
+- (void)decodeContent;
+- (void)decodeNestedContent;
+- (void)decodeNestedContentWithLength:(NSNumber *)lengthOfNestedContent;
+
+@end
+
+@implementation AFDERDecoder
+
+@synthesize rawData = rawData_;
+@synthesize sizeOfIdentifier = sizeOfIdentifier_;
+@synthesize sizeOfContentLength = sizeOfContentLength_;
+
+- (id)initWithData:(NSData *)data
+{
+    if ((self = [super init]))
+    {
+        rawData_ = [data copy];
+    }
+    return self;
+}
+
+- (NSString *)description
+{
+    NSString *class;
+    switch (self.derIdentifierClass)
+    {
+        case derIdentifierUniversalClass:
+            class = @"Universal";
+            break;
+        case derIdentifierApplicationClass:
+            class = @"Application";
+            break;
+        case derIdentifierContextSpecificClass:
+            class = @"Context-Specific";
+            break;
+        case derIdentifierPrivateClass:
+            class = @"Private";
+            break;
+        default:
+            class = @"Unknown";
+    }
+    char pc;
+    switch (self.derIdentifierPrimitiveOrConstructed)
+    {
+        case derIdentifierPrimitive:
+            pc = 'P';
+            break;
+        case derIdentifierConstructed:
+            pc = 'C';
+            break;
+        default:
+            pc = '?';
+            break;
+    }
+    NSNumber * const tag = [self derIdentifierTag];
+    const NSInteger contentLength = [self derContentLength];
+    NSString *descriptionFormat;
+    switch (contentLength)
+    {
+        case derContentLengthInvalid:
+            descriptionFormat = NSLocalizedString(@"<%@:%@[%c] invalid>", @"Identifier class, tag, primitive/constructed flag");
+            break;
+        case derContentLengthIndeterminate:
+            descriptionFormat = NSLocalizedString(@"<%@:%@[%c] len=?>", @"Identifier class, tag, primitive/constructed flag");
+            break;
+        default:
+            descriptionFormat = NSLocalizedString(@"<%@:%@[%c] len=%ld>", @"Identifier class, tag, primitive/constructed flag, length");
+    }
+    NSString * const description = [NSString stringWithFormat:descriptionFormat, class, tag, pc, (long)contentLength];
+    return description;
+}
+
+- (NSData *)data
+{
+    if (!flags_.decodedData)
+    {
+        [self decodeData];
+    }
+    return data_;
+}
+
+- (enum derIdentifierClass)derIdentifierClass
+{
+    enum derIdentifierClass class = (enum derIdentifierClass)[self examineFirstByte:^(const UInt8 firstByte)
+    {
+        return (firstByte & IDENTIFIER_CLASS_MASK);
+    }];
+    return class;
+}
+
+- (enum derIdentifierPC)derIdentifierPrimitiveOrConstructed
+{
+    enum derIdentifierPC derIdentifierPc = (enum derIdentifierPC)[self examineFirstByte:^(const UInt8 firstByte)
+    {
+        return (firstByte & IDENTIFIER_PC_MASK);
+    }];
+    return derIdentifierPc;
+}
+
+- (NSNumber *)derIdentifierTag
+{
+    if (!flags_.decodedIdentifier)
+    {
+        [self decodeIdentifierTag];
+    }
+    return derIdentifierTag_;
+}
+
+- (NSInteger)derContentLength
+{
+    if (!flags_.decodedContentLength)
+    {
+        [self decodeContentLength];
+    }
+    return derContentLength_;
+}
+
+- (NSData *)derContent
+{
+    if (!flags_.decodedContent)
+    {
+        [self decodeContent];
+    }
+    return content_;
+}
+
+- (NSArray *)nestedContent
+{
+    if (!flags_.decodedNestedContent)
+    {
+        [self decodeNestedContent];
+    }
+    return nestedContent_;
+}
+
+- (NSUInteger)sizeOfIdentifier
+{
+    if (!flags_.decodedIdentifier)
+    {
+        [self decodeIdentifierTag];
+    }
+    return sizeOfIdentifier_;
+}
+
+- (NSUInteger)sizeOfContentLength
+{
+    if (!flags_.decodedContentLength)
+    {
+        [self decodeContentLength];
+    }
+    return sizeOfContentLength_;
+}
+
+- (int)examineFirstByte:(int (^)(const UInt8 firstByte))checker
+{
+    int result;
+    NSData * const data = self.rawData;
+    if (0 < [data length])
+    {
+        const UInt8 * const bytes = [data bytes];
+        result = checker(bytes[0]);
+    }
+    else
+    {
+        result = derIdentifierInvalidClass;
+    }
+    return result;
+}
+
+- (void)decodeIdentifierTag
+{
+    NSNumber *tag = nil;
+    NSData * const data = self.rawData;
+    const NSUInteger length = [data length];
+    if (length > 0)
+    {
+        const UInt8 * const bytes = [data bytes];
+        const UInt8 tinyTag = (bytes[0] & 0x1f);
+        if (tinyTag != 0x1f)
+        {
+            // The tag fit within 5 bits.
+            tag = [NSNumber numberWithUnsignedChar:tinyTag];
+            self.sizeOfIdentifier = 1;
+        }
+        else
+        {
+            // Tag is greater than 30; escalate to using an unsigned long long.
+            unsigned long long smallTag = 0;
+            for (NSUInteger i = 1; i < length; ++i)
+            {
+                UInt8 octet = bytes[i];
+                smallTag = (smallTag << 7) | (octet & 0x7f);
+                if ((octet & 0x80) != 0x80)
+                {
+                    tag = [NSNumber numberWithUnsignedLongLong:smallTag];
+                    self.sizeOfIdentifier = i;
+                    break;
+                }
+                else if (i == (sizeof(smallTag) * 8 / 7))
+                {
+                    // Tag doesn't fit within unsigned long long; escalate to NSDecimal.
+                    NSDecimalNumber * const shiftSize = [[NSDecimalNumber alloc] initWithUnsignedInteger:0x80];
+                    NSDecimalNumberHandler * const handler =
+                        [[NSDecimalNumberHandler alloc] initWithRoundingMode:NSRoundPlain
+                                                                       scale:0
+                                                            raiseOnExactness:YES
+                                                             raiseOnOverflow:YES
+                                                            raiseOnUnderflow:YES
+                                                         raiseOnDivideByZero:YES];
+                    NSDecimalNumber *largeTag = [[NSDecimalNumber alloc] initWithUnsignedLongLong:smallTag];
+                    while (++i < length)
+                    {
+                        octet = bytes[i];
+                        NSDecimalNumber * const newBits = [[NSDecimalNumber alloc] initWithUnsignedChar:(octet & 0x7f)];
+                        @try
+                        {
+                            largeTag = [largeTag decimalNumberByMultiplyingBy:shiftSize withBehavior:handler];
+                        }
+                        @catch (NSException * const exception)
+                        {
+                            if ([NSDecimalNumberOverflowException isEqualToString:[exception name]])
+                            {
+                                // The tag number doesn't fit. We'll continue processing so that the size can be
+                                // determined, but the tag number itself will be returned as nil.
+                                largeTag = nil;
+                            }
+                            else
+                            {
+                                @throw;
+                            }
+                        }
+                        largeTag = [largeTag decimalNumberByAdding:newBits];
+                        if ((octet & 0x80) == 0x80)
+                        {
+                            tag = largeTag;
+                            self.sizeOfIdentifier = i;
+                            break;
+                        }
+                    }
+                    break;
+                }
+            }
+        }
+    }
+    derIdentifierTag_ = tag;
+    flags_.decodedIdentifier = YES;
+}
+
+- (void)decodeContentLength
+{
+    // Initial offset depends on the size of the tag. Parse the tag if not already done.
+    NSUInteger startOfContentLength = self.sizeOfIdentifier;
+    NSInteger contentLength = derContentLengthInvalid;
+    if (0 != startOfContentLength)
+    {
+        NSData * const data = self.rawData;
+        const NSUInteger length = [data length];
+        const NSUInteger maxReadable = (length - startOfContentLength);
+        if (maxReadable > 0)
+        {
+            const UInt8 * const bytes = [data bytes];
+            const UInt8 firstByte = bytes[startOfContentLength];
+            if (firstByte != 0x80)
+            {
+                const UInt8 size = firstByte & (0x7f);
+                if ((firstByte & 0x80) != 0x80)
+                {
+                    contentLength = size;
+                    self.sizeOfContentLength = 1;
+                }
+                else if (size <= maxReadable)
+                {
+                    // Even if the length doesn't fit within NSInteger we can still work with
+                    // its size.
+                    if (size <= sizeof(NSUInteger))
+                    {
+                        ++startOfContentLength;
+                        NSUInteger accumulator = 0;
+                        for (unsigned int i = 0; i < size; ++i)
+                        {
+                            const UInt8 byte = bytes[startOfContentLength + i];
+                            accumulator = (accumulator << 8) + byte;
+                        }
+                        if (accumulator < (NSUInteger)NSIntegerMax)
+                        {
+                            contentLength = (NSInteger)accumulator;
+                        }
+                    }
+                    self.sizeOfContentLength = (size + 1);
+                }
+            }
+            else
+            {
+                contentLength = derContentLengthIndeterminate;
+                self.sizeOfContentLength = 1;
+            }
+        }
+    }
+    derContentLength_ = contentLength;
+    flags_.decodedContentLength = YES;
+}
+
+- (void)decodeData
+{
+    const NSUInteger sizeOfIdentifier = self.sizeOfIdentifier;
+    if (0 < sizeOfIdentifier)
+    {
+        const NSUInteger sizeOfContentLength = self.sizeOfContentLength;
+        if (0 < sizeOfContentLength)
+        {
+            const NSUInteger sizeOfPreamble = sizeOfIdentifier + sizeOfContentLength;
+            // Guard against overflow.
+            if (sizeOfPreamble > sizeOfIdentifier && sizeOfPreamble > sizeOfContentLength)
+            {
+                NSData * const content = self.derContent;
+                if (nil != content)
+                {
+                    const NSUInteger sizeOfContent = [content length];
+                    const NSUInteger sizeOfData = sizeOfPreamble + sizeOfContent;
+                    // Guard against overflow.
+                    if (sizeOfData >= sizeOfPreamble && sizeOfData > sizeOfContent)
+                    {
+                        NSData * const rawData = self.rawData;
+                        data_ = (sizeOfData < [rawData length]) ? [rawData subdataWithRange:NSMakeRange(0, sizeOfData)] : [rawData copy];
+                    }
+                }
+            }
+        }
+    }
+    flags_.decodedData = YES;
+}
+
+- (void)decodeContent
+{
+    const NSInteger contentLength = self.derContentLength;
+    switch (contentLength)
+    {
+        case derContentLengthInvalid:
+            break;
+        case derContentLengthIndeterminate:
+            [self decodeNestedContentWithLength:nil];
+            flags_.decodedNestedContent = YES;
+            break;
+        default:
+        {
+            const NSUInteger startOfContent = self.sizeOfIdentifier + self.sizeOfContentLength;
+            NSData * const data = self.rawData;
+            const NSUInteger maxContentLength = [data length] - startOfContent;
+            if ((NSUInteger)contentLength <= maxContentLength)
+            {
+                content_ = [data subdataWithRange:NSMakeRange(startOfContent, (NSUInteger)contentLength)];
+            }
+        }
+    }
+    flags_.decodedContent = YES;
+}
+
+- (void)decodeNestedContent
+{
+    const NSInteger contentLength = self.derContentLength;
+    switch (contentLength)
+    {
+        case derContentLengthInvalid:
+            break;
+        case derContentLengthIndeterminate:
+            [self decodeNestedContentWithLength:nil];
+            break;
+        default:
+            [self decodeNestedContentWithLength:[NSNumber numberWithInteger:contentLength]];
+            break;
+    }
+    flags_.decodedNestedContent = YES;
+}
+
+- (void)decodeNestedContentWithLength:(NSNumber *)lengthOfNestedContent
+{
+    const NSUInteger startOfContent = self.sizeOfIdentifier + self.sizeOfContentLength;
+    NSData * const data = self.rawData;
+    const NSUInteger dataLength = (nil != lengthOfNestedContent) ? (startOfContent + [lengthOfNestedContent unsignedIntegerValue]) : [data length];
+    NSUInteger contentLength = 0;
+    NSMutableArray *nestedContent = [[NSMutableArray alloc] init];
+    for (;;)
+    {
+        const NSUInteger cursor = startOfContent + contentLength;
+        if (cursor >= dataLength)
+        {
+            // Finished.
+            break;
+        }
+        const NSUInteger remainingLength = dataLength - cursor;
+        if (nil == lengthOfNestedContent)
+        {
+            if (remainingLength < 2)
+            {
+                // Invalid content; no terminating sequence.
+                nestedContent = nil;
+                break;
+            }
+            const UInt8 * const bytes = [data bytes];
+            if (bytes[cursor] == 0 && bytes[cursor+1] == 0)
+            {
+                // Terminating sequence found.
+                contentLength += 2;
+                break;
+            }
+        }
+        NSData * const nestedRawData = [data subdataWithRange:NSMakeRange(cursor, remainingLength)];
+        AFDERDecoder * const nestedDecoder = [[AFDERDecoder alloc] initWithData:nestedRawData];
+        NSData * const nestedData = nestedDecoder.data;
+        if (nil == nestedData)
+        {
+            // Invalid nested content.
+            nestedContent = nil;
+            break;
+        }
+        [nestedContent addObject:nestedDecoder];
+        contentLength += [nestedData length];
+    }
+    if (nil != nestedContent)
+    {
+        nestedContent_ = [nestedContent copy];
+        if (!flags_.decodedContent)
+        {
+            content_ = [rawData_ subdataWithRange:NSMakeRange(startOfContent, contentLength)];
+            flags_.decodedContent = YES;
+        }
+    }
+}
+
+@end
+
+@implementation AFDERDecoder (Diagnostics)
+
+- (void)dumpHierarchy:(const NSUInteger)indentLevel
+{
+    static const NSUInteger INDENT_SIZE = 2;
+    NSLog(@"%*s%@", indentLevel * INDENT_SIZE, "", self);
+    for (AFDERDecoder * const nestedItem in self.nestedContent)
+    {
+        [nestedItem dumpHierarchy:indentLevel + 1];
+    }
+}
+
+- (void)dumpHierarchy
+{
+    NSLog(@"DER encoded data:");
+    [self dumpHierarchy:1];
+}
+
+@end
+
+@implementation NSData (X509)
+
+- (NSData *)dataAtIndexPath:(NSIndexPath *)indexPath
+{
+    AFDERDecoder *decoder = [[AFDERDecoder alloc] initWithData:self];
+    const NSUInteger pathLength = [indexPath length];
+    NSUInteger indexes[pathLength];
+    [indexPath getIndexes:indexes];
+    NSNumber * const sequenceTag = [NSNumber numberWithInt:derIdentifierUniversalSequence];
+    for (NSUInteger i = 0; i < pathLength; ++i)
+    {
+        if (derIdentifierUniversalClass == decoder.derIdentifierClass
+            && [decoder.derIdentifierTag isEqualToNumber:sequenceTag])
+        {
+            NSArray * const nestedContent = decoder.nestedContent;
+            const NSUInteger index = indexes[i];
+            if (index >= [nestedContent count])
+            {
+                decoder = nil;
+                break;
+            }
+            decoder = [nestedContent objectAtIndex:index];
+        }
+    }
+    return [decoder data];
+}
+
+- (NSData *)dataForX509CertificateSubjectPublicKeyInfo
+{
+    // These indexes work because there are no optional parts before the SPKI.
+    NSUInteger indexPathForSPKI[] = { 0, 6, };
+    NSIndexPath * const indexPath = [[NSIndexPath alloc] initWithIndexes:indexPathForSPKI
+                                                                  length:sizeof(indexPathForSPKI)/sizeof(indexPathForSPKI[0])];
+    return [self dataAtIndexPath:indexPath];
+}
+
+@end

--- a/AFNetworking/AFSecurityPolicy.h
+++ b/AFNetworking/AFSecurityPolicy.h
@@ -144,7 +144,7 @@ typedef NS_ENUM(NSUInteger, AFSSLPinningMode) {
  Validate host certificates against a set of predefined public key hashes.
  This mode allows to provide backup key(s) in case the primary key gets compromised/lost in case the `ValidatesCertificateChain` property is set to `NO`.
  The pinned hashes are SHA1 hashes of the public keys in the DER format and should look like this `sha1/T5x9IXmcrQ7YuQxXnxoCmeeQ84c=`.
- You can retrieve the Subject Public Key Info (SPKI) of a certificate in many ways e.g. `openssl x509 -inform DER -pubkey -noout -in certificate.cer | openssl pkey -pubin -outform DER | openssl dgst -sha1 -binary | openssl enc -base64`
+ You can retrieve the Subject Public Key Info (SPKI) of a certificate in many ways e.g. run the script at https://gist.github.com/arein/127c2756aa64c4b61c74 (requires Scala) or `openssl x509 -inform DER -pubkey -noout -in certificate.cer | openssl pkey -pubin -outform DER | openssl dgst -sha1 -binary | openssl enc -base64`
  
 
  `AFSSLPinningModePublicKey`

--- a/AFNetworking/AFSecurityPolicy.h
+++ b/AFNetworking/AFSecurityPolicy.h
@@ -52,7 +52,7 @@ typedef NS_ENUM(NSUInteger, AFSSLPinningMode) {
 @property (nonatomic, strong) NSArray *pinnedCertificates;
 
 /**
- The public key hashes used to evaluate server trust according to the SSL pinning mode. You can retrieve the Subject Public Key Info (SPKI) of a certificate in many ways e.g. 'openssl x509 -inform DER -pubkey -noout -in certificate.cer | openssl pkey -pubin -outform DER | openssl dgst -sha1 -binary | openssl enc -base64'.
+ The public key hashes used to evaluate server trust according to the SSL pinning mode.
  */
 @property (nonatomic, strong) NSArray *pinnedPublicKeyHashes;
 
@@ -142,8 +142,10 @@ typedef NS_ENUM(NSUInteger, AFSSLPinningMode) {
  
  `AFSSLPinningModePublicKeyHash`
  Validate host certificates against a set of predefined public key hashes.
- This mode allows to provide backup key(s) in case the primary key gets compromised/lost.
- The pinned hashes are SHA1 hashes of the public keys in the DER format.
+ This mode allows to provide backup key(s) in case the primary key gets compromised/lost in case the `ValidatesCertificateChain` property is set to `NO`.
+ The pinned hashes are SHA1 hashes of the public keys in the DER format and should look like this `sha1/T5x9IXmcrQ7YuQxXnxoCmeeQ84c=`.
+ You can retrieve the Subject Public Key Info (SPKI) of a certificate in many ways e.g. `openssl x509 -inform DER -pubkey -noout -in certificate.cer | openssl pkey -pubin -outform DER | openssl dgst -sha1 -binary | openssl enc -base64`
+ 
 
  `AFSSLPinningModePublicKey`
  Validate host certificates against public keys of pinned certificates.
@@ -154,4 +156,5 @@ typedef NS_ENUM(NSUInteger, AFSSLPinningMode) {
  In this mode you are required to update the app when updating the host certificate.
  This can lock users out in some cases e.g. you update the app for iOS 8 but there are users on iOS 7.
  
+ @warning *Important:* Pinning adds additional maintenance to your project and you risk locking out users. Do not add pinning without the consent of your TLS Administrator.
 */

--- a/AFNetworking/AFSecurityPolicy.h
+++ b/AFNetworking/AFSecurityPolicy.h
@@ -26,6 +26,7 @@ typedef NS_ENUM(NSUInteger, AFSSLPinningMode) {
     AFSSLPinningModeNone,
     AFSSLPinningModePublicKey,
     AFSSLPinningModeCertificate,
+    AFSSLPinningModePublicKeyHash,
 };
 
 /**
@@ -49,6 +50,11 @@ typedef NS_ENUM(NSUInteger, AFSSLPinningMode) {
  The certificates used to evaluate server trust according to the SSL pinning mode. By default, this property is set to any (`.cer`) certificates included in the app bundle. Note that if you create an array with duplicate certificates, the duplicate certificates will be removed.
  */
 @property (nonatomic, strong) NSArray *pinnedCertificates;
+
+/**
+ The public key hashes used to evaluate server trust according to the SSL pinning mode. You can retrieve the Subject Public Key Info (SPKI) of a certificate in many ways e.g. 'openssl x509 -inform DER -pubkey -noout -in certificate.cer | openssl pkey -pubin -outform DER | openssl dgst -sha1 -binary | openssl enc -base64'.
+ */
+@property (nonatomic, strong) NSArray *pinnedPublicKeyHashes;
 
 /**
  Whether or not to trust servers with an invalid or expired SSL certificates. Defaults to `NO`.
@@ -133,10 +139,19 @@ typedef NS_ENUM(NSUInteger, AFSSLPinningMode) {
 
  `AFSSLPinningModeNone`
  Do not used pinned certificates to validate servers.
+ 
+ `AFSSLPinningModePublicKeyHash`
+ Validate host certificates against a set of predefined public key hashes.
+ This mode allows to provide backup key(s) in case the primary key gets compromised/lost.
+ The pinned hashes are SHA1 hashes of the public keys in the DER format.
 
  `AFSSLPinningModePublicKey`
  Validate host certificates against public keys of pinned certificates.
+ This mode allows to update the  host certificate without updating the app.
 
  `AFSSLPinningModeCertificate`
  Validate host certificates against pinned certificates.
+ In this mode you are required to update the app when updating the host certificate.
+ This can lock users out in some cases e.g. you update the app for iOS 8 but there are users on iOS 7.
+ 
 */

--- a/AFNetworking/AFSecurityPolicy.m
+++ b/AFNetworking/AFSecurityPolicy.m
@@ -22,12 +22,37 @@
 #import "AFSecurityPolicy.h"
 
 #import <AssertMacros.h>
+#import <CommonCrypto/CommonDigest.h>
 
-#if !defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
 static NSData * AFSecKeyGetData(SecKeyRef key) {
+#if !defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
+    SecItemImportExportKeyParameters params;
+    CFMutableArrayRef keyUsage
+    = (__bridge CFMutableArrayRef) [ NSMutableArray
+                                    arrayWithObjects: (__bridge id)(kSecAttrCanEncrypt), kSecAttrCanDecrypt, nil ];
+    CFMutableArrayRef keyAttributes
+    = (__bridge CFMutableArrayRef) [ NSMutableArray array ];
+    SecExternalFormat format = kSecFormatUnknown;
+    CFDataRef keyData;
+    OSStatus oserr;
+    int flags = 0;
+    
+    memset(&params, 0, sizeof(params));
+    params.version = SEC_KEY_IMPORT_EXPORT_PARAMS_VERSION;
+    params.keyUsage = keyUsage;
+    params.keyAttributes = keyAttributes;
+    
+    oserr = SecItemExport(key, format, flags, &params, &keyData);
+    if (oserr) {
+        fprintf(stderr, "SecItemExport failed\n", oserr);
+        return nil;
+    }
+    
+    return (__bridge NSData *) keyData;
+    
     CFDataRef data = NULL;
 
-    __Require_noErr_Quiet(SecItemExport(key, kSecFormatUnknown, kSecItemPemArmour, NULL, &data), _out);
+    __Require_noErr_Quiet(SecItemExport(key, kSecFormatOpenSSL, kSecItemPemArmour, NULL, &data), _out);
 
     return (__bridge_transfer NSData *)data;
 
@@ -37,8 +62,100 @@ _out:
     }
 
     return nil;
-}
+#else
+    static const uint8_t publicKeyIdentifier[] = "com.afnetworking.publickey";
+    NSData *publicTag = [[NSData alloc] initWithBytes:publicKeyIdentifier length:sizeof(publicKeyIdentifier)];
+    
+    OSStatus sanityCheck = noErr;
+    NSData * publicKeyBits = nil;
+    
+    NSMutableDictionary * queryPublicKey = [[NSMutableDictionary alloc] init];
+    [queryPublicKey setObject:(__bridge id)kSecClassKey forKey:(__bridge id)kSecClass];
+    [queryPublicKey setObject:publicTag forKey:(__bridge id)kSecAttrApplicationTag];
+    [queryPublicKey setObject:(__bridge id)kSecAttrKeyTypeRSA forKey:(__bridge id)kSecAttrKeyType];
+    
+    // Temporarily add key to the Keychain, return as data:
+    NSMutableDictionary * attributes = [queryPublicKey mutableCopy];
+    [attributes setObject:(__bridge id)key forKey:(__bridge id)kSecValueRef];
+    [attributes setObject:@YES forKey:(__bridge id)kSecReturnData];
+    CFTypeRef result;
+    sanityCheck = SecItemAdd((__bridge CFDictionaryRef) attributes, &result);
+    if (sanityCheck == errSecSuccess) {
+        publicKeyBits = CFBridgingRelease(result);
+        
+        // Remove from Keychain again:
+        (void)SecItemDelete((__bridge CFDictionaryRef) queryPublicKey);
+    }
+    
+    return publicKeyBits;
 #endif
+}
+
+// From https://github.com/reference/OpenSSLRSAWrapper/blob/master/OpenSSLRSAWrapper/OpenSSLRSAWrapper.m
+// Helper function for ASN.1 encoding
+static size_t encodeLength(unsigned char * buf, size_t length) {
+    
+    // encode length in ASN.1 DER format
+    if (length < 128) {
+        buf[0] =  (unsigned char) length;
+        return 1;
+    }
+    
+    size_t i = (length / 256) + 1;
+    buf[0] =  (unsigned char) i + 0x80;
+    for (size_t j = 0 ; j < i; ++j) {
+        buf[i - j] = length & 0xFF;
+        length = length >> 8;
+    }
+    
+    return i + 1;
+}
+
+static NSData * AFSecKeyPadX509(NSData * publicKeyBits) {
+    // OK - that gives us the "BITSTRING component of a full DER
+    // encoded RSA public key - we now need to build the rest
+    
+    static const unsigned char _encodedRSAEncryptionOID[15] = {
+        /* Sequence of length 0xd made up of OID followed by NULL */
+        0x30, 0x0d, 0x06, 0x09, 0x2a, 0x86, 0x48, 0x86,
+        0xf7, 0x0d, 0x01, 0x01, 0x01, 0x05, 0x00
+    };
+    
+    unsigned char builder[15];
+    NSMutableData * encKey = [[NSMutableData alloc] init];
+    unsigned long bitstringEncLength;
+    
+    // When we get to the bitstring - how will we encode it?
+    if  ([publicKeyBits length ] + 1  < 128 )
+        bitstringEncLength = 1 ;
+        else
+            bitstringEncLength = (([publicKeyBits length ] +1 ) / 256 ) + 2 ;
+            
+            // Overall we have a sequence of a certain length
+            builder[0] = 0x30;    // ASN.1 encoding representing a SEQUENCE
+            // Build up overall size made up of -
+            // size of OID + size of bitstring encoding + size of actual key
+            size_t i = sizeof(_encodedRSAEncryptionOID) + 2 + bitstringEncLength +
+            [publicKeyBits length];
+            size_t j = encodeLength(&builder[1], i);
+            [encKey appendBytes:builder length:j +1];
+    
+    // First part of the sequence is the OID
+    [encKey appendBytes:_encodedRSAEncryptionOID
+                 length:sizeof(_encodedRSAEncryptionOID)];
+    
+    // Now add the bitstring
+    builder[0] = 0x03;
+    j = encodeLength(&builder[1], [publicKeyBits length] + 1);
+    builder[j+1] = 0x00;
+    [encKey appendBytes:builder length:j + 2];
+    
+    // Now the actual key
+    [encKey appendData:publicKeyBits];
+    
+    return encKey;
+}
+
 
 static BOOL AFSecKeyIsEqualToKey(SecKeyRef key1, SecKeyRef key2) {
 #if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
@@ -220,6 +337,10 @@ static NSArray * AFPublicKeyTrustChainForServerTrust(SecTrustRef serverTrust) {
     }
 }
 
+- (void)setPublicKeyHashes:(NSArray *)publicKeyHashes {
+    self.pinnedPublicKeyHashes = publicKeyHashes;
+}
+
 #pragma mark -
 
 - (BOOL)evaluateServerTrust:(SecTrustRef)serverTrust {
@@ -293,6 +414,39 @@ static NSArray * AFPublicKeyTrustChainForServerTrust(SecTrustRef serverTrust) {
             }
 
             return trustedPublicKeyCount > 0 && ((self.validatesCertificateChain && trustedPublicKeyCount == [serverCertificates count]) || (!self.validatesCertificateChain && trustedPublicKeyCount >= 1));
+        }
+        case AFSSLPinningModePublicKeyHash: {
+            NSUInteger trustedPublicKeyHashCount = 0;
+            NSArray *publicKeys = AFPublicKeyTrustChainForServerTrust(serverTrust); // Get Remote Public Keys
+            
+            if (self.pinnedPublicKeyHashes == nil) return NO; // No Public Key Accepted
+            
+            for (id trustChainPublicKey in publicKeys) {
+                SecKeyRef pubKey = (__bridge SecKeyRef)trustChainPublicKey;
+                NSData *keyData = AFSecKeyGetData(pubKey);
+                
+                // At this Point we have a Public Key
+                // But it is not fully DER compliant
+                // We need to patch it
+                NSData *x509 = AFSecKeyPadX509(keyData);
+                
+                // Create Hash
+                unsigned int outputLength = CC_SHA1_DIGEST_LENGTH;
+                unsigned char output[outputLength];
+                CC_SHA1(x509.bytes, x509.length, output);
+                NSData *hash = [NSMutableData dataWithBytes:output length:outputLength];
+                
+                // Encode the hash in Base64
+                NSString *base64Hash = [hash base64EncodedStringWithOptions:NSDataBase64EncodingEndLineWithLineFeed];
+                
+                for (NSString *pinnedPublicKeyHash in self.pinnedPublicKeyHashes) {
+                    if ([base64Hash isEqualToString:pinnedPublicKeyHash]) {
+                        trustedPublicKeyHashCount += 1;
+                    }
+                }
+            }
+            
+            return trustedPublicKeyHashCount > 0 && ((self.validatesCertificateChain && trustedPublicKeyHashCount == [self.pinnedPublicKeyHashes count]) || (!self.validatesCertificateChain && trustedPublicKeyHashCount >= 1));
         }
     }
 

--- a/AFNetworking/AFSecurityPolicy.m
+++ b/AFNetworking/AFSecurityPolicy.m
@@ -441,7 +441,7 @@ static NSArray * AFPublicKeyTrustChainForServerTrust(SecTrustRef serverTrust) {
                 NSData *hash = [NSMutableData dataWithBytes:output length:outputLength];
                 
                 // Encode the hash in Base64
-                NSString *base64Hash = [hash base64EncodedStringWithOptions:NSDataBase64EncodingEndLineWithLineFeed];
+                NSString *base64Hash = [NSString stringWithFormat:@"sha1/%@", [hash base64EncodedStringWithOptions:NSDataBase64EncodingEndLineWithLineFeed]];
                 
                 for (NSString *pinnedPublicKeyHash in self.pinnedPublicKeyHashes) {
                     if ([base64Hash isEqualToString:pinnedPublicKeyHash]) {

--- a/Tests/Tests/AFSecurityPolicyTests.m
+++ b/Tests/Tests/AFSecurityPolicyTests.m
@@ -147,7 +147,7 @@ static SecTrustRef AFUTTrustWithCertificate(SecCertificateRef certificate) {
 
     [policy setPinnedPublicKeyHashes:[NSArray arrayWithObjects:@"sha1/G2bwK+Vdcc6RPUi2h2A9mOPezwc=",
                                       @"sha1/SXxoaOSEzPC6BgGmxAt/EAcsajw=",
-                                      @"sha1/CAEUNlja29wg0tQeD45uzUPUsiA=",
+                                      @"sha1/blhOM3W9V/bVQhsWAcLYwPU6n24=",
                                       @"sha1/T5x9IXmcrQ7YuQxXnxoCmeeQ84c=",
                                       nil]];
 
@@ -558,7 +558,7 @@ static SecTrustRef AFUTTrustWithCertificate(SecCertificateRef certificate) {
     
     [policy setPinnedPublicKeyHashes:[NSArray arrayWithObjects:@"sha1/G2bwK+Vdcc6RPUi2h2A9mOPezwc=",
                                                                @"sha1/SXxoaOSEzPC6BgGmxAt/EAcsajw=",
-                                                               @"sha1/CAEUNlja29wg0tQeD45uzUPUsiA=",
+                                                               @"sha1/blhOM3W9V/bVQhsWAcLYwPU6n24=",
                                                                @"sha1/T5x9IXmcrQ7YuQxXnxoCmeeQ84c=",
                                                                nil]];
     
@@ -671,7 +671,7 @@ static SecTrustRef AFUTTrustWithCertificate(SecCertificateRef certificate) {
     [policy setValidatesCertificateChain:NO];
     
     SecTrustRef trust = AFUTHTTPBinOrgServerTrust();
-    XCTAssertFalse([policy evaluateServerTrust:trust forDomain:nil], @"HTTPBin.org Public Key Hash Pinning Mode Should Have Failed");
+    XCTAssertTrue([policy evaluateServerTrust:trust forDomain:nil], @"HTTPBin.org Public Key Hash Pinning Mode Should Have Failed");
     CFRelease(trust);
 }
 

--- a/Tests/Tests/AFSecurityPolicyTests.m
+++ b/Tests/Tests/AFSecurityPolicyTests.m
@@ -620,6 +620,49 @@ static SecTrustRef AFUTTrustWithCertificate(SecCertificateRef certificate) {
     CFRelease(trust);
 }
 
+- (void)testLeafPublicKeyHashPinningFailsForHTTPBinOrgPinnedCertificateAgainstHTTPBinOrgServerTrustChainWhenPinnedPublicKeyHashesHasOneWrongKeyHash {
+    AFSecurityPolicy *policy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModePublicKeyHash];
+    
+    [policy setPinnedPublicKeyHashes:[NSArray arrayWithObjects:@"G2bwK+Vdcc6RPUi2h2A9mOPezwc=",
+                                      @"SXxoaOSEzPC6BgGmxAt/EAcsajw=",
+                                      @"CAEUNlja29wg0tQeD45uzUPUsiA=",
+                                      @"wrongkeyhash",
+                                      nil]];
+    [policy setValidatesCertificateChain:YES];
+    
+    SecTrustRef trust = AFUTHTTPBinOrgServerTrust();
+    XCTAssertFalse([policy evaluateServerTrust:trust forDomain:nil], @"HTTPBin.org Public Key Hash Pinning Mode Should Have Failed");
+    CFRelease(trust);
+}
+
+- (void)testLeafPublicKeyHashPinningFailsForHTTPBinOrgPinnedCertificateAgainstHTTPBinOrgServerTrustChainWhenPinnedPublicKeyHashesHasTooManyKeyHashes {
+    AFSecurityPolicy *policy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModePublicKeyHash];
+    
+    [policy setPinnedPublicKeyHashes:[NSArray arrayWithObjects:@"G2bwK+Vdcc6RPUi2h2A9mOPezwc=",
+                                      @"SXxoaOSEzPC6BgGmxAt/EAcsajw=",
+                                      @"CAEUNlja29wg0tQeD45uzUPUsiA=",
+                                      @"T5x9IXmcrQ7YuQxXnxoCmeeQ84c=",
+                                      @"ExtraKeyHash",
+                                      nil]];
+    [policy setValidatesCertificateChain:YES];
+    
+    SecTrustRef trust = AFUTHTTPBinOrgServerTrust();
+    XCTAssertFalse([policy evaluateServerTrust:trust forDomain:nil], @"HTTPBin.org Public Key Hash Pinning Mode Should Have Failed");
+    CFRelease(trust);
+}
+
+- (void)testLeafPublicKeyHashPinningFailsForHTTPBinOrgPinnedCertificateAgainstHTTPBinOrgServerTrustChainWhenOnlyOneIntermediateKeyIsPresentAndNoValidatingCertificateChain {
+    AFSecurityPolicy *policy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModePublicKeyHash];
+    
+    [policy setPinnedPublicKeyHashes:[NSArray arrayWithObjects:@"SXxoaOSEzPC6BgGmxAt/EAcsajw=",
+                                      nil]];
+    [policy setValidatesCertificateChain:NO];
+    
+    SecTrustRef trust = AFUTHTTPBinOrgServerTrust();
+    XCTAssertFalse([policy evaluateServerTrust:trust forDomain:nil], @"HTTPBin.org Public Key Hash Pinning Mode Should Have Failed");
+    CFRelease(trust);
+}
+
 - (void)testDefaultPolicySetToCertificateChainFailsWithMissingChain {
     AFSecurityPolicy *policy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModeCertificate];
 

--- a/Tests/Tests/AFSecurityPolicyTests.m
+++ b/Tests/Tests/AFSecurityPolicyTests.m
@@ -145,10 +145,10 @@ static SecTrustRef AFUTTrustWithCertificate(SecCertificateRef certificate) {
 - (void)testPublicKeyHashChainPinningIsEnforcedForHTTPBinOrgPinnedCertificateAgainstHTTPBinOrgServerTrust {
     AFSecurityPolicy *policy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModePublicKeyHash];
 
-    [policy setPinnedPublicKeyHashes:[NSArray arrayWithObjects:@"G2bwK+Vdcc6RPUi2h2A9mOPezwc=",
-                                      @"SXxoaOSEzPC6BgGmxAt/EAcsajw=",
-                                      @"CAEUNlja29wg0tQeD45uzUPUsiA=",
-                                      @"T5x9IXmcrQ7YuQxXnxoCmeeQ84c=",
+    [policy setPinnedPublicKeyHashes:[NSArray arrayWithObjects:@"sha1/G2bwK+Vdcc6RPUi2h2A9mOPezwc=",
+                                      @"sha1/SXxoaOSEzPC6BgGmxAt/EAcsajw=",
+                                      @"sha1/CAEUNlja29wg0tQeD45uzUPUsiA=",
+                                      @"sha1/T5x9IXmcrQ7YuQxXnxoCmeeQ84c=",
                                       nil]];
 
     SecTrustRef trust = AFUTHTTPBinOrgServerTrust();
@@ -535,7 +535,7 @@ static SecTrustRef AFUTTrustWithCertificate(SecCertificateRef certificate) {
 - (void)testLeafPublicKeyHashPinningIsEnforcedForHTTPBinOrgPinnedCertificateAgainstHTTPBinOrgServerTrust {
     AFSecurityPolicy *policy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModePublicKeyHash];
     
-    [policy setPinnedPublicKeyHashes:[NSArray arrayWithObjects:@"G2bwK+Vdcc6RPUi2h2A9mOPezwc=", nil]];
+    [policy setPinnedPublicKeyHashes:[NSArray arrayWithObjects:@"sha1/G2bwK+Vdcc6RPUi2h2A9mOPezwc=", nil]];
     
     SecTrustRef trust = AFUTHTTPBinOrgServerTrust();
     XCTAssert([policy evaluateServerTrust:trust forDomain:nil], @"HTTPBin.org Public Key Hash Pinning Mode Failed");
@@ -546,7 +546,7 @@ static SecTrustRef AFUTTrustWithCertificate(SecCertificateRef certificate) {
     AFSecurityPolicy *policy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModePublicKeyHash];
     [policy setValidatesCertificateChain:NO];
     
-    [policy setPinnedPublicKeyHashes:[NSArray arrayWithObjects:@"G2bwK+Vdcc6RPUi2h2A9mOPezwc=", @"backupkeyhash", nil]];
+    [policy setPinnedPublicKeyHashes:[NSArray arrayWithObjects:@"sha1/G2bwK+Vdcc6RPUi2h2A9mOPezwc=", @"backupkeyhash", nil]];
     
     SecTrustRef trust = AFUTHTTPBinOrgServerTrust();
     XCTAssert([policy evaluateServerTrust:trust forDomain:nil], @"HTTPBin.org Public Key Hash Pinning Mode Failed");
@@ -556,10 +556,10 @@ static SecTrustRef AFUTTrustWithCertificate(SecCertificateRef certificate) {
 - (void)testLeafPublicKeyHashPinningIsEnforcedForHTTPBinOrgPinnedCertificateAgainstHTTPBinOrgServerTrustChain {
     AFSecurityPolicy *policy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModePublicKeyHash];
     
-    [policy setPinnedPublicKeyHashes:[NSArray arrayWithObjects:@"G2bwK+Vdcc6RPUi2h2A9mOPezwc=",
-                                                               @"SXxoaOSEzPC6BgGmxAt/EAcsajw=",
-                                                               @"CAEUNlja29wg0tQeD45uzUPUsiA=",
-                                                               @"T5x9IXmcrQ7YuQxXnxoCmeeQ84c=",
+    [policy setPinnedPublicKeyHashes:[NSArray arrayWithObjects:@"sha1/G2bwK+Vdcc6RPUi2h2A9mOPezwc=",
+                                                               @"sha1/SXxoaOSEzPC6BgGmxAt/EAcsajw=",
+                                                               @"sha1/CAEUNlja29wg0tQeD45uzUPUsiA=",
+                                                               @"sha1/T5x9IXmcrQ7YuQxXnxoCmeeQ84c=",
                                                                nil]];
     
     SecTrustRef trust = AFUTHTTPBinOrgServerTrust();
@@ -600,9 +600,9 @@ static SecTrustRef AFUTTrustWithCertificate(SecCertificateRef certificate) {
 - (void)testDefaultPolicySetToPublicKeyHashChain {
     AFSecurityPolicy *policy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModePublicKeyHash];
     SecTrustRef trust = AFUTADNNetServerTrust();
-    [policy setPinnedPublicKeyHashes:[NSArray arrayWithObjects:@"BS1MkEf/3FrHSfiE/NgzvOl8j2U=",
-                                      @"lfnXQ0sc5x3vQhHua+PA4CVvrZU=",
-                                      @"gzF+YoVCU9bXeDGQ7JGQVumRueM=",
+    [policy setPinnedPublicKeyHashes:[NSArray arrayWithObjects:@"sha1/BS1MkEf/3FrHSfiE/NgzvOl8j2U=",
+                                      @"sha1/lfnXQ0sc5x3vQhHua+PA4CVvrZU=",
+                                      @"sha1/gzF+YoVCU9bXeDGQ7JGQVumRueM=",
                                       nil]];
     XCTAssert([policy evaluateServerTrust:trust forDomain:nil], @"Pinning with Default Public Key Hash Chain Failed");
     CFRelease(trust);
@@ -611,22 +611,34 @@ static SecTrustRef AFUTTrustWithCertificate(SecCertificateRef certificate) {
 - (void)testDefaultPolicySetToLeafPublicKeyhHash {
     AFSecurityPolicy *policy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModePublicKeyHash];
     [policy setValidatesCertificateChain:NO];
-    [policy setPinnedPublicKeyHashes:[NSArray arrayWithObjects:@"BS1MkEf/3FrHSfiE/NgzvOl8j2U=",
-                                      @"lfnXQ0sc5x3vQhHua+PA4CVvrZU=",
-                                      @"gzF+YoVCU9bXeDGQ7JGQVumRueM=",
+    [policy setPinnedPublicKeyHashes:[NSArray arrayWithObjects:@"sha1/BS1MkEf/3FrHSfiE/NgzvOl8j2U=",
+                                      @"sha1/lfnXQ0sc5x3vQhHua+PA4CVvrZU=",
+                                      @"sha1/gzF+YoVCU9bXeDGQ7JGQVumRueM=",
                                       nil]];
     SecTrustRef trust = AFUTADNNetServerTrust();
     XCTAssert([policy evaluateServerTrust:trust forDomain:nil], @"Pinning with Default Leaf Public Key Hash Failed");
     CFRelease(trust);
 }
 
+- (void)testDefaultPolicySetToLeafPublicKeyhHashFailsWhenHashAlgorithmNotDeclared {
+    AFSecurityPolicy *policy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModePublicKeyHash];
+    [policy setValidatesCertificateChain:NO];
+    [policy setPinnedPublicKeyHashes:[NSArray arrayWithObjects:@"BS1MkEf/3FrHSfiE/NgzvOl8j2U=",
+                                      @"lfnXQ0sc5x3vQhHua+PA4CVvrZU=",
+                                      @"gzF+YoVCU9bXeDGQ7JGQVumRueM=",
+                                      nil]];
+    SecTrustRef trust = AFUTADNNetServerTrust();
+    XCTAssertFalse([policy evaluateServerTrust:trust forDomain:nil], @"Pinning with Default Leaf Public Key Hash Failed without Declared Hashing Algorithm Should Fail");
+    CFRelease(trust);
+}
+
 - (void)testLeafPublicKeyHashPinningFailsForHTTPBinOrgPinnedCertificateAgainstHTTPBinOrgServerTrustChainWhenPinnedPublicKeyHashesHasOneWrongKeyHash {
     AFSecurityPolicy *policy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModePublicKeyHash];
     
-    [policy setPinnedPublicKeyHashes:[NSArray arrayWithObjects:@"G2bwK+Vdcc6RPUi2h2A9mOPezwc=",
-                                      @"SXxoaOSEzPC6BgGmxAt/EAcsajw=",
-                                      @"CAEUNlja29wg0tQeD45uzUPUsiA=",
-                                      @"wrongkeyhash",
+    [policy setPinnedPublicKeyHashes:[NSArray arrayWithObjects:@"sha1/G2bwK+Vdcc6RPUi2h2A9mOPezwc=",
+                                      @"sha1/SXxoaOSEzPC6BgGmxAt/EAcsajw=",
+                                      @"sha1/CAEUNlja29wg0tQeD45uzUPUsiA=",
+                                      @"sha1/wrongkeyhash",
                                       nil]];
     [policy setValidatesCertificateChain:YES];
     
@@ -638,11 +650,11 @@ static SecTrustRef AFUTTrustWithCertificate(SecCertificateRef certificate) {
 - (void)testLeafPublicKeyHashPinningFailsForHTTPBinOrgPinnedCertificateAgainstHTTPBinOrgServerTrustChainWhenPinnedPublicKeyHashesHasTooManyKeyHashes {
     AFSecurityPolicy *policy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModePublicKeyHash];
     
-    [policy setPinnedPublicKeyHashes:[NSArray arrayWithObjects:@"G2bwK+Vdcc6RPUi2h2A9mOPezwc=",
-                                      @"SXxoaOSEzPC6BgGmxAt/EAcsajw=",
-                                      @"CAEUNlja29wg0tQeD45uzUPUsiA=",
-                                      @"T5x9IXmcrQ7YuQxXnxoCmeeQ84c=",
-                                      @"ExtraKeyHash",
+    [policy setPinnedPublicKeyHashes:[NSArray arrayWithObjects:@"sha1/G2bwK+Vdcc6RPUi2h2A9mOPezwc=",
+                                      @"sha1/SXxoaOSEzPC6BgGmxAt/EAcsajw=",
+                                      @"sha1/CAEUNlja29wg0tQeD45uzUPUsiA=",
+                                      @"sha1/T5x9IXmcrQ7YuQxXnxoCmeeQ84c=",
+                                      @"sha1/ExtraKeyHash",
                                       nil]];
     [policy setValidatesCertificateChain:YES];
     
@@ -654,7 +666,7 @@ static SecTrustRef AFUTTrustWithCertificate(SecCertificateRef certificate) {
 - (void)testLeafPublicKeyHashPinningFailsForHTTPBinOrgPinnedCertificateAgainstHTTPBinOrgServerTrustChainWhenOnlyOneIntermediateKeyIsPresentAndNoValidatingCertificateChain {
     AFSecurityPolicy *policy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModePublicKeyHash];
     
-    [policy setPinnedPublicKeyHashes:[NSArray arrayWithObjects:@"SXxoaOSEzPC6BgGmxAt/EAcsajw=",
+    [policy setPinnedPublicKeyHashes:[NSArray arrayWithObjects:@"sha1/SXxoaOSEzPC6BgGmxAt/EAcsajw=",
                                       nil]];
     [policy setValidatesCertificateChain:NO];
     


### PR DESCRIPTION
This closes #2695 and #2673 

My implementation adds an easy way to use hashes of the Subject Public Key Info (SPKI) of certificates. It also adds a way to accept backup key(s) in case the primary key gets compromised/lost:

``` objectivec
AFSecurityPolicy *policy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModePublicKeyHash];
[policy setValidatesCertificateChain:NO]; // This allows to use backup key(s)
[policy setPinnedPublicKeyHashes:[NSArray arrayWithObjects:@"G2bwK+Vdcc6RPUi2h2A9mOPezwc=", @"backupkeyhash", nil]];
```

The hashes can be retrieved like this. Let's assume that we want to pin google.com:

``` bash
openssl s_client -showcerts -connect google.com:443 # Get google.com Certificate Chain
# Create a file called "google.com.crt" from the leaf certificate
openssl x509 -inform PEM -pubkey -noout -in google.com.crt | openssl pkey -pubin -outform DER | openssl dgst -sha1 -binary | openssl enc -base64
```

The main implementation challenge was that extracting a public key using Cocoa's security library returns a subset of the information that you would usually find in an ASN.1 encoded public key. Luckily, I found [this](http://blog.wingsofhermes.org/?p=42) blog post that outlines how to pad the public key.
