### PR TITLE
watchOS_support: Fix to allow proper compilation on iOS SDK prior to 9.0

### DIFF
--- a/AFNetworking/AFNetworking.h
+++ b/AFNetworking/AFNetworking.h
@@ -29,7 +29,7 @@
     #import "AFURLRequestSerialization.h"
     #import "AFURLResponseSerialization.h"
     #import "AFSecurityPolicy.h"
-#if !defined(TARGET_OS_WATCH) || !TARGET_OS_WATCH
+#if !TARGET_OS_WATCH
     #import "AFNetworkReachabilityManager.h"
     #import "AFURLConnectionOperation.h"
     #import "AFHTTPRequestOperation.h"

--- a/AFNetworking/AFNetworking.h
+++ b/AFNetworking/AFNetworking.h
@@ -29,7 +29,7 @@
     #import "AFURLRequestSerialization.h"
     #import "AFURLResponseSerialization.h"
     #import "AFSecurityPolicy.h"
-#if !TARGET_OS_WATCH
+#if !defined(TARGET_OS_WATCH) || !TARGET_OS_WATCH
     #import "AFNetworkReachabilityManager.h"
     #import "AFURLConnectionOperation.h"
     #import "AFHTTPRequestOperation.h"

--- a/AFNetworking/AFSecurityPolicy.m
+++ b/AFNetworking/AFSecurityPolicy.m
@@ -23,7 +23,7 @@
 
 #import <AssertMacros.h>
 
-#if !TARGET_OS_IPHONE && (defined(TARGET_OS_IOS) && !TARGET_OS_IOS) && (defined(TARGET_OS_WATCH) && !TARGET_OS_WATCH)
+#if !TARGET_OS_IPHONE || ((defined(TARGET_OS_IOS) && !TARGET_OS_IOS) && (defined(TARGET_OS_WATCH) && !TARGET_OS_WATCH))
 static NSData * AFSecKeyGetData(SecKeyRef key) {
     CFDataRef data = NULL;
 

--- a/AFNetworking/AFSecurityPolicy.m
+++ b/AFNetworking/AFSecurityPolicy.m
@@ -23,7 +23,7 @@
 
 #import <AssertMacros.h>
 
-#if !TARGET_OS_IOS && !TARGET_OS_WATCH
+#if defined(TARGET_OS_IOS) && defined(TARGET_OS_WATCH) && !TARGET_OS_IOS && !TARGET_OS_WATCH
 static NSData * AFSecKeyGetData(SecKeyRef key) {
     CFDataRef data = NULL;
 
@@ -41,7 +41,7 @@ _out:
 #endif
 
 static BOOL AFSecKeyIsEqualToKey(SecKeyRef key1, SecKeyRef key2) {
-#if TARGET_OS_IOS || TARGET_OS_WATCH
+#if (TARGET_OS_IPHONE && !defined(TARGET_OS_IOS) && !defined(TARGET_OS_WATCH)) || TARGET_OS_IOS || TARGET_OS_WATCH
     return [(__bridge id)key1 isEqual:(__bridge id)key2];
 #else
     return [AFSecKeyGetData(key1) isEqual:AFSecKeyGetData(key2)];

--- a/AFNetworking/AFSecurityPolicy.m
+++ b/AFNetworking/AFSecurityPolicy.m
@@ -23,7 +23,7 @@
 
 #import <AssertMacros.h>
 
-#if defined(TARGET_OS_IOS) && defined(TARGET_OS_WATCH) && !TARGET_OS_IOS && !TARGET_OS_WATCH
+#if !TARGET_OS_IPHONE && (defined(TARGET_OS_IOS) && !TARGET_OS_IOS) && (defined(TARGET_OS_WATCH) && !TARGET_OS_WATCH)
 static NSData * AFSecKeyGetData(SecKeyRef key) {
     CFDataRef data = NULL;
 
@@ -41,7 +41,7 @@ _out:
 #endif
 
 static BOOL AFSecKeyIsEqualToKey(SecKeyRef key1, SecKeyRef key2) {
-#if (TARGET_OS_IPHONE && !defined(TARGET_OS_IOS) && !defined(TARGET_OS_WATCH)) || TARGET_OS_IOS || TARGET_OS_WATCH
+#if TARGET_OS_IPHONE || TARGET_OS_IOS || TARGET_OS_WATCH
     return [(__bridge id)key1 isEqual:(__bridge id)key2];
 #else
     return [AFSecKeyGetData(key1) isEqual:AFSecKeyGetData(key2)];

--- a/AFNetworking/AFURLResponseSerialization.m
+++ b/AFNetworking/AFURLResponseSerialization.m
@@ -21,7 +21,7 @@
 
 #import "AFURLResponseSerialization.h"
 
-#if TARGET_OS_IOS
+#if TARGET_OS_IPHONE && (!defined(TARGET_OS_IOS) || TARGET_OS_IOS)
 #import <UIKit/UIKit.h>
 #elif TARGET_OS_WATCH
 #import <WatchKit/WatchKit.h>


### PR DESCRIPTION
The current `watchOS_support` branch does not correctly compile when trying to use an iOS SDK prior to 9.0. This issues is an annoying and avoidable regression.

The main issue is that the current code assumes that `TARGET_OS_IOS` is sufficient to determine that you’re compiling for iOS. However, this was only added in the 9.0 SDK, so it as absent when trying to use an older SDK (or Xcode version), which causes the compilation to take the “OS X” route.

The change in this PR uses the fact that `TARGET_OS_IPHONE` is true for both iOS and watchOS and exists prior the iOS 9 SDK.