### PR TITLE
Convert query escapes to `stringByAddingPercentEncodingWithAllowedCharacters`

### DIFF
--- a/Tests/Tests/AFHTTPRequestSerializationTests.m
+++ b/Tests/Tests/AFHTTPRequestSerializationTests.m
@@ -74,9 +74,9 @@
 
 - (void)testThatAFHTTPRequestSerialiationSerializesURLEncodableQueryParametersCorrectly {
     NSURLRequest *originalRequest = [NSURLRequest requestWithURL:[NSURL URLWithString:@"http://example.com"]];
-    NSURLRequest *serializedRequest = [self.requestSerializer requestBySerializingRequest:originalRequest withParameters:@{@"key":@" !\"#$%&'()*+,/"} error:nil];
+    NSURLRequest *serializedRequest = [self.requestSerializer requestBySerializingRequest:originalRequest withParameters:@{@"key":@" :#[]@!$&'()*+,;=/?"} error:nil];
 
-    XCTAssertTrue([[[serializedRequest URL] query] isEqualToString:@"key=%20%21%22%23%24%25%26%27%28%29%2A%2B%2C%2F"], @"Query parameters have not been serialized correctly (%@)", [[serializedRequest URL] query]);
+    XCTAssertTrue([[[serializedRequest URL] query] isEqualToString:@"key=%20%3A%23%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D/?"], @"Query parameters have not been serialized correctly (%@)", [[serializedRequest URL] query]);
 }
 
 - (void)testThatAFHTTPRequestSerialiationSerializesURLEncodedQueryParametersCorrectly {


### PR DESCRIPTION
Since watchOS requires us to use `stringByAddingPercentEncodingWithAllowedCharacters`, we've migrated over to that. We're also using the logic that has been baked in to AlamoFire.

Note this does have one backwards compatible issue. `/` and `?` are no longer encoded in the query parameters, per RFC 3986.

```
 In RFC 3986 - Section 3.4, it states that the "?" and "/" characters should not be escaped to allow
 query strings to include a URL. Therefore, all "reserved" characters with the exception of "?" and "/"
 should be percent-escaped in the query string.
    - parameter string: The string to be percent-escaped.
    - returns: The percent-escaped string.
```

@cnoon want to take a look?