### PR TITLE
Cleanup xcode7 warnings

### DIFF
--- a/AFNetworking/AFNetworkReachabilityManager.m
+++ b/AFNetworking/AFNetworkReachabilityManager.m
@@ -114,12 +114,7 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {
     static AFNetworkReachabilityManager *_sharedManager = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        struct sockaddr_in address;
-        bzero(&address, sizeof(address));
-        address.sin_len = sizeof(address);
-        address.sin_family = AF_INET;
-
-        _sharedManager = [self managerForAddress:&address];
+        _sharedManager = [[self alloc] init];
     });
 
     return _sharedManager;
@@ -141,6 +136,25 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {
     manager.networkReachabilityAssociation = AFNetworkReachabilityForAddress;
 
     return manager;
+}
+
+- (instancetype)init
+{
+	struct sockaddr_in address;
+	bzero(&address, sizeof(address));
+	address.sin_len = sizeof(address);
+	address.sin_family = AF_INET;
+	
+	SCNetworkReachabilityRef reachability = SCNetworkReachabilityCreateWithAddress(kCFAllocatorDefault, (const struct sockaddr *)&address);
+	
+	self = [self initWithReachability: reachability];
+	if(!self){
+		return nil;
+	}
+	
+	self.networkReachabilityAssociation = AFNetworkReachabilityForAddress;
+	
+	return self;
 }
 
 - (instancetype)initWithReachability:(SCNetworkReachabilityRef)reachability {

--- a/AFNetworking/AFURLConnectionOperation.m
+++ b/AFNetworking/AFURLConnectionOperation.m
@@ -180,6 +180,10 @@ static inline BOOL AFStateTransitionIsValid(AFOperationState fromState, AFOperat
     return _networkRequestThread;
 }
 
+- (instancetype)init {
+	return [self initWithRequest: nil];
+}
+
 - (instancetype)initWithRequest:(NSURLRequest *)urlRequest {
     NSParameterAssert(urlRequest);
 

--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -316,7 +316,8 @@ static NSString * const AFNSURLSessionTaskDidSuspendNotification = @"com.alamofi
             7) If the current class implementation of `resume` is not equal to the super class implementation of `resume` AND the current implementation of `resume` is not equal to the original implementation of `af_resume`, THEN swizzle the methods
             8) Set the current class to the super class, and repeat steps 3-8
          */
-        NSURLSessionDataTask *localDataTask = [[NSURLSession sessionWithConfiguration:nil] dataTaskWithURL:nil];
+        NSURLSessionDataTask *localDataTask = [[NSURLSession sessionWithConfiguration: [NSURLSessionConfiguration defaultSessionConfiguration]]
+											   dataTaskWithURL: [NSURL new]];
         IMP originalAFResumeIMP = method_getImplementation(class_getInstanceMethod([_AFURLSessionTaskSwizzling class], @selector(af_resume)));
         Class currentClass = [localDataTask class];
         


### PR DESCRIPTION
There are a couple new warnings being produced by xcode7.  This pull request cleans up warnings around nil being passed into non-nullable parameters, as well as designated initializers that are not being overridden in subclasses. 