### PR TITLE
Let app devs use taskDescription by using associated objects internally

### DIFF
--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -282,6 +282,7 @@ static inline BOOL af_addMethod(Class class, SEL selector, Method method) {
     return class_addMethod(class, selector,  method_getImplementation(method),  method_getTypeEncoding(method));
 }
 
+static void *AFNSURLSessionTaskSessionManagerKey = &AFNSURLSessionTaskSessionManagerKey;
 static NSString * const AFNSURLSessionTaskDidResumeNotification  = @"com.alamofire.networking.nsurlsessiontask.resume";
 static NSString * const AFNSURLSessionTaskDidSuspendNotification = @"com.alamofire.networking.nsurlsessiontask.suspend";
 
@@ -390,7 +391,6 @@ static NSString * const AFNSURLSessionTaskDidSuspendNotification = @"com.alamofi
 @property (readwrite, nonatomic, strong) NSOperationQueue *operationQueue;
 @property (readwrite, nonatomic, strong) NSURLSession *session;
 @property (readwrite, nonatomic, strong) NSMutableDictionary *mutableTaskDelegatesKeyedByTaskIdentifier;
-@property (readonly, nonatomic, copy) NSString *taskDescriptionForSessionTasks;
 @property (readwrite, nonatomic, strong) NSLock *lock;
 @property (readwrite, nonatomic, copy) AFURLSessionDidBecomeInvalidBlock sessionDidBecomeInvalid;
 @property (readwrite, nonatomic, copy) AFURLSessionDidReceiveAuthenticationChallengeBlock sessionDidReceiveAuthenticationChallenge;
@@ -471,29 +471,23 @@ static NSString * const AFNSURLSessionTaskDidSuspendNotification = @"com.alamofi
 
 #pragma mark -
 
-- (NSString *)taskDescriptionForSessionTasks {
-    return [NSString stringWithFormat:@"%p", self];
-}
-
 - (void)taskDidResume:(NSNotification *)notification {
     NSURLSessionTask *task = notification.object;
-    if ([task respondsToSelector:@selector(taskDescription)]) {
-        if ([task.taskDescription isEqualToString:self.taskDescriptionForSessionTasks]) {
-            dispatch_async(dispatch_get_main_queue(), ^{
-                [[NSNotificationCenter defaultCenter] postNotificationName:AFNetworkingTaskDidResumeNotification object:task];
-            });
-        }
+    id manager = objc_getAssociatedObject(task, AFNSURLSessionTaskSessionManagerKey);
+    if (self == manager) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [[NSNotificationCenter defaultCenter] postNotificationName:AFNetworkingTaskDidResumeNotification object:task];
+        });
     }
 }
 
 - (void)taskDidSuspend:(NSNotification *)notification {
     NSURLSessionTask *task = notification.object;
-    if ([task respondsToSelector:@selector(taskDescription)]) {
-        if ([task.taskDescription isEqualToString:self.taskDescriptionForSessionTasks]) {
-            dispatch_async(dispatch_get_main_queue(), ^{
-                [[NSNotificationCenter defaultCenter] postNotificationName:AFNetworkingTaskDidSuspendNotification object:task];
-            });
-        }
+    id manager = objc_getAssociatedObject(task, AFNSURLSessionTaskSessionManagerKey);
+    if (self == manager) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [[NSNotificationCenter defaultCenter] postNotificationName:AFNetworkingTaskDidSuspendNotification object:task];
+        });
     }
 }
 
@@ -528,7 +522,7 @@ static NSString * const AFNSURLSessionTaskDidSuspendNotification = @"com.alamofi
     delegate.manager = self;
     delegate.completionHandler = completionHandler;
 
-    dataTask.taskDescription = self.taskDescriptionForSessionTasks;
+    objc_setAssociatedObject(dataTask, AFNSURLSessionTaskSessionManagerKey, self, OBJC_ASSOCIATION_ASSIGN);
     [self setDelegate:delegate forTask:dataTask];
 }
 
@@ -565,8 +559,7 @@ static NSString * const AFNSURLSessionTaskDidSuspendNotification = @"com.alamofi
         *progress = delegate.progress;
     }
 
-    uploadTask.taskDescription = self.taskDescriptionForSessionTasks;
-
+    objc_setAssociatedObject(uploadTask, AFNSURLSessionTaskSessionManagerKey, self, OBJC_ASSOCIATION_ASSIGN);
     [self setDelegate:delegate forTask:uploadTask];
 }
 
@@ -589,8 +582,7 @@ static NSString * const AFNSURLSessionTaskDidSuspendNotification = @"com.alamofi
         *progress = delegate.progress;
     }
 
-    downloadTask.taskDescription = self.taskDescriptionForSessionTasks;
-
+    objc_setAssociatedObject(downloadTask, AFNSURLSessionTaskSessionManagerKey, self, OBJC_ASSOCIATION_ASSIGN);
     [self setDelegate:delegate forTask:downloadTask];
 }
 


### PR DESCRIPTION
A _while_ ago, we started using a swizzle-observation of `-[NSURLSessionTask resume]` and `-[NSURLSessionTask suspend]` instead of KVO-observing the `state`, due to a crashing bug inside KVO. For background, see #1477.

Because app developers can use multiple instances of `AFURLSessionManager`, and because swizzle-observation will make every session manager see every task's state changes, regardless of which manager actually owns the task, we needed a way to associate the task with the session manager (#2476). We ended up using the `NSURLSessionTask`'s `taskDescription` for that purpose (#2477).

But some app developers have expressed interest in using the `taskDescription` for their own purposes (#2805), so this pull request replaces that implementation with one using `objc_(get|set)AssociatedObject`. We're using the runtime already...why not? (Sigh.)

Addresses #2805.
