### PR TITLE
Removed NSNull objects from JSON arrays

### DIFF
--- a/AFNetworking/AFURLResponseSerialization.m
+++ b/AFNetworking/AFURLResponseSerialization.m
@@ -60,7 +60,9 @@ static id AFJSONObjectByRemovingKeysWithNullValues(id JSONObject, NSJSONReadingO
     if ([JSONObject isKindOfClass:[NSArray class]]) {
         NSMutableArray *mutableArray = [NSMutableArray arrayWithCapacity:[(NSArray *)JSONObject count]];
         for (id value in (NSArray *)JSONObject) {
-            [mutableArray addObject:AFJSONObjectByRemovingKeysWithNullValues(value, readingOptions)];
+            if (![value isKindOfClass:[NSNull class]]) {
+                [mutableArray addObject:AFJSONObjectByRemovingKeysWithNullValues(value, readingOptions)];
+            }
         }
 
         return (readingOptions & NSJSONReadingMutableContainers) ? mutableArray : [NSArray arrayWithArray:mutableArray];

--- a/Tests/Tests/AFJSONSerializationTests.m
+++ b/Tests/Tests/AFJSONSerializationTests.m
@@ -133,4 +133,14 @@ static NSData * AFJSONTestData() {
     XCTAssertNotNil(error, @"Serialization error should not be nil");
 }
 
+- (void)testThatJSONResponseSerializerRemovesNullsFromArray {
+    NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:self.baseURL statusCode:200 HTTPVersion:@"1.1" headerFields:@{@"Content-Type": @"text/json"}];
+    NSError *error = nil;
+    self.responseSerializer.removesKeysWithNullValues = YES;
+    id responseData = [self.responseSerializer responseObjectForResponse:response data:[@"{\"key\": [4, null, 3]}" dataUsingEncoding:NSUTF8StringEncoding] error:&error];
+    id expected = @{@"key": @[@4, @3]};
+    XCTAssertNil(error, @"Serialization error should be nil");
+    XCTAssert([expected isEqualToDictionary:responseData], @"Expected NSNull to be removed. (Expected %@, got %@)", expected, responseData);
+}
+
 @end


### PR DESCRIPTION
Right now, `{"key": [1,2,null,4]}` becomes `@{@"key": @[@1, @2, [NSNull null], @4]}`.

This PR removes NSNulls from arrays while processing arrays in `AFJSONObjectByRemovingKeysWithNullValues`.

This PR also has a test for that behavior.