### PR TITLE
Ability to set a custom processing queue for AFHTTPRequestOperation

### DIFF
--- a/AFNetworking/AFHTTPRequestOperation.h
+++ b/AFNetworking/AFHTTPRequestOperation.h
@@ -65,6 +65,19 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setCompletionBlockWithSuccess:(nullable void (^)(AFHTTPRequestOperation *operation, id responseObject))success
                               failure:(nullable void (^)(AFHTTPRequestOperation *operation, NSError *error))failure;
 
+///---------------------------------
+/// @name Managing Callback Queues
+///---------------------------------
+
+/**
+ The dispatch queue for the block that is determining which callback block (success or failure) will be called according to response. If `NULL` (default), a private concurrent queue is used.
+ */
+#if OS_OBJECT_HAVE_OBJC_SUPPORT
+@property (nonatomic, strong, nullable) dispatch_queue_t completionProcessingQueue;
+#else
+@property (nonatomic, assign, nullable) dispatch_queue_t completionProcessingQueue;
+#endif
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/AFNetworking/AFHTTPRequestOperation.m
+++ b/AFNetworking/AFHTTPRequestOperation.m
@@ -116,7 +116,7 @@ static dispatch_group_t http_request_operation_completion_group() {
             dispatch_group_enter(self.completionGroup);
         }
 
-        dispatch_async(http_request_operation_processing_queue(), ^{
+		dispatch_async(self.completionProcessingQueue ?: http_request_operation_processing_queue(), ^{
             if (self.error) {
                 if (failure) {
                     dispatch_group_async(self.completionGroup ?: http_request_operation_completion_group(), self.completionQueue ?: dispatch_get_main_queue(), ^{
@@ -199,6 +199,7 @@ static dispatch_group_t http_request_operation_completion_group() {
     operation.responseSerializer = [self.responseSerializer copyWithZone:zone];
     operation.completionQueue = self.completionQueue;
     operation.completionGroup = self.completionGroup;
+	operation.completionProcessingQueue = self.completionProcessingQueue;
 
     return operation;
 }

--- a/AFNetworking/AFHTTPRequestOperationManager.h
+++ b/AFNetworking/AFHTTPRequestOperationManager.h
@@ -175,6 +175,15 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign, nullable) dispatch_group_t completionGroup;
 #endif
 
+/**
+ The dispatch queue for the block that is determining which callback block (success or failure) will be called according to response. If `NULL` (default), a private concurrent queue is used.
+ */
+#if OS_OBJECT_HAVE_OBJC_SUPPORT
+@property (nonatomic, strong, nullable) dispatch_queue_t completionProcessingQueue;
+#else
+@property (nonatomic, assign, nullable) dispatch_queue_t completionProcessingQueue;
+#endif
+
 ///---------------------------------------------
 /// @name Creating and Initializing HTTP Clients
 ///---------------------------------------------

--- a/AFNetworking/AFHTTPRequestOperationManager.m
+++ b/AFNetworking/AFHTTPRequestOperationManager.m
@@ -128,7 +128,7 @@
     [operation setCompletionBlockWithSuccess:success failure:failure];
     operation.completionQueue = self.completionQueue;
     operation.completionGroup = self.completionGroup;
-
+	operation.completionProcessingQueue = self.completionProcessingQueue;
     return operation;
 }
 

--- a/Tests/AFNetworking Tests.xcodeproj/project.pbxproj
+++ b/Tests/AFNetworking Tests.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		36DE265018053E930062F4E3 /* adn_2.cer in Resources */ = {isa = PBXBuildFile; fileRef = 36DE264D18053E930062F4E3 /* adn_2.cer */; };
 		36DE2652180544600062F4E3 /* AFHTTPRequestOperationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 29CBFC3817DF4F120021AB75 /* AFHTTPRequestOperationTests.m */; };
 		3D56634E3A564CEE86172413 /* libPods-osx.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 96A923755B00464187DEDBAF /* libPods-osx.a */; };
+		4F4BB4F71BA6004600E67455 /* AFHTTPRequestOperationManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F4BB4F61BA6004600E67455 /* AFHTTPRequestOperationManagerTests.m */; settings = {ASSET_TAGS = (); }; };
 		6D86BAA5C6174E98AE719CE9 /* libPods-ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 55E73C267F33406A9F92476C /* libPods-ios.a */; };
 		77D65EBC1848A03C004CA024 /* AFPropertyListResponseSerializerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 77D65EBB1848A03C004CA024 /* AFPropertyListResponseSerializerTests.m */; };
 		77D65EBD1848A03C004CA024 /* AFPropertyListResponseSerializerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 77D65EBB1848A03C004CA024 /* AFPropertyListResponseSerializerTests.m */; };
@@ -114,6 +115,7 @@
 		36DE264B18053E930062F4E3 /* adn_0.cer */ = {isa = PBXFileReference; lastKnownFileType = file; name = adn_0.cer; path = Resources/ADN.net/ADNNetServerTrustChain/adn_0.cer; sourceTree = "<group>"; };
 		36DE264C18053E930062F4E3 /* adn_1.cer */ = {isa = PBXFileReference; lastKnownFileType = file; name = adn_1.cer; path = Resources/ADN.net/ADNNetServerTrustChain/adn_1.cer; sourceTree = "<group>"; };
 		36DE264D18053E930062F4E3 /* adn_2.cer */ = {isa = PBXFileReference; lastKnownFileType = file; name = adn_2.cer; path = Resources/ADN.net/ADNNetServerTrustChain/adn_2.cer; sourceTree = "<group>"; };
+		4F4BB4F61BA6004600E67455 /* AFHTTPRequestOperationManagerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFHTTPRequestOperationManagerTests.m; sourceTree = "<group>"; };
 		520A0FB27D040CF3258787D2 /* Pods-osx.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-osx.debug.xcconfig"; path = "Pods/Target Support Files/Pods-osx/Pods-osx.debug.xcconfig"; sourceTree = "<group>"; };
 		55E73C267F33406A9F92476C /* libPods-ios.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ios.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		77D65EBB1848A03C004CA024 /* AFPropertyListResponseSerializerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFPropertyListResponseSerializerTests.m; sourceTree = "<group>"; };
@@ -284,6 +286,7 @@
 				2940C0091B063C6700AFDAC7 /* AFUIActivityIndicatorViewTests.m */,
 				2940C00B1B064C3200AFDAC7 /* AFUIRefreshControlTests.m */,
 				C61291631B21E27700B9475A /* AFUIImageViewTests.m */,
+				4F4BB4F61BA6004600E67455 /* AFHTTPRequestOperationManagerTests.m */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -539,6 +542,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4F4BB4F71BA6004600E67455 /* AFHTTPRequestOperationManagerTests.m in Sources */,
 				2940C00A1B063C6700AFDAC7 /* AFUIActivityIndicatorViewTests.m in Sources */,
 				C61291641B21E27700B9475A /* AFUIImageViewTests.m in Sources */,
 				29CBFC3917DF4F120021AB75 /* AFHTTPRequestOperationTests.m in Sources */,

--- a/Tests/Podfile
+++ b/Tests/Podfile
@@ -6,6 +6,7 @@ inhibit_all_warnings!
 
 def import_pods
   pod 'OCMock', '~> 2.1.1'
+  pod 'OHHTTPStubs', '~> 4.2.0'
   pod 'Expecta', '~> 0.2.1'
   pod 'AFNetworking', :path => '../'
 end

--- a/Tests/Tests/AFHTTPRequestOperationManagerTests.m
+++ b/Tests/Tests/AFHTTPRequestOperationManagerTests.m
@@ -1,0 +1,111 @@
+//
+//  AFHTTPRequestOperationManagerTests.m
+//  AFNetworking Tests
+//
+//  Created by Yavuz Nuzumlali on 13/09/15.
+//  Copyright © 2015 AFNetworking. All rights reserved.
+//
+
+#import <OHHTTPStubs/OHHTTPStubs.h>
+#import "AFHTTPRequestOperationManager.h"
+#import "AFTestCase.h"
+
+@interface AFHTTPRequestOperationManagerTests : AFTestCase
+
+@property (nonatomic, strong) AFHTTPRequestOperationManager *requestManager;
+@end
+
+@implementation AFHTTPRequestOperationManagerTests
+
+- (void)setUp {
+    [super setUp];
+	[Expecta setAsynchronousTestTimeout:10.0];
+
+	[OHHTTPStubs removeAllStubs];
+	self.requestManager = [[AFHTTPRequestOperationManager alloc] initWithBaseURL:self.baseURL];
+	self.requestManager.requestSerializer = [AFJSONRequestSerializer serializer];
+	self.requestManager.responseSerializer = [AFJSONResponseSerializer serializer];
+}
+
+- (void)tearDown {
+    [super tearDown];
+	[OHHTTPStubs removeAllStubs];
+	[Expecta setAsynchronousTestTimeout:5.0];
+}
+
+- (BOOL)isArraySorted:(NSArray*)array {
+	for (int i = 0; i < array.count - 2; i++) {
+		if ([array[i] integerValue] > [array[i+1] integerValue]) {
+			NSString *arrayStr = [[array subarrayWithRange:NSMakeRange(0, i+1)] componentsJoinedByString:@","];
+			@throw [NSException exceptionWithName:[NSString stringWithFormat:@"Order is corrupted. Subarray : %@", arrayStr] reason:@"" userInfo:nil];
+		}
+	}
+	return YES;
+}
+
+- (void)testThatUsingDefaultCompletionProcessingQueueWillCauseToLoseOrder {
+	// Stub all requests and return a response containing all HTTP headers of the corresponding request
+	[OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest * __nonnull request) {
+		return YES;
+	} withStubResponse:^OHHTTPStubsResponse * __nonnull(NSURLRequest * __nonnull request) {
+		return [OHHTTPStubsResponse responseWithData:[NSData data] statusCode:200 headers:[request allHTTPHeaderFields]];
+	}];
+
+	// Configure operationQueue to process requests serially.
+	self.requestManager.operationQueue.maxConcurrentOperationCount = 1;
+
+	int requestCount = 5000;
+	// This will hold ids of the requests in their completion order.
+	NSMutableArray *orderArray = [NSMutableArray array];
+	for (int i = 0; i < requestCount; i++) {
+		// Generate dummy requests and set their order number as an HTTP header value having key 'id'
+		[self.requestManager.requestSerializer setValue:[NSString stringWithFormat:@"%d",i] forHTTPHeaderField:@"id"];
+		[self.requestManager POST:@""
+					   parameters:nil
+						  success:^(AFHTTPRequestOperation * __nonnull operation, id  __nonnull responseObject) {
+							  // Add id of the request to orderArray
+							  [orderArray addObject:[operation.response allHeaderFields][@"id"]];
+						  }
+						  failure:^(AFHTTPRequestOperation * __nonnull operation, NSError * __nonnull error) {
+						  }
+		 ];
+	}
+	expect(orderArray.count).will.equal(@(requestCount));
+	expect(^{[self isArraySorted:orderArray];}).will.raiseAny();
+}
+
+- (void)testThatUsingSerialCompletionProcessingQueueDoesNotLoseOrder {
+	// Stub all requests and return a response containing all HTTP headers of the corresponding request
+	[OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest * __nonnull request) {
+		return YES;
+	} withStubResponse:^OHHTTPStubsResponse * __nonnull(NSURLRequest * __nonnull request) {
+		return [OHHTTPStubsResponse responseWithData:[NSData data] statusCode:200 headers:[request allHTTPHeaderFields]];
+	}];
+
+	// Configure operationQueue to process requests serially.
+	self.requestManager.operationQueue.maxConcurrentOperationCount = 1;
+	// Set a serial queue for 'completionProcessingQueue'
+	self.requestManager.completionProcessingQueue = dispatch_queue_create("com.alamofire.serialCompletionProcessingQueue", DISPATCH_QUEUE_SERIAL);
+
+	int requestCount = 5000;
+	// This will hold ids of the requests in their completion order.
+	NSMutableArray *orderArray = [NSMutableArray array];
+	for (int i = 0; i < requestCount; i++) {
+		// Generate dummy requests and set their order number as an HTTP header value having key 'id'
+		[self.requestManager.requestSerializer setValue:[NSString stringWithFormat:@"%d",i] forHTTPHeaderField:@"id"];
+		[self.requestManager POST:@""
+					   parameters:nil
+						  success:^(AFHTTPRequestOperation * __nonnull operation, id  __nonnull responseObject) {
+							  // Add id of the request to orderArray
+							  [orderArray addObject:[operation.response allHeaderFields][@"id"]];
+						  }
+						  failure:^(AFHTTPRequestOperation * __nonnull operation, NSError * __nonnull error) {
+						  }
+		 ];
+	}
+	expect(orderArray.count).will.equal(@(requestCount));
+	expect(^{[self isArraySorted:orderArray];}).willNot.raiseAny();
+}
+
+
+@end


### PR DESCRIPTION
As stated in #2929, when an AFHTTPRequestOperation completes, it dispatches the task of calling success/failure blocks into `http_request_operation_processing_queue()` queue, which is a concurrent queue by default.

If somebody needs to assure that success/failure blocks of requests will be called exactly the same order with calling order of the requests, she can set `requestManager.operationQueue.maxConcurrentOperationCount = 1`. This will guarantee that requests will be sent to network layer in calling order, and their `completionBlock`s will be called in order also. However, because http_request_operation_processing_queue() works concurrently, the calling order of success/failure blocks happens to be broken in edge cases.

Setting a serial queue instance to this property will also gurantee ordering for success/failure callback blocks.

By the way, I'm not really sure about the name of the property, is there anyone having a better name proposal?