### PR TITLE
problem with baseURL

### DIFF
--- a/AFNetworking/AFHTTPSessionManager.h
+++ b/AFNetworking/AFHTTPSessionManager.h
@@ -84,7 +84,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface AFHTTPSessionManager : AFURLSessionManager <NSSecureCoding, NSCopying>
 
 /**
- The URL used to monitor reachability, and construct requests from relative paths in methods like `requestWithMethod:URLString:parameters:`, and the `GET` / `POST` / et al. convenience methods.
+ The URL used to construct requests from relative paths in methods like `requestWithMethod:URLString:parameters:`, and the `GET` / `POST` / et al. convenience methods.
  */
 @property (readonly, nonatomic, strong, nullable) NSURL *baseURL;
 


### PR DESCRIPTION
```Objective-C
/**
 The URL used to monitor reachability, and construct requests from relative paths in methods like `requestWithMethod:URLString:parameters:`, and the `GET` / `POST` / et al. convenience methods.
 */
@property (readonly, nonatomic, strong) NSURL *baseURL;
```

In the `- (instancetype)initWithBaseURL:(NSURL *)` method, `self.reachabilityManager` doesn't use the baseURL. I know I can adjust `self.reachabilityManager` later with `"initWithReachability`. But the description confused me. Is this a problem? 
