### PR TITLE
Fix for issue #2572 Crash on AFImageWithDataAtScale when loading image

### DIFF
--- a/AFNetworking.xcworkspace/contents.xcworkspacedata
+++ b/AFNetworking.xcworkspace/contents.xcworkspacedata
@@ -136,6 +136,12 @@
       <FileRef
          location = "group:UIRefreshControl+AFNetworking.m">
       </FileRef>
+      <FileRef
+         location = "group:/Users/pferreira/work/GitHub/AFNetworking/UIKit+AFNetworking/UIImage+AFNetworking.h">
+      </FileRef>
+      <FileRef
+         location = "group:UIImage+AFNetworking.m">
+      </FileRef>
    </Group>
    <FileRef
       location = "group:Tests/AFNetworking Tests.xcodeproj">

--- a/AFNetworking/AFURLResponseSerialization.m
+++ b/AFNetworking/AFURLResponseSerialization.m
@@ -530,18 +530,26 @@ static id AFJSONObjectByRemovingKeysWithNullValues(id JSONObject, NSJSONReadingO
 #import <CoreGraphics/CoreGraphics.h>
 
 NSLock* _AFImageLock = nil;
-@interface ImageLockInitializer : NSObject
+@interface ImageSyncronizer : NSObject
 @end
-@implementation ImageLockInitializer : NSObject
+@implementation ImageSyncronizer : NSObject
 + (void)initialize {
     _AFImageLock = [[NSLock alloc] init];
+}
+
++ (void) imageLock {
+    [_AFImageLock lock];
+}
+
++ (void) imageUnlock {
+    [_AFImageLock unlock];
 }
 @end
 
 static UIImage * AFImageWithDataAtScale(NSData *data, CGFloat scale) {
-    [_AFImageLock lock];
+    [ImageSyncronizer imageLock];
     UIImage *image = [[UIImage alloc] initWithData:data];
-    [_AFImageLock unlock];
+    [ImageSyncronizer imageUnlock];
     if (image.images) {
         return image;
     }

--- a/AFNetworking/AFURLResponseSerialization.m
+++ b/AFNetworking/AFURLResponseSerialization.m
@@ -529,12 +529,23 @@ static id AFJSONObjectByRemovingKeysWithNullValues(id JSONObject, NSJSONReadingO
 #if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
 #import <CoreGraphics/CoreGraphics.h>
 
+NSLock* _AFImageLock = nil;
+@interface ImageLockInitializer : NSObject
+@end
+@implementation ImageLockInitializer : NSObject
++ (void)initialize {
+    _AFImageLock = [[NSLock alloc] init];
+}
+@end
+
 static UIImage * AFImageWithDataAtScale(NSData *data, CGFloat scale) {
+    [_AFImageLock lock];
     UIImage *image = [[UIImage alloc] initWithData:data];
+    [_AFImageLock unlock];
     if (image.images) {
         return image;
     }
-
+    
     return [[UIImage alloc] initWithCGImage:[image CGImage] scale:scale orientation:image.imageOrientation];
 }
 

--- a/AFNetworking/AFURLResponseSerialization.m
+++ b/AFNetworking/AFURLResponseSerialization.m
@@ -528,28 +528,10 @@ static id AFJSONObjectByRemovingKeysWithNullValues(id JSONObject, NSJSONReadingO
 
 #if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
 #import <CoreGraphics/CoreGraphics.h>
-
-NSLock* _AFImageLock = nil;
-@interface ImageSyncronizer : NSObject
-@end
-@implementation ImageSyncronizer : NSObject
-+ (void)initialize {
-    _AFImageLock = [[NSLock alloc] init];
-}
-
-+ (void) imageLock {
-    [_AFImageLock lock];
-}
-
-+ (void) imageUnlock {
-    [_AFImageLock unlock];
-}
-@end
+#import "UIImage+AFNetworking.h"
 
 static UIImage * AFImageWithDataAtScale(NSData *data, CGFloat scale) {
-    [ImageSyncronizer imageLock];
-    UIImage *image = [[UIImage alloc] initWithData:data];
-    [ImageSyncronizer imageUnlock];
+    UIImage *image = [UIImage safeImageWithData:data];
     if (image.images) {
         return image;
     }

--- a/Example/AFNetworking iOS Example.xcodeproj/project.pbxproj
+++ b/Example/AFNetworking iOS Example.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		297F56CA17A9B1AB0014D95C /* AFSecurityPolicy.m in Sources */ = {isa = PBXBuildFile; fileRef = 297F56C917A9B1AB0014D95C /* AFSecurityPolicy.m */; };
 		2982AD3217107C0000FFF048 /* adn.cer in Resources */ = {isa = PBXBuildFile; fileRef = 2982AD3117107C0000FFF048 /* adn.cer */; };
+		A4CBD6001B4C98FB0082DAF0 /* UIImage+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = A4CBD5FF1B4C98FB0082DAF0 /* UIImage+AFNetworking.m */; };
 		E8C2E7A618970EE40097DCC8 /* root_ca.cer in Resources */ = {isa = PBXBuildFile; fileRef = E8C2E7A418970EE00097DCC8 /* root_ca.cer */; };
 		E8C2E7A718970EE40097DCC8 /* digicert_ca_3.cer in Resources */ = {isa = PBXBuildFile; fileRef = E8C2E7A518970EE00097DCC8 /* digicert_ca_3.cer */; };
 		F8129C7415910C37009BFE23 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = F8129C7215910C37009BFE23 /* AppDelegate.m */; };
@@ -56,6 +57,8 @@
 		2982AD3117107C0000FFF048 /* adn.cer */ = {isa = PBXFileReference; lastKnownFileType = file; path = adn.cer; sourceTree = SOURCE_ROOT; };
 		50ABD6EC159FC2CE001BE42C /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = System/Library/Frameworks/MobileCoreServices.framework; sourceTree = SDKROOT; };
 		55BDA27E17F5A434005DB933 /* UIKit+AFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIKit+AFNetworking.h"; sourceTree = "<group>"; };
+		A4CBD5FE1B4C98FB0082DAF0 /* UIImage+AFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImage+AFNetworking.h"; sourceTree = "<group>"; };
+		A4CBD5FF1B4C98FB0082DAF0 /* UIImage+AFNetworking.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImage+AFNetworking.m"; sourceTree = "<group>"; };
 		E8C2E7A418970EE00097DCC8 /* root_ca.cer */ = {isa = PBXFileReference; lastKnownFileType = file; path = root_ca.cer; sourceTree = SOURCE_ROOT; };
 		E8C2E7A518970EE00097DCC8 /* digicert_ca_3.cer */ = {isa = PBXFileReference; lastKnownFileType = file; path = digicert_ca_3.cer; sourceTree = SOURCE_ROOT; };
 		F8129C3815910830009BFE23 /* Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Prefix.pch; sourceTree = SOURCE_ROOT; };
@@ -228,6 +231,8 @@
 		F8E02CEA177A8B710087BB23 /* UIKit+AFNetworking */ = {
 			isa = PBXGroup;
 			children = (
+				A4CBD5FE1B4C98FB0082DAF0 /* UIImage+AFNetworking.h */,
+				A4CBD5FF1B4C98FB0082DAF0 /* UIImage+AFNetworking.m */,
 				55BDA27E17F5A434005DB933 /* UIKit+AFNetworking.h */,
 				F8E02CEB177A8B710087BB23 /* AFNetworkActivityIndicatorManager.h */,
 				F8E02CEC177A8B710087BB23 /* AFNetworkActivityIndicatorManager.m */,
@@ -465,6 +470,7 @@
 				F8FA94B8150EFEC100ED4EAD /* AFURLConnectionOperation.m in Sources */,
 				F8FA94C1150F019100ED4EAD /* PostTableViewCell.m in Sources */,
 				F8129C7415910C37009BFE23 /* AppDelegate.m in Sources */,
+				A4CBD6001B4C98FB0082DAF0 /* UIImage+AFNetworking.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/UIKit+AFNetworking/UIImage+AFNetworking.h
+++ b/UIKit+AFNetworking/UIImage+AFNetworking.h
@@ -1,0 +1,19 @@
+//
+//  UIImage_UIImage_AFNetworking.h
+//  
+//
+//  Created by Paulo Ferreira on 08/07/15.
+//
+//
+
+#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
+
+#import <UIKit/UIKit.h>
+
+@interface UIImage (AFNetworking)
+
++ (UIImage*) safeImageWithData:(NSData*)data;
+
+@end
+
+#endif

--- a/UIKit+AFNetworking/UIImage+AFNetworking.h
+++ b/UIKit+AFNetworking/UIImage+AFNetworking.h
@@ -1,10 +1,26 @@
 //
-//  UIImage_UIImage_AFNetworking.h
+//  UIImage+AFNetworking.h
 //  
 //
 //  Created by Paulo Ferreira on 08/07/15.
 //
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
 //
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 
 #if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
 

--- a/UIKit+AFNetworking/UIImage+AFNetworking.m
+++ b/UIKit+AFNetworking/UIImage+AFNetworking.m
@@ -4,7 +4,23 @@
 //
 //  Created by Paulo Ferreira on 08/07/15.
 //
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
 //
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 
 #if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
 

--- a/UIKit+AFNetworking/UIImage+AFNetworking.m
+++ b/UIKit+AFNetworking/UIImage+AFNetworking.m
@@ -1,0 +1,31 @@
+//
+//  UIImage+AFNetworking.m
+//  
+//
+//  Created by Paulo Ferreira on 08/07/15.
+//
+//
+
+#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
+
+#import "UIImage+AFNetworking.h"
+
+static NSLock* imageLock = nil;
+
+@implementation UIImage (AFNetworking)
+
++ (void) initialize
+{
+    imageLock = [[NSLock alloc] init];
+}
+
++ (UIImage*) safeImageWithData:(NSData*)data {
+    UIImage* image = nil;
+    [imageLock lock];
+    image = [UIImage imageWithData:data];
+    [imageLock unlock];
+    return image;
+}
+@end
+
+#endif

--- a/UIKit+AFNetworking/UIKit+AFNetworking.h
+++ b/UIKit+AFNetworking/UIKit+AFNetworking.h
@@ -35,4 +35,5 @@
     #import "UIProgressView+AFNetworking.h"
     #import "UIRefreshControl+AFNetworking.h"
     #import "UIWebView+AFNetworking.h"
+    #import "UIImage+AFNetworking.h"
 #endif /* _UIKIT_AFNETWORKING_ */


### PR DESCRIPTION
#2572 - UIImage initWithData is not thread safe. In order to avoid
crash we need to serialise call.