### PR TITLE
Fix issue #2739

### DIFF
--- a/Tests/Tests/AFUIActivityIndicatorViewTests.m
+++ b/Tests/Tests/AFUIActivityIndicatorViewTests.m
@@ -146,6 +146,7 @@
     [operation cancel];
 }
 
+// Tests issue #2739. -[UIActivityIndicatorView dealloc] removes an observer and clobbering it in a category creates a zombie reference.
 - (void)testBackgroundingDoesNotCauseCrashWithOperation {
     XCTestExpectation *expectation = [self expectationWithDescription:@"No Crash"];
     AFHTTPRequestOperation *operation = [self.operationManager

--- a/Tests/Tests/AFUIActivityIndicatorViewTests.m
+++ b/Tests/Tests/AFUIActivityIndicatorViewTests.m
@@ -146,4 +146,21 @@
     [operation cancel];
 }
 
+- (void)testBackgroundingDoesNotCauseCrashWithOperation {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"No Crash"];
+    AFHTTPRequestOperation *operation = [self.operationManager
+                                         HTTPRequestOperationWithRequest:self.request
+                                         success:^(AFHTTPRequestOperation *operation, id responseObject) {
+                                         } failure:nil];
+    [self.activityIndicatorView setAnimatingWithStateOfOperation:operation];
+    self.activityIndicatorView = nil;
+    
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationDidEnterBackgroundNotification object:nil];
+        [expectation fulfill];
+    });
+    
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
+}
+
 @end

--- a/UIKit+AFNetworking/UIActivityIndicatorView+AFNetworking.m
+++ b/UIKit+AFNetworking/UIActivityIndicatorView+AFNetworking.m
@@ -30,7 +30,7 @@
 #import "AFURLSessionManager.h"
 #endif
 
-@interface AFActivityIndicatorAnimator : NSObject
+@interface AFActivityIndicatorViewNotificationObserver : NSObject
 @property (readonly, nonatomic, weak) UIActivityIndicatorView *activityIndicatorView;
 - (instancetype)initWithActivityIndicatorView:(UIActivityIndicatorView *)activityIndicatorView;
 
@@ -43,28 +43,28 @@
 
 @implementation UIActivityIndicatorView (AFNetworking)
 
-- (AFActivityIndicatorAnimator *)af_activityIndicatorAnimator {
-    AFActivityIndicatorAnimator *animator = objc_getAssociatedObject(self, @selector(af_activityIndicatorAnimator));
-    if (animator == nil) {
-        animator = [[AFActivityIndicatorAnimator alloc] initWithActivityIndicatorView:self];
-        objc_setAssociatedObject(self, @selector(af_activityIndicatorAnimator), animator, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+- (AFActivityIndicatorViewNotificationObserver *)af_notificationObserver {
+    AFActivityIndicatorViewNotificationObserver *notificationObserver = objc_getAssociatedObject(self, @selector(af_notificationObserver));
+    if (notificationObserver == nil) {
+        notificationObserver = [[AFActivityIndicatorViewNotificationObserver alloc] initWithActivityIndicatorView:self];
+        objc_setAssociatedObject(self, @selector(af_notificationObserver), notificationObserver, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     }
-    return animator;
+    return notificationObserver;
 }
 
 #if __IPHONE_OS_VERSION_MIN_REQUIRED >= 70000
 - (void)setAnimatingWithStateOfTask:(NSURLSessionTask *)task {
-    [[self af_activityIndicatorAnimator] setAnimatingWithStateOfTask:task];
+    [[self af_notificationObserver] setAnimatingWithStateOfTask:task];
 }
 #endif
 
 - (void)setAnimatingWithStateOfOperation:(AFURLConnectionOperation *)operation {
-    [[self af_activityIndicatorAnimator] setAnimatingWithStateOfOperation:operation];
+    [[self af_notificationObserver] setAnimatingWithStateOfOperation:operation];
 }
 
 @end
 
-@implementation AFActivityIndicatorAnimator
+@implementation AFActivityIndicatorViewNotificationObserver
 
 - (instancetype)initWithActivityIndicatorView:(UIActivityIndicatorView *)activityIndicatorView
 {

--- a/UIKit+AFNetworking/UIActivityIndicatorView+AFNetworking.m
+++ b/UIKit+AFNetworking/UIActivityIndicatorView+AFNetworking.m
@@ -20,6 +20,7 @@
 // THE SOFTWARE.
 
 #import "UIActivityIndicatorView+AFNetworking.h"
+#import <objc/runtime.h>
 
 #if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
 
@@ -29,7 +30,50 @@
 #import "AFURLSessionManager.h"
 #endif
 
+@interface AFActivityIndicatorAnimator : NSObject
+@property (readonly, nonatomic, weak) UIActivityIndicatorView *activityIndicatorView;
+- (instancetype)initWithActivityIndicatorView:(UIActivityIndicatorView *)activityIndicatorView;
+
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= 70000
+- (void)setAnimatingWithStateOfTask:(NSURLSessionTask *)task;
+#endif
+- (void)setAnimatingWithStateOfOperation:(AFURLConnectionOperation *)operation;
+
+@end
+
 @implementation UIActivityIndicatorView (AFNetworking)
+
+- (AFActivityIndicatorAnimator *)af_activityIndicatorAnimator {
+    AFActivityIndicatorAnimator *animator = objc_getAssociatedObject(self, @selector(af_activityIndicatorAnimator));
+    if (animator == nil) {
+        animator = [[AFActivityIndicatorAnimator alloc] initWithActivityIndicatorView:self];
+        objc_setAssociatedObject(self, @selector(af_activityIndicatorAnimator), animator, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+    return animator;
+}
+
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= 70000
+- (void)setAnimatingWithStateOfTask:(NSURLSessionTask *)task {
+    [[self af_activityIndicatorAnimator] setAnimatingWithStateOfTask:task];
+}
+#endif
+
+- (void)setAnimatingWithStateOfOperation:(AFURLConnectionOperation *)operation {
+    [[self af_activityIndicatorAnimator] setAnimatingWithStateOfOperation:operation];
+}
+
+@end
+
+@implementation AFActivityIndicatorAnimator
+
+- (instancetype)initWithActivityIndicatorView:(UIActivityIndicatorView *)activityIndicatorView
+{
+    self = [super init];
+    if (self) {
+        _activityIndicatorView = activityIndicatorView;
+    }
+    return self;
+}
 
 #if __IPHONE_OS_VERSION_MIN_REQUIRED >= 70000
 - (void)setAnimatingWithStateOfTask:(NSURLSessionTask *)task {
@@ -38,14 +82,19 @@
     [notificationCenter removeObserver:self name:AFNetworkingTaskDidResumeNotification object:nil];
     [notificationCenter removeObserver:self name:AFNetworkingTaskDidSuspendNotification object:nil];
     [notificationCenter removeObserver:self name:AFNetworkingTaskDidCompleteNotification object:nil];
-
+    
     if (task) {
         if (task.state != NSURLSessionTaskStateCompleted) {
+            
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreceiver-is-weak"
+#pragma clang diagnostic ignored "-Warc-repeated-use-of-weak"
             if (task.state == NSURLSessionTaskStateRunning) {
-                [self startAnimating];
+                [self.activityIndicatorView startAnimating];
             } else {
-                [self stopAnimating];
+                [self.activityIndicatorView stopAnimating];
             }
+#pragma clang diagnostic pop
 
             [notificationCenter addObserver:self selector:@selector(af_startAnimating) name:AFNetworkingTaskDidResumeNotification object:task];
             [notificationCenter addObserver:self selector:@selector(af_stopAnimating) name:AFNetworkingTaskDidCompleteNotification object:task];
@@ -65,11 +114,16 @@
 
     if (operation) {
         if (![operation isFinished]) {
+            
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreceiver-is-weak"
+#pragma clang diagnostic ignored "-Warc-repeated-use-of-weak"
             if ([operation isExecuting]) {
-                [self startAnimating];
+                [self.activityIndicatorView startAnimating];
             } else {
-                [self stopAnimating];
+                [self.activityIndicatorView stopAnimating];
             }
+#pragma clang diagnostic pop
 
             [notificationCenter addObserver:self selector:@selector(af_startAnimating) name:AFNetworkingOperationDidStartNotification object:operation];
             [notificationCenter addObserver:self selector:@selector(af_stopAnimating) name:AFNetworkingOperationDidFinishNotification object:operation];
@@ -81,13 +135,19 @@
 
 - (void)af_startAnimating {
     dispatch_async(dispatch_get_main_queue(), ^{
-        [self startAnimating];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreceiver-is-weak"
+        [self.activityIndicatorView startAnimating];
+#pragma clang diagnostic pop
     });
 }
 
 - (void)af_stopAnimating {
     dispatch_async(dispatch_get_main_queue(), ^{
-        [self stopAnimating];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreceiver-is-weak"
+        [self.activityIndicatorView stopAnimating];
+#pragma clang diagnostic pop
     });
 }
 

--- a/UIKit+AFNetworking/UIActivityIndicatorView+AFNetworking.m
+++ b/UIKit+AFNetworking/UIActivityIndicatorView+AFNetworking.m
@@ -153,9 +153,9 @@
 
 #pragma mark -
 
--(void)dealloc
-{
+- (void)dealloc {
     NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
+    
 #if __IPHONE_OS_VERSION_MIN_REQUIRED >= 70000
     [notificationCenter removeObserver:self name:AFNetworkingTaskDidCompleteNotification object:nil];
     [notificationCenter removeObserver:self name:AFNetworkingTaskDidResumeNotification object:nil];

--- a/UIKit+AFNetworking/UIRefreshControl+AFNetworking.m
+++ b/UIKit+AFNetworking/UIRefreshControl+AFNetworking.m
@@ -148,9 +148,9 @@
 
 #pragma mark -
 
--(void)dealloc
-{
+- (void)dealloc {
     NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
+    
 #if __IPHONE_OS_VERSION_MIN_REQUIRED >= 70000
     [notificationCenter removeObserver:self name:AFNetworkingTaskDidCompleteNotification object:nil];
     [notificationCenter removeObserver:self name:AFNetworkingTaskDidResumeNotification object:nil];

--- a/UIKit+AFNetworking/UIRefreshControl+AFNetworking.m
+++ b/UIKit+AFNetworking/UIRefreshControl+AFNetworking.m
@@ -21,6 +21,7 @@
 // THE SOFTWARE.
 
 #import "UIRefreshControl+AFNetworking.h"
+#import <objc/runtime.h>
 
 #if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
 
@@ -30,7 +31,50 @@
 #import "AFURLSessionManager.h"
 #endif
 
+@interface AFRefreshControlAnimator : NSObject
+@property (readonly, nonatomic, weak) UIRefreshControl *refreshControl;
+- (instancetype)initWithActivityRefreshControl:(UIRefreshControl *)refreshControl;
+
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= 70000
+- (void)setRefreshingWithStateOfTask:(NSURLSessionTask *)task;
+#endif
+- (void)setRefreshingWithStateOfOperation:(AFURLConnectionOperation *)operation;
+
+@end
+
 @implementation UIRefreshControl (AFNetworking)
+
+- (AFRefreshControlAnimator *)af_refreshControlAnimator {
+    AFRefreshControlAnimator *animator = objc_getAssociatedObject(self, @selector(af_refreshControlAnimator));
+    if (animator == nil) {
+        animator = [[AFRefreshControlAnimator alloc] initWithActivityRefreshControl:self];
+        objc_setAssociatedObject(self, @selector(af_refreshControlAnimator), animator, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+    return animator;
+}
+
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= 70000
+- (void)setRefreshingWithStateOfTask:(NSURLSessionTask *)task {
+    [[self af_refreshControlAnimator] setRefreshingWithStateOfTask:task];
+}
+#endif
+
+- (void)setRefreshingWithStateOfOperation:(AFURLConnectionOperation *)operation {
+    [[self af_refreshControlAnimator] setRefreshingWithStateOfOperation:operation];
+}
+
+@end
+
+@implementation AFRefreshControlAnimator
+
+- (instancetype)initWithActivityRefreshControl:(UIRefreshControl *)refreshControl
+{
+    self = [super init];
+    if (self) {
+        _refreshControl = refreshControl;
+    }
+    return self;
+}
 
 #if __IPHONE_OS_VERSION_MIN_REQUIRED >= 70000
 - (void)setRefreshingWithStateOfTask:(NSURLSessionTask *)task {
@@ -41,15 +85,19 @@
     [notificationCenter removeObserver:self name:AFNetworkingTaskDidCompleteNotification object:nil];
 
     if (task) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreceiver-is-weak"
+#pragma clang diagnostic ignored "-Warc-repeated-use-of-weak"
         if (task.state == NSURLSessionTaskStateRunning) {
-            [self beginRefreshing];
+            [self.refreshControl beginRefreshing];
 
             [notificationCenter addObserver:self selector:@selector(af_beginRefreshing) name:AFNetworkingTaskDidResumeNotification object:task];
             [notificationCenter addObserver:self selector:@selector(af_endRefreshing) name:AFNetworkingTaskDidCompleteNotification object:task];
             [notificationCenter addObserver:self selector:@selector(af_endRefreshing) name:AFNetworkingTaskDidSuspendNotification object:task];
         } else {
-            [self endRefreshing];
+            [self.refreshControl endRefreshing];
         }
+#pragma clang diagnostic pop
     }
 }
 #endif
@@ -61,16 +109,20 @@
     [notificationCenter removeObserver:self name:AFNetworkingOperationDidFinishNotification object:nil];
 
     if (operation) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreceiver-is-weak"
+#pragma clang diagnostic ignored "-Warc-repeated-use-of-weak"
         if (![operation isFinished]) {
             if ([operation isExecuting]) {
-                [self beginRefreshing];
+                [self.refreshControl beginRefreshing];
             } else {
-                [self endRefreshing];
+                [self.refreshControl endRefreshing];
             }
 
             [notificationCenter addObserver:self selector:@selector(af_beginRefreshing) name:AFNetworkingOperationDidStartNotification object:operation];
             [notificationCenter addObserver:self selector:@selector(af_endRefreshing) name:AFNetworkingOperationDidFinishNotification object:operation];
         }
+#pragma clang diagnostic pop
     }
 }
 
@@ -78,13 +130,19 @@
 
 - (void)af_beginRefreshing {
     dispatch_async(dispatch_get_main_queue(), ^{
-        [self beginRefreshing];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreceiver-is-weak"
+        [self.refreshControl beginRefreshing];
+#pragma clang diagnostic pop
     });
 }
 
 - (void)af_endRefreshing {
     dispatch_async(dispatch_get_main_queue(), ^{
-        [self endRefreshing];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreceiver-is-weak"
+        [self.refreshControl endRefreshing];
+#pragma clang diagnostic pop
     });
 }
 

--- a/UIKit+AFNetworking/UIRefreshControl+AFNetworking.m
+++ b/UIKit+AFNetworking/UIRefreshControl+AFNetworking.m
@@ -31,7 +31,7 @@
 #import "AFURLSessionManager.h"
 #endif
 
-@interface AFRefreshControlAnimator : NSObject
+@interface AFRefreshControlNotificationObserver : NSObject
 @property (readonly, nonatomic, weak) UIRefreshControl *refreshControl;
 - (instancetype)initWithActivityRefreshControl:(UIRefreshControl *)refreshControl;
 
@@ -44,28 +44,28 @@
 
 @implementation UIRefreshControl (AFNetworking)
 
-- (AFRefreshControlAnimator *)af_refreshControlAnimator {
-    AFRefreshControlAnimator *animator = objc_getAssociatedObject(self, @selector(af_refreshControlAnimator));
-    if (animator == nil) {
-        animator = [[AFRefreshControlAnimator alloc] initWithActivityRefreshControl:self];
-        objc_setAssociatedObject(self, @selector(af_refreshControlAnimator), animator, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+- (AFRefreshControlNotificationObserver *)af_notificationObserver {
+    AFRefreshControlNotificationObserver *notificationObserver = objc_getAssociatedObject(self, @selector(af_notificationObserver));
+    if (notificationObserver == nil) {
+        notificationObserver = [[AFRefreshControlNotificationObserver alloc] initWithActivityRefreshControl:self];
+        objc_setAssociatedObject(self, @selector(af_notificationObserver), notificationObserver, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     }
-    return animator;
+    return notificationObserver;
 }
 
 #if __IPHONE_OS_VERSION_MIN_REQUIRED >= 70000
 - (void)setRefreshingWithStateOfTask:(NSURLSessionTask *)task {
-    [[self af_refreshControlAnimator] setRefreshingWithStateOfTask:task];
+    [[self af_notificationObserver] setRefreshingWithStateOfTask:task];
 }
 #endif
 
 - (void)setRefreshingWithStateOfOperation:(AFURLConnectionOperation *)operation {
-    [[self af_refreshControlAnimator] setRefreshingWithStateOfOperation:operation];
+    [[self af_notificationObserver] setRefreshingWithStateOfOperation:operation];
 }
 
 @end
 
-@implementation AFRefreshControlAnimator
+@implementation AFRefreshControlNotificationObserver
 
 - (instancetype)initWithActivityRefreshControl:(UIRefreshControl *)refreshControl
 {


### PR DESCRIPTION
This introduces associated objects so notifications can be cleared in dealloc without clobbering the class's dealloc.