### PR TITLE
Fixed issue where xcrun was returning unavailable simulators

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -59,26 +59,30 @@ end
 def get_ios_simulators
   device_section_regex = /== Devices ==(.*?)(?=(?===)|\z)/m
   runtime_section_regex = /== Runtimes ==(.*?)(?=(?===)|\z)/m
-  runtime_version_regex  = /iOS (.*) \((.*) - .*?\)/
+  runtime_version_regex  = /iOS (.*) \((.*) - .*?\) (\(.*\))/
   xcrun_output = `xcrun simctl list`
   puts "Available iOS Simulators: \n#{xcrun_output}"
   
   simulators = Hash.new
   runtimes_section = xcrun_output.scan(runtime_section_regex)[0]
   runtimes_section[0].scan(runtime_version_regex) {|result|
-    simulators[result[0]] = Hash.new
-    simulators[result[0]][:runtime] = result[1]
+    if result[2] !~ /unavailable/
+      simulators[result[0]] = Hash.new
+      simulators[result[0]][:runtime] = result[1]
+    end
   }
   
   device_section = xcrun_output.scan(device_section_regex)[0]
   version_regex = /-- iOS (.*?) --(.*?)(?=(?=-- .*? --)|\z)/m
   simulator_name_regex = /(.*) \([A-F0-9-]*\) \(.*\)/
-  device_section[0].scan(version_regex) {|result| 
-    simulators[result[0]][:device_names] = Array.new
-    result[1].scan(simulator_name_regex) { |device_name_result| 
-      device_name = device_name_result[0].strip
-      simulators[result[0]][:device_names].push(device_name)
-    }
+  device_section[0].scan(version_regex) {|result|
+    if simulators.has_key?(result[0])
+      simulators[result[0]][:device_names] = Array.new
+      result[1].scan(simulator_name_regex) { |device_name_result| 
+        device_name = device_name_result[0].strip
+        simulators[result[0]][:device_names].push(device_name)
+      }
+    end
    }
    return simulators
 end


### PR DESCRIPTION
Once I got the beta on my machine, I saw the following output from `xcrun simctl list`

```
== Device Types ==
iPhone 4s (com.apple.CoreSimulator.SimDeviceType.iPhone-4s)
iPhone 5 (com.apple.CoreSimulator.SimDeviceType.iPhone-5)
iPhone 5s (com.apple.CoreSimulator.SimDeviceType.iPhone-5s)
iPhone 6 Plus (com.apple.CoreSimulator.SimDeviceType.iPhone-6-Plus)
iPhone 6 (com.apple.CoreSimulator.SimDeviceType.iPhone-6)
iPad 2 (com.apple.CoreSimulator.SimDeviceType.iPad-2)
iPad Retina (com.apple.CoreSimulator.SimDeviceType.iPad-Retina)
iPad Air (com.apple.CoreSimulator.SimDeviceType.iPad-Air)
Resizable iPhone (com.apple.CoreSimulator.SimDeviceType.Resizable-iPhone)
Resizable iPad (com.apple.CoreSimulator.SimDeviceType.Resizable-iPad)
== Runtimes ==
iOS 7.1 (7.1 - 11D167) (com.apple.CoreSimulator.SimRuntime.iOS-7-1)
iOS 8.3 (8.3 - 12F69) (com.apple.CoreSimulator.SimRuntime.iOS-8-3)
== Devices ==
-- iOS 7.1 --
    iPhone 4s (D25D2EBC-D546-4B83-AF69-0DE1A5D65BAE) (Shutdown)
    iPhone 5 (14DC9015-3924-4635-9F1D-10727F36F359) (Shutdown)
    iPhone 5s (F041D510-648E-4276-B6AC-50C14E48A1EF) (Shutdown)
    iPad 2 (D6841185-9E61-402A-899A-9213365E5E30) (Shutdown)
    iPad Retina (3B28833F-32F7-41BF-A4CD-92CAF0230CF7) (Shutdown)
    iPad Air (0C7AFAD4-9905-487F-B871-4332822DBA89) (Shutdown)
-- iOS 8.3 --
    iPhone 4s (4835694D-635C-49F1-96B1-784E5BBF3139) (Shutdown)
    iPhone 5 (76CC3980-846E-4E8D-9F9D-54BC275DEA61) (Shutdown)
    iPhone 5s (89B42505-7898-49E8-B954-FBDE561763B4) (Shutdown)
    iPhone 6 Plus (F8EF8D5B-0D49-4E58-B37A-43927674E873) (Shutdown)
    iPhone 6 (B53D1800-0136-4A42-8677-C868881B59ED) (Shutdown)
    iPad 2 (F4BC80B9-1337-4663-9475-75E7383F0517) (Shutdown)
    iPad Retina (E19F379D-CD69-454E-BE6E-8E6851BC086F) (Shutdown)
    iPad Air (92B57CCD-A76F-4A04-AD1D-EE57725B6554) (Shutdown)
    Resizable iPhone (71439A99-5262-4C71-99BC-8DD41521C910) (Shutdown)
    Resizable iPad (3160AAC8-7A45-4EFF-824A-A10D71613EE3) (Shutdown)
-- Unavailable: com.apple.CoreSimulator.SimRuntime.iOS-8-0 --
    iPhone 4s (5DE87BD1-BE23-492C-80EF-6A1F83196B6E) (Shutdown) (unavailable, runtime profile not found)
    iPhone 5 (A83AE786-69F0-46DA-A1E4-FAC9F9F0A996) (Shutdown) (unavailable, runtime profile not found)
    iPhone 5s (9A7C25E9-944B-4969-9600-58695A89BF62) (Shutdown) (unavailable, runtime profile not found)
    iPhone 6 Plus (45A5A28D-AE38-4905-A557-3FF9BC785FD5) (Shutdown) (unavailable, runtime profile not found)
    iPhone 6 (EA9EDED0-2402-4F7D-B4D7-8513F0BD322E) (Shutdown) (unavailable, runtime profile not found)
    iPad 2 (C96E5813-BA1E-4366-8EDD-C756B476DB4D) (Shutdown) (unavailable, runtime profile not found)
    iPad Retina (5DC7A923-6113-4F73-8E78-8ED4455A1986) (Shutdown) (unavailable, runtime profile not found)
    iPad Air (CE63558E-4726-4934-86C7-4D337D3A1ACC) (Shutdown) (unavailable, runtime profile not found)
    Resizable iPhone (13A1F4A0-F0C7-47C4-B676-80ECCAA287B5) (Shutdown) (unavailable, runtime profile not found)
    Resizable iPad (5D3FA2FC-0E84-40C0-B783-3A06D29411D3) (Shutdown) (unavailable, runtime profile not found)
-- Unavailable: com.apple.CoreSimulator.SimRuntime.iOS-8-1 --
    iPhone 4s (18C6D385-7F20-41AA-B45F-3BF91892FA3C) (Shutdown) (unavailable, runtime profile not found)
    iPhone 5 (3597BB97-16F4-4039-8D49-A3595FE77C33) (Shutdown) (unavailable, runtime profile not found)
    iPhone 5s (401B106A-1293-44F6-8B39-F5D212E21EF7) (Shutdown) (unavailable, runtime profile not found)
    iPhone 6 Plus (6FAB3308-9851-43E7-8224-829325A5318A) (Shutdown) (unavailable, runtime profile not found)
    iPhone 6 (B5018EED-C9BA-4A95-A344-19A4D9231DE4) (Shutdown) (unavailable, runtime profile not found)
    iPad 2 (F0E69BBC-94FB-43EA-9F50-EB5571D43179) (Shutdown) (unavailable, runtime profile not found)
    iPad Retina (F0074735-FFA5-497C-B820-1CA4C54A6249) (Shutdown) (unavailable, runtime profile not found)
    iPad Air (FBF8EBAA-D189-4A53-BE78-450B0E61A6C1) (Shutdown) (unavailable, runtime profile not found)
    Resizable iPhone (BB1A2556-9F41-4169-9331-69A706EBE71D) (Shutdown) (unavailable, runtime profile not found)
    Resizable iPad (3F7EB89F-C354-4426-99A7-8B2876D9137C) (Shutdown) (unavailable, runtime profile not found)
-- Unavailable: com.apple.CoreSimulator.SimRuntime.iOS-8-2 --
    iPhone 4s (7CF52AEB-3758-4C96-969A-1BCCDE390C30) (Shutdown) (unavailable, runtime profile not found)
    iPhone 5 (C633DDCD-0697-45A9-A476-978BBD112089) (Shutdown) (unavailable, runtime profile not found)
    iPhone 5s (0761C4F9-A72B-44A5-B729-7C58108C1675) (Shutdown) (unavailable, runtime profile not found)
    iPhone 6 Plus (6D25620E-7284-4205-8957-F87FCDC293F0) (Shutdown) (unavailable, runtime profile not found)
    iPhone 6 (16B237D6-7CBD-4900-8945-67AFDDFFC34D) (Shutdown) (unavailable, runtime profile not found)
    iPad 2 (5AFB1022-CD89-4819-BFA4-2B00F6023610) (Shutdown) (unavailable, runtime profile not found)
    iPad Retina (ABF307BA-336E-4E89-ACF1-9B50CFC55792) (Shutdown) (unavailable, runtime profile not found)
    iPad Air (F35FE79E-049F-4E48-ADC0-6C0797664322) (Shutdown) (unavailable, runtime profile not found)
    Resizable iPhone (F45688AD-BE2E-411B-B42E-DA7F3F7D9064) (Shutdown) (unavailable, runtime profile not found)
    Resizable iPad (41446467-6BCF-4285-8ED4-8340640463F8) (Shutdown) (unavailable, runtime profile not found)
-- Unavailable: com.apple.CoreSimulator.SimRuntime.iOS-9-0 --
    iPhone 4s (3DEA76F0-5778-4C95-A8BA-1420E99D1262) (Shutdown) (unavailable, runtime profile not found)
    iPhone 5 (5BD2699A-6667-40E5-973E-3E2A7FB79C8D) (Shutdown) (unavailable, runtime profile not found)
    iPhone 5s (A6875D18-860B-4E64-B40A-F90E0196CD10) (Shutdown) (unavailable, runtime profile not found)
    iPhone 6 Plus (C604E625-AD90-42C7-B2C6-002BD40D6ADB) (Shutdown) (unavailable, runtime profile not found)
    iPhone 6 (1DAABBE6-F53E-4813-8C25-9AABDD03FF2B) (Shutdown) (unavailable, runtime profile not found)
    iPad 2 (71E03143-91B8-4F35-8A2D-888A6E1F88AA) (Shutdown) (unavailable, runtime profile not found)
    iPad Retina (1EABE0E3-AC73-4CD6-9077-60E2320342D4) (Shutdown) (unavailable, runtime profile not found)
    iPad Air (4936A241-59E8-4B2D-B3BF-FA203389B4D3) (Shutdown) (unavailable, runtime profile not found)
    iPad Air 2 (8A6B245D-16C0-43A2-BEB8-E24BB5670D6E) (Shutdown) (unavailable, runtime profile not found)
-- Unavailable: com.apple.CoreSimulator.SimRuntime.watchOS-2-0 --
    Apple Watch - 38mm (50C34B32-F561-489A-B86D-3541D4A9ECD4) (Shutdown) (unavailable, runtime profile not found)
    Apple Watch - 42mm (614A4B29-6E71-40A1-8031-CF667DE8FD5D) (Shutdown) (unavailable, runtime profile not found)
```

This PR modifies the rakefile to ignore sims that are listed as unavailable.