### PR TITLE
Provide URL request to the success block when images are retrieved from cache

### DIFF
--- a/Tests/AFNetworking Tests.xcodeproj/project.pbxproj
+++ b/Tests/AFNetworking Tests.xcodeproj/project.pbxproj
@@ -49,6 +49,9 @@
 		B6C1B95718ABF9E300C8B21A /* adn_0.cer in Resources */ = {isa = PBXBuildFile; fileRef = 36DE264B18053E930062F4E3 /* adn_0.cer */; };
 		B6C1B95818ABF9E300C8B21A /* adn_1.cer in Resources */ = {isa = PBXBuildFile; fileRef = 36DE264C18053E930062F4E3 /* adn_1.cer */; };
 		B6C1B95918ABF9E300C8B21A /* adn_2.cer in Resources */ = {isa = PBXBuildFile; fileRef = 36DE264D18053E930062F4E3 /* adn_2.cer */; };
+		C61291641B21E27700B9475A /* AFUIImageViewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C61291631B21E27700B9475A /* AFUIImageViewTests.m */; };
+		C61291651B21F9E300B9475A /* Icon.png in Resources */ = {isa = PBXBuildFile; fileRef = F8C6F281174D2C6200B154D5 /* Icon.png */; };
+		C61291661B21FA4D00B9475A /* Icon.png in Resources */ = {isa = PBXBuildFile; fileRef = F8C6F281174D2C6200B154D5 /* Icon.png */; };
 		CBBDB1651A7981FB00D412EE /* httpbinorg_01162016.cer in Resources */ = {isa = PBXBuildFile; fileRef = CBBDB1641A7981E200D412EE /* httpbinorg_01162016.cer */; };
 		CBBDB1661A79820700D412EE /* httpbinorg_01162016.cer in Resources */ = {isa = PBXBuildFile; fileRef = CBBDB1641A7981E200D412EE /* httpbinorg_01162016.cer */; };
 		CBBDB16A1A798AB500D412EE /* AddTrust_External_CA_Root.cer in Resources */ = {isa = PBXBuildFile; fileRef = CBBDB1671A798AB500D412EE /* AddTrust_External_CA_Root.cer */; };
@@ -123,6 +126,7 @@
 		B6774DC818FBB49E0044DB17 /* AFNetworkActivityManagerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFNetworkActivityManagerTests.m; sourceTree = "<group>"; };
 		BC9AB30A551203E10B6C890E /* Pods-osx.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-osx.release.xcconfig"; path = "Pods/Target Support Files/Pods-osx/Pods-osx.release.xcconfig"; sourceTree = "<group>"; };
 		C280748C740FAD506581E3CE /* Pods-ios.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ios.release.xcconfig"; path = "Pods/Target Support Files/Pods-ios/Pods-ios.release.xcconfig"; sourceTree = "<group>"; };
+		C61291631B21E27700B9475A /* AFUIImageViewTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFUIImageViewTests.m; sourceTree = "<group>"; };
 		CBBDB1641A7981E200D412EE /* httpbinorg_01162016.cer */ = {isa = PBXFileReference; lastKnownFileType = file; path = httpbinorg_01162016.cer; sourceTree = "<group>"; };
 		CBBDB1671A798AB500D412EE /* AddTrust_External_CA_Root.cer */ = {isa = PBXFileReference; lastKnownFileType = file; path = AddTrust_External_CA_Root.cer; sourceTree = "<group>"; };
 		CBBDB1681A798AB500D412EE /* COMODO_RSA_Certification_Authority.cer */ = {isa = PBXFileReference; lastKnownFileType = file; path = COMODO_RSA_Certification_Authority.cer; sourceTree = "<group>"; };
@@ -279,6 +283,7 @@
 				DE533FCD1ACCF34200C62CFB /* AFNetworkReachabilityManagerTests.m */,
 				2940C0091B063C6700AFDAC7 /* AFUIActivityIndicatorViewTests.m */,
 				2940C00B1B064C3200AFDAC7 /* AFUIRefreshControlTests.m */,
+				C61291631B21E27700B9475A /* AFUIImageViewTests.m */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -438,6 +443,7 @@
 				A74DA00B18D2FB9400F3B969 /* foobar.com.cer in Resources */,
 				36DE265018053E930062F4E3 /* adn_2.cer in Resources */,
 				29CBFC7617DF697C0021AB75 /* HTTPBinOrgServerTrustChain in Resources */,
+				C61291651B21F9E300B9475A /* Icon.png in Resources */,
 				A74DA00918D2FB9400F3B969 /* AltName.cer in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -458,6 +464,7 @@
 				A74DA00C18D2FB9400F3B969 /* foobar.com.cer in Resources */,
 				B6C1B95918ABF9E300C8B21A /* adn_2.cer in Resources */,
 				29CBFC7717DF697C0021AB75 /* HTTPBinOrgServerTrustChain in Resources */,
+				C61291661B21FA4D00B9475A /* Icon.png in Resources */,
 				A74DA00A18D2FB9400F3B969 /* AltName.cer in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -533,6 +540,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2940C00A1B063C6700AFDAC7 /* AFUIActivityIndicatorViewTests.m in Sources */,
+				C61291641B21E27700B9475A /* AFUIImageViewTests.m in Sources */,
 				29CBFC3917DF4F120021AB75 /* AFHTTPRequestOperationTests.m in Sources */,
 				943B1F41192E406C00304316 /* AFURLSessionManagerTests.m in Sources */,
 				F837FFAF195744A0009078A0 /* AFHTTPResponseSerializationTests.m in Sources */,

--- a/Tests/Tests/AFHTTPRequestSerializationTests.m
+++ b/Tests/Tests/AFHTTPRequestSerializationTests.m
@@ -1,4 +1,4 @@
-// AFHTTPSerializationTests.m
+// AFHTTPRequestSerializationTests.m
 // Copyright (c) 2011–2015 Alamofire Software Foundation (http://alamofire.org/)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/Tests/Tests/AFUIActivityIndicatorViewTests.m
+++ b/Tests/Tests/AFUIActivityIndicatorViewTests.m
@@ -1,4 +1,4 @@
-// AFNetworkReachabilityManagerTests.h
+// AFUIActivityIndicatorViewTests.h
 // Copyright (c) 2011–2015 Alamofire Software Foundation (http://alamofire.org/)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/Tests/Tests/AFUIImageViewTests.m
+++ b/Tests/Tests/AFUIImageViewTests.m
@@ -65,6 +65,7 @@
      placeholderImage:nil
      success:^(NSURLRequest *request, NSHTTPURLResponse *response, UIImage *image) {
          XCTAssertEqual(request, weakSelf.cachedImageRequest, @"URL requests do not match");
+         XCTAssertNil(response, @"Response should be nil when image is returned from cache");
          XCTAssertEqual(image, weakSelf.cachedImage, @"Cached images do not match");
          [expectation fulfill];
      }

--- a/Tests/Tests/AFUIImageViewTests.m
+++ b/Tests/Tests/AFUIImageViewTests.m
@@ -21,16 +21,12 @@
 
 #import "AFTestCase.h"
 #import <AFNetworking/UIImageView+AFNetworking.h>
-#import <AFNetworking/AFURLSessionManager.h>
-#import <AFNetworking/AFHTTPRequestOperationManager.h>
 #import <OCMock/OCMock.h>
 
 @interface AFUIImageViewTests : AFTestCase
 @property (nonatomic, strong) UIImage *cachedImage;
 @property (nonatomic, strong) NSURLRequest *cachedImageRequest;
 @property (nonatomic, strong) UIImageView *imageView;
-@property (nonatomic, strong) AFURLSessionManager *sessionManager;
-@property (nonatomic, strong) AFHTTPRequestOperationManager *operationManager;
 @end
 
 @implementation AFUIImageViewTests

--- a/Tests/Tests/AFUIImageViewTests.m
+++ b/Tests/Tests/AFUIImageViewTests.m
@@ -1,0 +1,79 @@
+// AFUIImageViewTests.h
+// Copyright (c) 2011–2015 Alamofire Software Foundation (http://alamofire.org/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "AFTestCase.h"
+#import <AFNetworking/UIImageView+AFNetworking.h>
+#import <AFNetworking/AFURLSessionManager.h>
+#import <AFNetworking/AFHTTPRequestOperationManager.h>
+#import <OCMock/OCMock.h>
+
+@interface AFUIImageViewTests : AFTestCase
+@property (nonatomic, strong) UIImage *cachedImage;
+@property (nonatomic, strong) NSURLRequest *cachedImageRequest;
+@property (nonatomic, strong) UIImageView *imageView;
+@property (nonatomic, strong) AFURLSessionManager *sessionManager;
+@property (nonatomic, strong) AFHTTPRequestOperationManager *operationManager;
+@end
+
+@implementation AFUIImageViewTests
+
+- (void)setUp {
+    [super setUp];
+    self.imageView = [UIImageView new];
+    [self setUpSharedImageCache];
+}
+
+- (void)tearDown {
+    [self tearDownSharedImageCache];
+    [super tearDown];
+}
+
+- (void)setUpSharedImageCache {
+    NSString *resourcePath = [[NSBundle bundleForClass:[self class]] resourcePath];
+    NSString *imagePath = [resourcePath stringByAppendingPathComponent:@"Icon.png"];
+    self.cachedImage = [UIImage imageWithContentsOfFile:imagePath];
+    self.cachedImageRequest = [NSURLRequest requestWithURL:[NSURL URLWithString:@"http://foo.bar/image"]];
+    
+    id<AFImageCache> mockImageCache = [OCMockObject mockForProtocol:@protocol(AFImageCache)];
+    [[[(OCMockObject *)mockImageCache stub] andReturn:self.cachedImage] cachedImageForRequest:self.cachedImageRequest];
+    [UIImageView setSharedImageCache:mockImageCache];
+}
+
+- (void)tearDownSharedImageCache {
+    [UIImageView setSharedImageCache:nil];
+}
+
+- (void)testSetImageWithURLRequestUsesCachedImage {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Image view uses cached image"];
+    typeof(self) __weak weakSelf = self;
+    [self.imageView
+     setImageWithURLRequest:self.cachedImageRequest
+     placeholderImage:nil
+     success:^(NSURLRequest *request, NSHTTPURLResponse *response, UIImage *image) {
+         XCTAssertEqual(request, weakSelf.cachedImageRequest, @"URL requests do not match");
+         XCTAssertEqual(image, weakSelf.cachedImage, @"Cached images do not match");
+         [expectation fulfill];
+     }
+     failure:nil];
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
+}
+
+@end

--- a/Tests/Tests/AFUIRefreshControlTests.m
+++ b/Tests/Tests/AFUIRefreshControlTests.m
@@ -1,4 +1,4 @@
-// AFNetworkReachabilityManagerTests.h
+// AFUIRefreshControlTests.h
 // Copyright (c) 2011–2015 Alamofire Software Foundation (http://alamofire.org/)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/Tests/Tests/AFURLSessionManagerTests.m
+++ b/Tests/Tests/AFURLSessionManagerTests.m
@@ -1,4 +1,4 @@
-// AFNetworkActivityManagerTests.m
+// AFURLSessionManagerTests.m
 // Copyright (c) 2011–2015 Alamofire Software Foundation (http://alamofire.org/)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/UIKit+AFNetworking/UIImageView+AFNetworking.h
+++ b/UIKit+AFNetworking/UIImageView+AFNetworking.h
@@ -98,7 +98,7 @@
 
  @param urlRequest The URL request used for the image request.
  @param placeholderImage The image to be set initially, until the image request finishes. If `nil`, the image view will not change its image until the image request finishes.
- @param success A block to be executed when the image request operation finishes successfully. This block has no return value and takes three arguments: the request sent from the client, the response received from the server, and the image created from the response data of request. If the image was returned from cache, the request and response parameters will be `nil`.
+ @param success A block to be executed when the image request operation finishes successfully. This block has no return value and takes three arguments: the request sent from the client, the response received from the server, and the image created from the response data of request. If the image was returned from cache, the response parameter will be `nil`.
  @param failure A block object to be executed when the image request operation finishes unsuccessfully, or that finishes successfully. This block has no return value and takes three arguments: the request sent from the client, the response received from the server, and the error object describing the network or parsing error that occurred.
  */
 - (void)setImageWithURLRequest:(NSURLRequest *)urlRequest

--- a/UIKit+AFNetworking/UIImageView+AFNetworking.m
+++ b/UIKit+AFNetworking/UIImageView+AFNetworking.m
@@ -129,7 +129,7 @@
     UIImage *cachedImage = [[[self class] sharedImageCache] cachedImageForRequest:urlRequest];
     if (cachedImage) {
         if (success) {
-            success(nil, nil, cachedImage);
+            success(urlRequest, nil, cachedImage);
         } else {
             self.image = cachedImage;
         }


### PR DESCRIPTION
When UIImageView+AFNetworking successfully retrieves an image from the cache, the URL request was not being provided to the success block along with the image. This meant that there was no way to compare retrieved image's URL with the URL that should be displayed.