### PR TITLE
Changed Accept-Language header to start with the locale with country code (with more tests)

### DIFF
--- a/AFNetworking/AFURLRequestSerialization.h
+++ b/AFNetworking/AFURLRequestSerialization.h
@@ -170,6 +170,13 @@ forHTTPHeaderField:(NSString *)field;
  */
 - (void)clearAuthorizationHeader;
 
+/**
+ Sets the "Accept-Languages" HTTP header in request objects made by the HTTP client.
+ 
+ @param languages an array of NSString objects, where each string is a language ID.
+ */
+- (void)setAcceptLanguageHeader:(NSArray*)languages;
+
 ///-------------------------------------------------------
 /// @name Configuring Query String Parameter Serialization
 ///-------------------------------------------------------

--- a/AFNetworking/AFURLRequestSerialization.h
+++ b/AFNetworking/AFURLRequestSerialization.h
@@ -173,7 +173,7 @@ forHTTPHeaderField:(NSString *)field;
 /**
  Sets the "Accept-Languages" HTTP header in request objects made by the HTTP client.
  
- @param languages an array of NSString objects, where each string is a language ID.
+ @param languages an array of NSLocale objects or NSString objects, where each string is a language ID.
  */
 - (void)setAcceptLanguageHeader:(NSArray*)languages;
 

--- a/AFNetworking/AFURLRequestSerialization.m
+++ b/AFNetworking/AFURLRequestSerialization.m
@@ -203,7 +203,9 @@ static void *AFHTTPRequestSerializerObserverContext = &AFHTTPRequestSerializerOb
 
     self.mutableHTTPRequestHeaders = [NSMutableDictionary dictionary];
 
-    [self setAcceptLanguageHeader:[NSLocale preferredLanguages]];
+    NSMutableArray *acceptLanguages = [[NSLocale preferredLanguages] mutableCopy];
+    [acceptLanguages insertObject:[NSLocale currentLocale] atIndex:0];
+    [self setAcceptLanguageHeader:acceptLanguages];
 
     NSString *userAgent = nil;
 #pragma clang diagnostic push

--- a/AFNetworking/AFURLRequestSerialization.m
+++ b/AFNetworking/AFURLRequestSerialization.m
@@ -203,14 +203,7 @@ static void *AFHTTPRequestSerializerObserverContext = &AFHTTPRequestSerializerOb
 
     self.mutableHTTPRequestHeaders = [NSMutableDictionary dictionary];
 
-    // Accept-Language HTTP Header; see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.4
-    NSMutableArray *acceptLanguagesComponents = [NSMutableArray array];
-    [[NSLocale preferredLanguages] enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
-        float q = 1.0f - (idx * 0.1f);
-        [acceptLanguagesComponents addObject:[NSString stringWithFormat:@"%@;q=%0.1g", obj, q]];
-        *stop = q <= 0.5f;
-    }];
-    [self setValue:[acceptLanguagesComponents componentsJoinedByString:@", "] forHTTPHeaderField:@"Accept-Language"];
+    [self setAcceptLanguageHeader:[NSLocale preferredLanguages]];
 
     NSString *userAgent = nil;
 #pragma clang diagnostic push
@@ -323,6 +316,17 @@ forHTTPHeaderField:(NSString *)field
 
 - (void)clearAuthorizationHeader {
 	[self.mutableHTTPRequestHeaders removeObjectForKey:@"Authorization"];
+}
+
+- (void)setAcceptLanguageHeader:(NSArray*)languages {
+    // Accept-Language HTTP Header; see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.4
+    NSMutableArray *acceptLanguagesComponents = [NSMutableArray array];
+    [languages enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+        float q = 1.0f - (idx * 0.1f);
+        [acceptLanguagesComponents addObject:[NSString stringWithFormat:@"%@;q=%0.1g", obj, q]];
+        *stop = q <= 0.5f;
+    }];
+    [self setValue:[acceptLanguagesComponents componentsJoinedByString:@", "] forHTTPHeaderField:@"Accept-Language"];
 }
 
 #pragma mark -

--- a/AFNetworking/AFURLRequestSerialization.m
+++ b/AFNetworking/AFURLRequestSerialization.m
@@ -323,7 +323,17 @@ forHTTPHeaderField:(NSString *)field
     NSMutableArray *acceptLanguagesComponents = [NSMutableArray array];
     [languages enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
         float q = 1.0f - (idx * 0.1f);
-        [acceptLanguagesComponents addObject:[NSString stringWithFormat:@"%@;q=%0.1g", obj, q]];
+        NSString *langTag;
+        if ([obj isKindOfClass:[NSLocale class]]) {
+            NSLocale *locale = (NSLocale *)obj;
+            // Language Tags; see http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.10
+            langTag = [NSString stringWithFormat:@"%@-%@",
+                       [locale objectForKey:NSLocaleLanguageCode],
+                       [locale objectForKey:NSLocaleCountryCode]];
+        } else {
+            langTag = obj;
+        }
+        [acceptLanguagesComponents addObject:[NSString stringWithFormat:@"%@;q=%0.1g", langTag, q]];
         *stop = q <= 0.5f;
     }];
     [self setValue:[acceptLanguagesComponents componentsJoinedByString:@", "] forHTTPHeaderField:@"Accept-Language"];

--- a/Tests/Tests/AFHTTPRequestSerializationTests.m
+++ b/Tests/Tests/AFHTTPRequestSerializationTests.m
@@ -149,12 +149,12 @@
 }
 
 - (void)testThatAcceptLanguageEncodesCorrectly {
-    //    NSLocale *currentLocale = [NSLocale localeWithLocaleIdentifier:@"en_US"];
-    NSArray *preferredLanguages = @[ @"en", @"fr", @"de", @"zh-Hans", @"zh-Hant", @"ja" ];
+    NSLocale *currentLocale = [NSLocale localeWithLocaleIdentifier:@"en_US"];
+    NSArray *preferredLanguages = @[ currentLocale, @"en", @"fr", @"de", @"zh-Hans", @"zh-Hant", @"ja" ];
     [self.requestSerializer setAcceptLanguageHeader:preferredLanguages];
 
     NSString *value = [self.requestSerializer valueForHTTPHeaderField:@"Accept-Language"];
     
-    XCTAssertEqualObjects(@"en;q=1, fr;q=0.9, de;q=0.8, zh-Hans;q=0.7, zh-Hant;q=0.6, ja;q=0.5", value);
+    XCTAssertEqualObjects(@"en-US;q=1, en;q=0.9, fr;q=0.8, de;q=0.7, zh-Hans;q=0.6, zh-Hant;q=0.5", value);
 }
 @end

--- a/Tests/Tests/AFHTTPRequestSerializationTests.m
+++ b/Tests/Tests/AFHTTPRequestSerializationTests.m
@@ -148,4 +148,13 @@
     expect(error).to.equal(serializerError);
 }
 
+- (void)testThatAcceptLanguageEncodesCorrectly {
+    //    NSLocale *currentLocale = [NSLocale localeWithLocaleIdentifier:@"en_US"];
+    NSArray *preferredLanguages = @[ @"en", @"fr", @"de", @"zh-Hans", @"zh-Hant", @"ja" ];
+    [self.requestSerializer setAcceptLanguageHeader:preferredLanguages];
+
+    NSString *value = [self.requestSerializer valueForHTTPHeaderField:@"Accept-Language"];
+    
+    XCTAssertEqualObjects(@"en;q=1, fr;q=0.9, de;q=0.8, zh-Hans;q=0.7, zh-Hant;q=0.6, ja;q=0.5", value);
+}
 @end


### PR DESCRIPTION
a re-implementaiton of https://github.com/AFNetworking/AFNetworking/pull/2746

in order to make it easier to test, I added a new method:

``` objc
/**
 Sets the "Accept-Languages" HTTP header in request objects made by the HTTP client.

 @param languages an array of NSLocale objects or NSString objects, where each string is a language ID.
 */
- (void)setAcceptLanguageHeader:(NSArray*)languages;
```

I added the tests based on what [NSLocale currentLocale] and [NSLocale preferredLanguages] returned on my environment.

Let me know if you want an explicit test for the default Accept-Language.
