### PR TITLE
Add charset specification

### DIFF
--- a/AFNetworking/AFURLRequestSerialization.m
+++ b/AFNetworking/AFURLRequestSerialization.m
@@ -1262,7 +1262,7 @@ typedef enum {
 
     if (parameters) {
         if (![mutableRequest valueForHTTPHeaderField:@"Content-Type"]) {
-            [mutableRequest setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
+            [mutableRequest setValue:@"application/json; charset=utf-8" forHTTPHeaderField:@"Content-Type"];
         }
 
         [mutableRequest setHTTPBody:[NSJSONSerialization dataWithJSONObject:parameters options:self.writingOptions error:error]];


### PR DESCRIPTION
As `dataWithJSONObject:options:error:` returns an UTF-8 encoded
`NSData`, we can deduce the charset used for all requests