### PR TITLE
Fix "method override not found" warnings on Xcode 7b2

### DIFF
--- a/AFNetworking/AFNetworkReachabilityManager.m
+++ b/AFNetworking/AFNetworkReachabilityManager.m
@@ -155,6 +155,11 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {
     return self;
 }
 
+- (instancetype)init NS_UNAVAILABLE
+{
+    return nil;
+}
+
 - (void)dealloc {
     [self stopMonitoring];
 

--- a/AFNetworking/AFURLConnectionOperation.m
+++ b/AFNetworking/AFURLConnectionOperation.m
@@ -204,6 +204,11 @@ static inline BOOL AFStateTransitionIsValid(AFOperationState fromState, AFOperat
     return self;
 }
 
+- (instancetype)init NS_UNAVAILABLE
+{
+    return nil;
+}
+
 - (void)dealloc {
     if (_outputStream) {
         [_outputStream close];


### PR DESCRIPTION
Fixes the `Method override for the designated initializer of the superclass '-init' not found` warnings on Xcode 7 beta 2. 

This is an alternative to https://github.com/AFNetworking/AFNetworking/pull/2789 , if we think `init` should be unavailable in these cases.