### PR TITLE
Updating AFNetworkActivityManagerTests to use a NiceMock

### DIFF
--- a/Tests/Tests/AFNetworkActivityManagerTests.m
+++ b/Tests/Tests/AFNetworkActivityManagerTests.m
@@ -40,7 +40,7 @@
     self.networkActivityIndicatorManager = [[AFNetworkActivityIndicatorManager alloc] init];
     self.networkActivityIndicatorManager.enabled = YES;
 
-    self.mockApplication = [OCMockObject mockForClass:[UIApplication class]];
+    self.mockApplication = [OCMockObject niceMockForClass:[UIApplication class]];
     [[[self.mockApplication stub] andReturn:self.mockApplication] sharedApplication];
 
     [[[self.mockApplication stub] andDo:^(NSInvocation *invocation) {


### PR DESCRIPTION
We have lots of random race condition failures that I believe are caused by a mock class getting a notification from another request finishing from a previous test. I think if we switch over to a niceMock, that should squash that random failure.