### PR TITLE
Changed Accept-Language header to start with the locale with country code

### DIFF
--- a/AFNetworking/AFURLRequestSerialization.m
+++ b/AFNetworking/AFURLRequestSerialization.m
@@ -208,11 +208,11 @@ static void *AFHTTPRequestSerializerObserverContext = &AFHTTPRequestSerializerOb
     NSMutableArray *acceptLanguagesComponents = [NSMutableArray array];
 	// Language Tags; see http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.10
     // [NSLocale preferredLanguages] returns a list of 'primary-tag', e.g. en, fr, zh-Hans
-	// so we should inject the full locale before adding just the primary ones, e.g. en-gb, fr-ca, zh-cn
+	// so we should inject the full locale before adding just the primary ones, e.g. en-GB, fr-CA, zh-CN
 	NSLocale *locale = [NSLocale currentLocale];
     [acceptLanguagesComponents addObject:[NSString stringWithFormat:@"%@-%@;q=1",
 										  [locale objectForKey:NSLocaleLanguageCode],
-										  [(NSString*)[locale objectForKey:NSLocaleCountryCode] lowercaseString]]];
+										  [locale objectForKey:NSLocaleCountryCode]]];
     [[NSLocale preferredLanguages] enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
         float q = 0.9f - (idx * 0.1f);
         [acceptLanguagesComponents addObject:[NSString stringWithFormat:@"%@;q=%0.1g", obj, q]];

--- a/AFNetworking/AFURLRequestSerialization.m
+++ b/AFNetworking/AFURLRequestSerialization.m
@@ -206,8 +206,15 @@ static void *AFHTTPRequestSerializerObserverContext = &AFHTTPRequestSerializerOb
 
     // Accept-Language HTTP Header; see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.4
     NSMutableArray *acceptLanguagesComponents = [NSMutableArray array];
+	// Language Tags; see http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.10
+    // [NSLocale preferredLanguages] returns a list of 'primary-tag', e.g. en, fr, zh-Hans
+	// so we should inject the full locale before adding just the primary ones, e.g. en-gb, fr-ca, zh-cn
+	NSLocale *locale = [NSLocale currentLocale];
+    [acceptLanguagesComponents addObject:[NSString stringWithFormat:@"%@-%@;q=1",
+										  [locale objectForKey:NSLocaleLanguageCode],
+										  [(NSString*)[locale objectForKey:NSLocaleCountryCode] lowercaseString]]];
     [[NSLocale preferredLanguages] enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
-        float q = 1.0f - (idx * 0.1f);
+        float q = 0.9f - (idx * 0.1f);
         [acceptLanguagesComponents addObject:[NSString stringWithFormat:@"%@;q=%0.1g", obj, q]];
         *stop = q <= 0.5f;
     }];


### PR DESCRIPTION
[NSLocale preferredLanguages] returns a list of 'primary-tag', e.g. en, fr, zh-Hans

That is not ideal when the server needs to know the country code of those locale.

So, prepend the header with a more explicit locale constructed from [NSLocale currentLocale]  