### PR TITLE
Added functionality to send empty array in params for NSURLRequest.

### DIFF
--- a/AFNetworking/AFURLRequestSerialization.m
+++ b/AFNetworking/AFURLRequestSerialization.m
@@ -145,6 +145,9 @@ NSArray * AFQueryStringPairsFromKeyAndValue(NSString *key, id value) {
         for (id nestedValue in array) {
             [mutableQueryStringComponents addObjectsFromArray:AFQueryStringPairsFromKeyAndValue([NSString stringWithFormat:@"%@[]", key], nestedValue)];
         }
+        if (array.count == 0) {
+            [mutableQueryStringComponents addObjectsFromArray:AFQueryStringPairsFromKeyAndValue([NSString stringWithFormat:@"%@[]", key], @"")];
+        }
     } else if ([value isKindOfClass:[NSSet class]]) {
         NSSet *set = value;
         for (id obj in [set sortedArrayUsingDescriptors:@[ sortDescriptor ]]) {

--- a/Tests/Tests/AFHTTPRequestSerializationTests.m
+++ b/Tests/Tests/AFHTTPRequestSerializationTests.m
@@ -116,6 +116,13 @@
     XCTAssertTrue([part.headers[@"Content-Type"] isEqualToString:@"application/x-x509-ca-cert"], @"MIME Type has not been obtained correctly (%@)", part.headers[@"Content-Type"]);
 }
 
+- (void)testThatAFHTTPRequestSerlizationSerializesParamsThatHaveEmptyArray {
+    NSURLRequest *originalRequest = [NSURLRequest requestWithURL:[NSURL URLWithString:@"http://example.com"]];
+    NSURLRequest *serializedRequest = [self.requestSerializer requestBySerializingRequest:originalRequest withParameters:@{@"key":@[]} error:nil];
+   
+    XCTAssertTrue([[[serializedRequest URL] query] isEqualToString:@"key%5B%5D="], @"Query parameters have not been serialized correctly (%@)", [[serializedRequest URL] query]);
+}
+
 #pragma mark -
 
 - (void)testThatValueForHTTPHeaderFieldReturnsSetValue {


### PR DESCRIPTION
Previously if trying to send a NSURLRequest with an empty array in the params the empty array would simply be dropped, now it will send the empty array as a key value pair with the value being an empty string.