### PR TITLE
Allow same library for app and extensions.

### DIFF
--- a/AFNetworking/AFURLConnectionOperation.h
+++ b/AFNetworking/AFURLConnectionOperation.h
@@ -73,10 +73,6 @@
 
  Connections will be validated on all matching certificates with a `.cer` extension in the bundle root.
 
- ## App Extensions
-
- When using AFNetworking in an App Extension, `#define AF_APP_EXTENSIONS` to avoid using unavailable APIs.
-
  ## NSCoding & NSCopying Conformance
 
  `AFURLConnectionOperation` conforms to the `NSCoding` and `NSCopying` protocols, allowing operations to be archived to disk, and copied in memory, respectively. However, because of the intrinsic limitations of capturing the exact state of an operation at a particular moment, there are some important caveats to keep in mind:
@@ -270,8 +266,8 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param handler A handler to be called shortly before the application’s remaining background time reaches 0. The handler is wrapped in a block that cancels the operation, and cleans up and marks the end of execution, unlike the `handler` parameter in `UIApplication -beginBackgroundTaskWithExpirationHandler:`, which expects this to be done in the handler itself. The handler is called synchronously on the main thread, thus blocking the application’s suspension momentarily while the application is notified.
   */
-#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && !defined(AF_APP_EXTENSIONS)
-- (void)setShouldExecuteAsBackgroundTaskWithExpirationHandler:(nullable void (^)(void))handler;
+#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
+- (void)setShouldExecuteAsBackgroundTaskWithExpirationHandler:(nullable void (^)(void))handler NS_EXTENSION_UNAVAILABLE_IOS("Not available in app extensions.");
 #endif
 
 ///---------------------------------

--- a/AFNetworking/AFURLConnectionOperation.m
+++ b/AFNetworking/AFURLConnectionOperation.m
@@ -37,12 +37,6 @@ typedef NS_ENUM(NSInteger, AFOperationState) {
     AFOperationFinishedState    = 3,
 };
 
-#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && !defined(AF_APP_EXTENSIONS)
-typedef UIBackgroundTaskIdentifier AFBackgroundTaskIdentifier;
-#else
-typedef id AFBackgroundTaskIdentifier;
-#endif
-
 static dispatch_group_t url_request_operation_completion_group() {
     static dispatch_group_t af_url_request_operation_completion_group;
     static dispatch_once_t onceToken;
@@ -72,6 +66,7 @@ typedef void (^AFURLConnectionOperationProgressBlock)(NSUInteger bytes, long lon
 typedef void (^AFURLConnectionOperationAuthenticationChallengeBlock)(NSURLConnection *connection, NSURLAuthenticationChallenge *challenge);
 typedef NSCachedURLResponse * (^AFURLConnectionOperationCacheResponseBlock)(NSURLConnection *connection, NSCachedURLResponse *cachedResponse);
 typedef NSURLRequest * (^AFURLConnectionOperationRedirectResponseBlock)(NSURLConnection *connection, NSURLRequest *request, NSURLResponse *redirectResponse);
+typedef void (^AFURLConnectionOperationBackgroundTaskCleanupBlock)();
 
 static inline NSString * AFKeyPathFromOperationState(AFOperationState state) {
     switch (state) {
@@ -144,7 +139,7 @@ static inline BOOL AFStateTransitionIsValid(AFOperationState fromState, AFOperat
 @property (readwrite, nonatomic, copy) NSString *responseString;
 @property (readwrite, nonatomic, assign) NSStringEncoding responseStringEncoding;
 @property (readwrite, nonatomic, assign) long long totalBytesRead;
-@property (readwrite, nonatomic, assign) AFBackgroundTaskIdentifier backgroundTaskIdentifier;
+@property (readwrite, nonatomic, copy) AFURLConnectionOperationBackgroundTaskCleanupBlock backgroundTaskCleanup;
 @property (readwrite, nonatomic, copy) AFURLConnectionOperationProgressBlock uploadProgress;
 @property (readwrite, nonatomic, copy) AFURLConnectionOperationProgressBlock downloadProgress;
 @property (readwrite, nonatomic, copy) AFURLConnectionOperationAuthenticationChallengeBlock authenticationChallenge;
@@ -214,13 +209,10 @@ static inline BOOL AFStateTransitionIsValid(AFOperationState fromState, AFOperat
         [_outputStream close];
         _outputStream = nil;
     }
-
-#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && !defined(AF_APP_EXTENSIONS)
-    if (_backgroundTaskIdentifier) {
-        [[UIApplication sharedApplication] endBackgroundTask:_backgroundTaskIdentifier];
-        _backgroundTaskIdentifier = UIBackgroundTaskInvalid;
+    
+    if (_backgroundTaskCleanup) {
+        _backgroundTaskCleanup();
     }
-#endif
 }
 
 #pragma mark -
@@ -293,13 +285,22 @@ static inline BOOL AFStateTransitionIsValid(AFOperationState fromState, AFOperat
     [self.lock unlock];
 }
 
-#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && !defined(AF_APP_EXTENSIONS)
+#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
 - (void)setShouldExecuteAsBackgroundTaskWithExpirationHandler:(void (^)(void))handler {
     [self.lock lock];
-    if (!self.backgroundTaskIdentifier) {
+    if (!self.backgroundTaskCleanup) {
         UIApplication *application = [UIApplication sharedApplication];
+        UIBackgroundTaskIdentifier __block backgroundTaskIdentifier = UIBackgroundTaskInvalid;
         __weak __typeof(self)weakSelf = self;
-        self.backgroundTaskIdentifier = [application beginBackgroundTaskWithExpirationHandler:^{
+        
+        self.backgroundTaskCleanup = ^(){
+            if (backgroundTaskIdentifier != UIBackgroundTaskInvalid) {
+                [[UIApplication sharedApplication] endBackgroundTask:backgroundTaskIdentifier];
+                backgroundTaskIdentifier = UIBackgroundTaskInvalid;
+            }
+        };
+        
+        backgroundTaskIdentifier = [application beginBackgroundTaskWithExpirationHandler:^{
             __strong __typeof(weakSelf)strongSelf = weakSelf;
 
             if (handler) {
@@ -308,9 +309,7 @@ static inline BOOL AFStateTransitionIsValid(AFOperationState fromState, AFOperat
 
             if (strongSelf) {
                 [strongSelf cancel];
-
-                [application endBackgroundTask:strongSelf.backgroundTaskIdentifier];
-                strongSelf.backgroundTaskIdentifier = UIBackgroundTaskInvalid;
+                strongSelf.backgroundTaskCleanup();
             }
         }];
     }

--- a/Example/AFNetworking iOS Example.xcodeproj/project.pbxproj
+++ b/Example/AFNetworking iOS Example.xcodeproj/project.pbxproj
@@ -11,6 +11,32 @@
 		2982AD3217107C0000FFF048 /* adn.cer in Resources */ = {isa = PBXBuildFile; fileRef = 2982AD3117107C0000FFF048 /* adn.cer */; };
 		E8C2E7A618970EE40097DCC8 /* root_ca.cer in Resources */ = {isa = PBXBuildFile; fileRef = E8C2E7A418970EE00097DCC8 /* root_ca.cer */; };
 		E8C2E7A718970EE40097DCC8 /* digicert_ca_3.cer in Resources */ = {isa = PBXBuildFile; fileRef = E8C2E7A518970EE00097DCC8 /* digicert_ca_3.cer */; };
+		EB1E89E91B669AB400B40518 /* profile-image-placeholder.png in Resources */ = {isa = PBXBuildFile; fileRef = F8FA94CC150F094D00ED4EAD /* profile-image-placeholder.png */; };
+		EB1E89EA1B669AB800B40518 /* profile-image-placeholder@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = F8FA94CD150F094D00ED4EAD /* profile-image-placeholder@2x.png */; };
+		EBE11F4A1B62EDD200753127 /* NotificationCenter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EBE11F491B62EDD200753127 /* NotificationCenter.framework */; };
+		EBE11F501B62EDD200753127 /* TodayViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = EBE11F4F1B62EDD200753127 /* TodayViewController.m */; };
+		EBE11F521B62EDD200753127 /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = EBE11F511B62EDD200753127 /* MainInterface.storyboard */; };
+		EBE11F561B62EDD200753127 /* Today Extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = EBE11F481B62EDD200753127 /* Today Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		EBE11F5A1B666EA200753127 /* Post.m in Sources */ = {isa = PBXBuildFile; fileRef = F8FA9493150EF97E00ED4EAD /* Post.m */; };
+		EBE11F5B1B666EA200753127 /* User.m in Sources */ = {isa = PBXBuildFile; fileRef = F8FA9496150EF98800ED4EAD /* User.m */; };
+		EBE11F5C1B66716F00753127 /* AFAppDotNetAPIClient.m in Sources */ = {isa = PBXBuildFile; fileRef = F8FA9490150EF8C100ED4EAD /* AFAppDotNetAPIClient.m */; };
+		EBE11F5D1B66716F00753127 /* AFURLConnectionOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F8FA94AC150EFEC100ED4EAD /* AFURLConnectionOperation.m */; };
+		EBE11F5E1B66716F00753127 /* AFHTTPRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F8FA949F150EFEC100ED4EAD /* AFHTTPRequestOperation.m */; };
+		EBE11F5F1B66716F00753127 /* AFHTTPRequestOperationManager.m in Sources */ = {isa = PBXBuildFile; fileRef = F8B3944C17DBF9B900430F25 /* AFHTTPRequestOperationManager.m */; };
+		EBE11F601B66716F00753127 /* AFURLSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = F86A37DF177397D900407E52 /* AFURLSessionManager.m */; };
+		EBE11F611B66716F00753127 /* AFHTTPSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = F8FA949D150EFEC100ED4EAD /* AFHTTPSessionManager.m */; };
+		EBE11F621B66716F00753127 /* AFURLRequestSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = F8D5499C17DB0EFE00BFF314 /* AFURLRequestSerialization.m */; };
+		EBE11F631B66716F00753127 /* AFURLResponseSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = F8D5499917DB0EF300BFF314 /* AFURLResponseSerialization.m */; };
+		EBE11F641B66716F00753127 /* AFNetworkReachabilityManager.m in Sources */ = {isa = PBXBuildFile; fileRef = F8D5499F17DB1C9100BFF314 /* AFNetworkReachabilityManager.m */; };
+		EBE11F651B66716F00753127 /* AFSecurityPolicy.m in Sources */ = {isa = PBXBuildFile; fileRef = 297F56C917A9B1AB0014D95C /* AFSecurityPolicy.m */; };
+		EBE11F661B66716F00753127 /* AFNetworkActivityIndicatorManager.m in Sources */ = {isa = PBXBuildFile; fileRef = F8E02CEC177A8B710087BB23 /* AFNetworkActivityIndicatorManager.m */; };
+		EBE11F671B66716F00753127 /* UIActivityIndicatorView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = F8E02CEE177A8B710087BB23 /* UIActivityIndicatorView+AFNetworking.m */; };
+		EBE11F681B66716F00753127 /* UIAlertView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = F8CBED2217D595320088ADC0 /* UIAlertView+AFNetworking.m */; };
+		EBE11F691B66716F00753127 /* UIButton+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = F8E02CF0177A8B710087BB23 /* UIButton+AFNetworking.m */; };
+		EBE11F6A1B66716F00753127 /* UIImageView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = F8E02CF2177A8B710087BB23 /* UIImageView+AFNetworking.m */; };
+		EBE11F6B1B66716F00753127 /* UIProgressView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = F8E02CF4177A8B710087BB23 /* UIProgressView+AFNetworking.m */; };
+		EBE11F6C1B66716F00753127 /* UIRefreshControl+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = F8664A1F18AA99F5007D8554 /* UIRefreshControl+AFNetworking.m */; };
+		EBE11F6D1B66716F00753127 /* UIWebView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = F8E02CF6177A8B710087BB23 /* UIWebView+AFNetworking.m */; };
 		F8129C7415910C37009BFE23 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = F8129C7215910C37009BFE23 /* AppDelegate.m */; };
 		F818101615E6A0C600EF93C2 /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 50ABD6EC159FC2CE001BE42C /* MobileCoreServices.framework */; };
 		F8664A2018AA99F5007D8554 /* UIRefreshControl+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = F8664A1F18AA99F5007D8554 /* UIRefreshControl+AFNetworking.m */; };
@@ -50,6 +76,30 @@
 		F8FA94D1150F094D00ED4EAD /* profile-image-placeholder@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = F8FA94CD150F094D00ED4EAD /* profile-image-placeholder@2x.png */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		EBE11F531B62EDD200753127 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F8E469571395739C00DB05C8 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = EBE11F471B62EDD200753127;
+			remoteInfo = "Today Extension";
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		EBE11F551B62EDD200753127 /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				EBE11F561B62EDD200753127 /* Today Extension.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
 		297F56C817A9B1AB0014D95C /* AFSecurityPolicy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFSecurityPolicy.h; sourceTree = "<group>"; };
 		297F56C917A9B1AB0014D95C /* AFSecurityPolicy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFSecurityPolicy.m; sourceTree = "<group>"; };
@@ -58,6 +108,12 @@
 		55BDA27E17F5A434005DB933 /* UIKit+AFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIKit+AFNetworking.h"; sourceTree = "<group>"; };
 		E8C2E7A418970EE00097DCC8 /* root_ca.cer */ = {isa = PBXFileReference; lastKnownFileType = file; path = root_ca.cer; sourceTree = SOURCE_ROOT; };
 		E8C2E7A518970EE00097DCC8 /* digicert_ca_3.cer */ = {isa = PBXFileReference; lastKnownFileType = file; path = digicert_ca_3.cer; sourceTree = SOURCE_ROOT; };
+		EBE11F481B62EDD200753127 /* Today Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "Today Extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
+		EBE11F491B62EDD200753127 /* NotificationCenter.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = NotificationCenter.framework; path = System/Library/Frameworks/NotificationCenter.framework; sourceTree = SDKROOT; };
+		EBE11F4D1B62EDD200753127 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		EBE11F4E1B62EDD200753127 /* TodayViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TodayViewController.h; sourceTree = "<group>"; };
+		EBE11F4F1B62EDD200753127 /* TodayViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TodayViewController.m; sourceTree = "<group>"; };
+		EBE11F511B62EDD200753127 /* MainInterface.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = MainInterface.storyboard; sourceTree = "<group>"; };
 		F8129C3815910830009BFE23 /* Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Prefix.pch; sourceTree = SOURCE_ROOT; };
 		F8129C7215910C37009BFE23 /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = SOURCE_ROOT; };
 		F8129C7315910C37009BFE23 /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = SOURCE_ROOT; };
@@ -123,6 +179,14 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		EBE11F451B62EDD200753127 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EBE11F4A1B62EDD200753127 /* NotificationCenter.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F8E4695D1395739C00DB05C8 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -140,6 +204,25 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		EBE11F4B1B62EDD200753127 /* Today Extension */ = {
+			isa = PBXGroup;
+			children = (
+				EBE11F4E1B62EDD200753127 /* TodayViewController.h */,
+				EBE11F4F1B62EDD200753127 /* TodayViewController.m */,
+				EBE11F511B62EDD200753127 /* MainInterface.storyboard */,
+				EBE11F4C1B62EDD200753127 /* Supporting Files */,
+			);
+			path = "Today Extension";
+			sourceTree = "<group>";
+		};
+		EBE11F4C1B62EDD200753127 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				EBE11F4D1B62EDD200753127 /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
 		F8D549A117DBE52C00BFF314 /* Serialization */ = {
 			isa = PBXGroup;
 			children = (
@@ -260,6 +343,7 @@
 				F8E4696A1395739D00DB05C8 /* Classes */,
 				F8E469ED1395812A00DB05C8 /* Images */,
 				F8E469931395743A00DB05C8 /* Vendor */,
+				EBE11F4B1B62EDD200753127 /* Today Extension */,
 				F8E469631395739D00DB05C8 /* Frameworks */,
 				F8E469611395739C00DB05C8 /* Products */,
 			);
@@ -272,6 +356,7 @@
 			isa = PBXGroup;
 			children = (
 				F8E469601395739C00DB05C8 /* AFNetworking iOS Example.app */,
+				EBE11F481B62EDD200753127 /* Today Extension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -286,6 +371,7 @@
 				F8E469641395739D00DB05C8 /* UIKit.framework */,
 				F8E469661395739D00DB05C8 /* Foundation.framework */,
 				F8E469681395739D00DB05C8 /* CoreGraphics.framework */,
+				EBE11F491B62EDD200753127 /* NotificationCenter.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -364,6 +450,23 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		EBE11F471B62EDD200753127 /* Today Extension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = EBE11F591B62EDD200753127 /* Build configuration list for PBXNativeTarget "Today Extension" */;
+			buildPhases = (
+				EBE11F441B62EDD200753127 /* Sources */,
+				EBE11F451B62EDD200753127 /* Frameworks */,
+				EBE11F461B62EDD200753127 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Today Extension";
+			productName = "Today Extension";
+			productReference = EBE11F481B62EDD200753127 /* Today Extension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 		F8E4695F1395739C00DB05C8 /* AFNetworking iOS Example */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = F8E469811395739D00DB05C8 /* Build configuration list for PBXNativeTarget "AFNetworking iOS Example" */;
@@ -371,10 +474,12 @@
 				F8E4695C1395739C00DB05C8 /* Sources */,
 				F8E4695D1395739C00DB05C8 /* Frameworks */,
 				F8E4695E1395739C00DB05C8 /* Resources */,
+				EBE11F551B62EDD200753127 /* Embed App Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				EBE11F541B62EDD200753127 /* PBXTargetDependency */,
 			);
 			name = "AFNetworking iOS Example";
 			productName = AFNetworkingExample;
@@ -390,6 +495,9 @@
 				LastUpgradeCheck = 0500;
 				ORGANIZATIONNAME = Gowalla;
 				TargetAttributes = {
+					EBE11F471B62EDD200753127 = {
+						CreatedOnToolsVersion = 6.4;
+					};
 					F8E4695F1395739C00DB05C8 = {
 						SystemCapabilities = {
 							com.apple.BackgroundModes = {
@@ -412,11 +520,22 @@
 			projectRoot = "";
 			targets = (
 				F8E4695F1395739C00DB05C8 /* AFNetworking iOS Example */,
+				EBE11F471B62EDD200753127 /* Today Extension */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		EBE11F461B62EDD200753127 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EBE11F521B62EDD200753127 /* MainInterface.storyboard in Resources */,
+				EB1E89EA1B669AB800B40518 /* profile-image-placeholder@2x.png in Resources */,
+				EB1E89E91B669AB400B40518 /* profile-image-placeholder.png in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F8E4695E1395739C00DB05C8 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -437,6 +556,34 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		EBE11F441B62EDD200753127 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EBE11F5C1B66716F00753127 /* AFAppDotNetAPIClient.m in Sources */,
+				EBE11F5D1B66716F00753127 /* AFURLConnectionOperation.m in Sources */,
+				EBE11F5E1B66716F00753127 /* AFHTTPRequestOperation.m in Sources */,
+				EBE11F5F1B66716F00753127 /* AFHTTPRequestOperationManager.m in Sources */,
+				EBE11F601B66716F00753127 /* AFURLSessionManager.m in Sources */,
+				EBE11F611B66716F00753127 /* AFHTTPSessionManager.m in Sources */,
+				EBE11F621B66716F00753127 /* AFURLRequestSerialization.m in Sources */,
+				EBE11F631B66716F00753127 /* AFURLResponseSerialization.m in Sources */,
+				EBE11F641B66716F00753127 /* AFNetworkReachabilityManager.m in Sources */,
+				EBE11F651B66716F00753127 /* AFSecurityPolicy.m in Sources */,
+				EBE11F661B66716F00753127 /* AFNetworkActivityIndicatorManager.m in Sources */,
+				EBE11F671B66716F00753127 /* UIActivityIndicatorView+AFNetworking.m in Sources */,
+				EBE11F681B66716F00753127 /* UIAlertView+AFNetworking.m in Sources */,
+				EBE11F691B66716F00753127 /* UIButton+AFNetworking.m in Sources */,
+				EBE11F6A1B66716F00753127 /* UIImageView+AFNetworking.m in Sources */,
+				EBE11F6B1B66716F00753127 /* UIProgressView+AFNetworking.m in Sources */,
+				EBE11F6C1B66716F00753127 /* UIRefreshControl+AFNetworking.m in Sources */,
+				EBE11F6D1B66716F00753127 /* UIWebView+AFNetworking.m in Sources */,
+				EBE11F501B62EDD200753127 /* TodayViewController.m in Sources */,
+				EBE11F5A1B666EA200753127 /* Post.m in Sources */,
+				EBE11F5B1B666EA200753127 /* User.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F8E4695C1395739C00DB05C8 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -470,7 +617,92 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		EBE11F541B62EDD200753127 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = EBE11F471B62EDD200753127 /* Today Extension */;
+			targetProxy = EBE11F531B62EDD200753127 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
 /* Begin XCBuildConfiguration section */
+		EBE11F571B62EDD200753127 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = "Today Extension/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.4;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		EBE11F581B62EDD200753127 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = "Today Extension/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.4;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 		F8E4697F1395739D00DB05C8 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -479,7 +711,6 @@
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = DEBUG;
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				GCC_VERSION = com.apple.compilers.llvmgcc42;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
@@ -493,7 +724,6 @@
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_VERSION = com.apple.compilers.llvmgcc42;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
@@ -530,7 +760,6 @@
 				GCC_SHORT_ENUMS = YES;
 				GCC_TREAT_IMPLICIT_FUNCTION_DECLARATIONS_AS_ERRORS = YES;
 				GCC_TREAT_INCOMPATIBLE_POINTER_TYPE_WARNINGS_AS_ERRORS = YES;
-				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS = YES;
 				GCC_WARN_ABOUT_MISSING_NEWLINE = YES;
@@ -583,7 +812,6 @@
 				GCC_SHORT_ENUMS = YES;
 				GCC_TREAT_IMPLICIT_FUNCTION_DECLARATIONS_AS_ERRORS = YES;
 				GCC_TREAT_INCOMPATIBLE_POINTER_TYPE_WARNINGS_AS_ERRORS = YES;
-				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS = YES;
 				GCC_WARN_ABOUT_MISSING_NEWLINE = YES;
@@ -613,6 +841,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		EBE11F591B62EDD200753127 /* Build configuration list for PBXNativeTarget "Today Extension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				EBE11F571B62EDD200753127 /* Debug */,
+				EBE11F581B62EDD200753127 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		F8E4695A1395739C00DB05C8 /* Build configuration list for PBXProject "AFNetworking iOS Example" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Example/Classes/Models/Post.m
+++ b/Example/Classes/Models/Post.m
@@ -63,3 +63,30 @@
 }
 
 @end
+
+@implementation Post (NSCoding)
+
+- (void)encodeWithCoder:(NSCoder *)aCoder {
+    [aCoder encodeInteger:(NSInteger)self.postID forKey:@"AF.postID"];
+    [aCoder encodeObject:self.text forKey:@"AF.text"];
+    [aCoder encodeObject:self.user forKey:@"AF.user"];
+}
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder {
+    self = [super init];
+    if (!self) {
+        return nil;
+    }
+    
+    self.postID = (NSUInteger)[aDecoder decodeIntegerForKey:@"AF.postID"];
+    self.text = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"AF.text"];
+    self.user = [aDecoder decodeObjectOfClass:[User class] forKey:@"AF.user"];
+    
+    return self;
+}
+
++ (BOOL)supportsSecureCoding {
+    return YES;
+}
+
+@end

--- a/Example/Classes/Models/User.h
+++ b/Example/Classes/Models/User.h
@@ -37,3 +37,6 @@ extern NSString * const kUserProfileImageDidLoadNotification;
 - (instancetype)initWithAttributes:(NSDictionary *)attributes;
 
 @end
+
+@interface User (NSCoding) <NSSecureCoding>
+@end

--- a/Example/Classes/Models/User.m
+++ b/Example/Classes/Models/User.m
@@ -98,3 +98,30 @@ NSString * const kUserProfileImageDidLoadNotification = @"com.alamofire.user.pro
 #endif
 
 @end
+
+@implementation User (NSCoding)
+
+- (void)encodeWithCoder:(NSCoder *)aCoder {
+    [aCoder encodeInteger:(NSInteger)self.userID forKey:@"AF.userID"];
+    [aCoder encodeObject:self.username forKey:@"AF.username"];
+    [aCoder encodeObject:self.avatarImageURLString forKey:@"AF.avatarImageURLString"];
+}
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder {
+    self = [super init];
+    if (!self) {
+        return nil;
+    }
+    
+    self.userID = (NSUInteger)[aDecoder decodeIntegerForKey:@"AF.userID"];
+    self.username = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"AF.username"];
+    self.avatarImageURLString = [aDecoder decodeObjectOfClass:[User class] forKey:@"AF.avatarImageURLString"];
+    
+    return self;
+}
+
++ (BOOL)supportsSecureCoding {
+    return YES;
+}
+
+@end

--- a/Example/Today Extension/Info.plist
+++ b/Example/Today Extension/Info.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>Most recent post</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.alamofire.AFNetworking-iOS-Example.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionMainStoryboard</key>
+		<string>MainInterface</string>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widget-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/Example/Today Extension/MainInterface.storyboard
+++ b/Example/Today Extension/MainInterface.storyboard
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7706" systemVersion="14E17e" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="M4Y-Lb-cyx">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
+        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
+    </dependencies>
+    <scenes>
+        <!--Today View Controller-->
+        <scene sceneID="cwh-vc-ff4">
+            <objects>
+                <viewController id="M4Y-Lb-cyx" customClass="TodayViewController" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="Ft6-oW-KC0"/>
+                        <viewControllerLayoutGuide type="bottom" id="FKl-LY-JtV"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" simulatedAppContext="notificationCenter" id="S3S-Oj-5AN">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="77"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="top" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" preferredMaxLayoutWidth="280" translatesAutoresizingMaskIntoConstraints="NO" id="GcN-lo-r42">
+                                <rect key="frame" x="52" y="8" width="248" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" cocoaTouchSystemColor="lightTextColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="1D3-Uq-R0m">
+                                <rect key="frame" x="0.0" y="8" width="44" height="44"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="1D3-Uq-R0m" secondAttribute="height" multiplier="1:1" id="OOU-Wu-VBT"/>
+                                    <constraint firstAttribute="width" constant="44" id="oKN-nk-EPb"/>
+                                </constraints>
+                            </imageView>
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="top" horizontalHuggingPriority="251" verticalCompressionResistancePriority="749" text="Body" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nb9-rZ-77O">
+                                <rect key="frame" x="52" y="37" width="248" height="32"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                <color key="textColor" cocoaTouchSystemColor="lightTextColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <constraints>
+                            <constraint firstItem="FKl-LY-JtV" firstAttribute="top" secondItem="nb9-rZ-77O" secondAttribute="bottom" constant="8" symbolic="YES" id="6EU-G7-ITc"/>
+                            <constraint firstItem="GcN-lo-r42" firstAttribute="trailing" secondItem="nb9-rZ-77O" secondAttribute="trailing" id="GoN-80-qe0"/>
+                            <constraint firstItem="1D3-Uq-R0m" firstAttribute="top" secondItem="Ft6-oW-KC0" secondAttribute="bottom" constant="8" symbolic="YES" id="Ksc-Wn-Vaa"/>
+                            <constraint firstAttribute="trailing" secondItem="GcN-lo-r42" secondAttribute="trailing" constant="20" symbolic="YES" id="L8K-9R-egU"/>
+                            <constraint firstItem="nb9-rZ-77O" firstAttribute="top" secondItem="GcN-lo-r42" secondAttribute="bottom" constant="8" symbolic="YES" id="STa-nM-6Ka"/>
+                            <constraint firstItem="FKl-LY-JtV" firstAttribute="top" relation="greaterThanOrEqual" secondItem="1D3-Uq-R0m" secondAttribute="bottom" priority="750" constant="8" symbolic="YES" id="V92-2W-P0k"/>
+                            <constraint firstItem="GcN-lo-r42" firstAttribute="leading" secondItem="1D3-Uq-R0m" secondAttribute="trailing" constant="8" id="jlo-tA-InD"/>
+                            <constraint firstItem="GcN-lo-r42" firstAttribute="top" secondItem="Ft6-oW-KC0" secondAttribute="bottom" constant="8" symbolic="YES" id="mYS-Cv-VNx"/>
+                            <constraint firstItem="GcN-lo-r42" firstAttribute="leading" secondItem="nb9-rZ-77O" secondAttribute="leading" id="qQK-vz-KFP"/>
+                            <constraint firstItem="1D3-Uq-R0m" firstAttribute="leading" secondItem="S3S-Oj-5AN" secondAttribute="leading" id="u6r-uv-gIO"/>
+                        </constraints>
+                    </view>
+                    <extendedEdge key="edgesForExtendedLayout"/>
+                    <nil key="simulatedStatusBarMetrics"/>
+                    <nil key="simulatedTopBarMetrics"/>
+                    <nil key="simulatedBottomBarMetrics"/>
+                    <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+                    <size key="freeformSize" width="320" height="77"/>
+                    <connections>
+                        <outlet property="bodyLabel" destination="nb9-rZ-77O" id="pGo-AS-EIL"/>
+                        <outlet property="imageView" destination="1D3-Uq-R0m" id="uwG-Yd-6vZ"/>
+                        <outlet property="titleLabel" destination="GcN-lo-r42" id="PAx-AS-fBR"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="vXp-U4-Rya" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="516" y="284"/>
+        </scene>
+    </scenes>
+    <simulatedMetricsContainer key="defaultSimulatedMetrics">
+        <simulatedStatusBarMetrics key="statusBar"/>
+        <simulatedOrientationMetrics key="orientation"/>
+        <simulatedScreenMetrics key="destination" type="retina4"/>
+    </simulatedMetricsContainer>
+</document>

--- a/Example/Today Extension/TodayViewController.h
+++ b/Example/Today Extension/TodayViewController.h
@@ -1,17 +1,18 @@
-// Post.h
+//  TodayViewController.h
 //
-// Copyright (c) 2012 Mattt Thompson (http://mattt.me/)
-// 
+//  Copyright (c) 2015 Brian Nickel
+//
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -20,22 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
-@class User;
-
-@interface Post : NSObject
-
-@property (nonatomic, assign) NSUInteger postID;
-@property (nonatomic, strong) NSString *text;
-
-@property (nonatomic, strong) User *user;
-
-- (instancetype)initWithAttributes:(NSDictionary *)attributes;
-
-+ (NSURLSessionDataTask *)globalTimelinePostsWithBlock:(void (^)(NSArray *posts, NSError *error))block;
-
-@end
-
-@interface Post (NSCoding) <NSSecureCoding>
+@interface TodayViewController : UIViewController
 @end

--- a/Example/Today Extension/TodayViewController.m
+++ b/Example/Today Extension/TodayViewController.m
@@ -1,0 +1,108 @@
+//  TodayViewController.m
+//
+//  Copyright (c) 2015 Brian Nickel
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <NotificationCenter/NotificationCenter.h>
+#import "TodayViewController.h"
+#import "Post.h"
+#import "User.h"
+#import "UIImageView+AFNetworking.h"
+
+@interface TodayViewController () <NCWidgetProviding>
+@property (strong, nonatomic) IBOutlet UIImageView *imageView;
+@property (strong, nonatomic) IBOutlet UILabel *titleLabel;
+@property (strong, nonatomic) IBOutlet UILabel *bodyLabel;
+@property (nonatomic, strong) Post *post;
+@end
+
+@implementation TodayViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    
+    NSURLCache *URLCache = [[NSURLCache alloc] initWithMemoryCapacity:4 * 1024 * 1024 diskCapacity:20 * 1024 * 1024 diskPath:nil];
+    [NSURLCache setSharedURLCache:URLCache];
+    self.post = [self loadSavedPost];
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+}
+
+- (void)widgetPerformUpdateWithCompletionHandler:(void (^)(NCUpdateResult))completionHandler {
+    [Post globalTimelinePostsWithBlock:^(NSArray *posts, NSError *error) {
+        if (!error) {
+            
+            self.post = posts.firstObject;
+            [self savePost:self.post];
+            
+            if (completionHandler) {
+                completionHandler(self.post != nil ? NCUpdateResultNewData : NCUpdateResultNoData);
+            }
+            
+        } else {
+            if (completionHandler) {
+                completionHandler(NCUpdateResultFailed);
+            }
+        }
+    }];
+}
+
+- (void)setPost:(Post *)post {
+    _post = post;
+    
+    self.titleLabel.hidden = post == nil;
+    self.bodyLabel.hidden = post == nil;
+    self.imageView.hidden = post == nil;
+    
+    if (post == nil) {
+        return;
+    }
+    
+    self.titleLabel.text = _post.user.username;
+    self.bodyLabel.text = _post.text;
+    [self.imageView setImageWithURL:_post.user.avatarImageURL placeholderImage:[UIImage imageNamed:@"profile-image-placeholder"]];
+}
+
+- (void)savePost:(Post *)post {
+    
+    if (post == nil) {
+        [[NSUserDefaults standardUserDefaults] removeObjectForKey:@"AF.post"];
+        [[NSUserDefaults standardUserDefaults] synchronize];
+        return;
+    }
+    
+    NSData *postData = [NSKeyedArchiver archivedDataWithRootObject:post];
+    [[NSUserDefaults standardUserDefaults] setObject:postData forKey:@"AF.post"];
+    [[NSUserDefaults standardUserDefaults] synchronize];
+}
+
+- (Post *)loadSavedPost {
+    NSData *postData = [[NSUserDefaults standardUserDefaults] objectForKey:@"AF.post"];
+    if (postData == nil || ![postData isKindOfClass:[NSData class]]) {
+        return nil;
+    }
+    
+    return [NSKeyedUnarchiver unarchiveObjectWithData:postData];
+}
+
+@end

--- a/UIKit+AFNetworking/AFNetworkActivityIndicatorManager.h
+++ b/UIKit+AFNetworking/AFNetworkActivityIndicatorManager.h
@@ -41,6 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
  See the Apple Human Interface Guidelines section about the Network Activity Indicator for more information:
  http://developer.apple.com/library/iOS/#documentation/UserExperience/Conceptual/MobileHIG/UIElementGuidelines/UIElementGuidelines.html#//apple_ref/doc/uid/TP40006556-CH13-SW44
  */
+NS_EXTENSION_UNAVAILABLE_IOS("Use view controller based solutions where appropriate instead.")
 @interface AFNetworkActivityIndicatorManager : NSObject
 
 /**

--- a/UIKit+AFNetworking/AFNetworkActivityIndicatorManager.m
+++ b/UIKit+AFNetworking/AFNetworkActivityIndicatorManager.m
@@ -113,9 +113,7 @@ static NSURLRequest * AFNetworkRequestFromNotification(NSNotification *notificat
 }
 
 - (void)updateNetworkActivityIndicatorVisibility {
-#if !defined(AF_APP_EXTENSIONS)
     [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:[self isNetworkActivityIndicatorVisible]];
-#endif
 }
 
 - (void)setActivityCount:(NSInteger)activityCount {

--- a/UIKit+AFNetworking/UIAlertView+AFNetworking.h
+++ b/UIKit+AFNetworking/UIAlertView+AFNetworking.h
@@ -23,7 +23,7 @@
 
 #import <Availability.h>
 
-#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && !defined(AF_APP_EXTENSIONS)
+#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
 
 #import <UIKit/UIKit.h>
 
@@ -48,7 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 #if __IPHONE_OS_VERSION_MIN_REQUIRED >= 70000
 + (void)showAlertViewForTaskWithErrorOnCompletion:(NSURLSessionTask *)task
-                                         delegate:(nullable id)delegate;
+                                         delegate:(nullable id)delegate NS_EXTENSION_UNAVAILABLE_IOS("Not available in app extensions.");
 #endif
 
 /**
@@ -63,7 +63,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)showAlertViewForTaskWithErrorOnCompletion:(NSURLSessionTask *)task
                                          delegate:(nullable id)delegate
                                 cancelButtonTitle:(nullable NSString *)cancelButtonTitle
-                                otherButtonTitles:(nullable NSString *)otherButtonTitles, ... NS_REQUIRES_NIL_TERMINATION;
+                                otherButtonTitles:(nullable NSString *)otherButtonTitles, ... NS_REQUIRES_NIL_TERMINATION NS_EXTENSION_UNAVAILABLE_IOS("Not available in app extensions.");
 #endif
 
 ///------------------------------------------
@@ -77,7 +77,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param delegate The alert view delegate.
  */
 + (void)showAlertViewForRequestOperationWithErrorOnCompletion:(AFURLConnectionOperation *)operation
-                                                     delegate:(nullable id)delegate;
+                                                     delegate:(nullable id)delegate NS_EXTENSION_UNAVAILABLE_IOS("Not available in app extensions.");
 
 /**
  Shows an alert view with the error of the specified request operation, if any, with a custom cancel button title and other button titles.
@@ -90,7 +90,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)showAlertViewForRequestOperationWithErrorOnCompletion:(AFURLConnectionOperation *)operation
                                                      delegate:(nullable id)delegate
                                             cancelButtonTitle:(nullable NSString *)cancelButtonTitle
-                                            otherButtonTitles:(nullable NSString *)otherButtonTitles, ... NS_REQUIRES_NIL_TERMINATION;
+                                            otherButtonTitles:(nullable NSString *)otherButtonTitles, ... NS_REQUIRES_NIL_TERMINATION NS_EXTENSION_UNAVAILABLE_IOS("Not available in app extensions.");
 
 @end
 

--- a/UIKit+AFNetworking/UIAlertView+AFNetworking.m
+++ b/UIKit+AFNetworking/UIAlertView+AFNetworking.m
@@ -21,7 +21,7 @@
 
 #import "UIAlertView+AFNetworking.h"
 
-#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && !defined(AF_APP_EXTENSIONS)
+#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
 
 #import "AFURLConnectionOperation.h"
 


### PR DESCRIPTION
clang will silence availability errors in classes and methods that are also unavailable to the target.  The following have been made unavailable to app extensions:
- `AFNetworkActivityIndicatorManager` class
- `UIAlertView` category methods
- `AFURLConnectionOperation setShouldExecuteAsBackgroundTaskWithExpirationHandler:`

Benefits of change:
- Fixes CocoaPods support for App Extensions.
- Allows single framework to be used in app.
- Eliminates the need for `AF_APP_EXTENSIONS`.