### PR TITLE
fix TARGET_OS_IPHONE missing, cause error on Xcode6.x

### DIFF
--- a/AFNetworking/AFSecurityPolicy.h
+++ b/AFNetworking/AFSecurityPolicy.h
@@ -54,6 +54,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) BOOL allowInvalidCertificates;
 
 /**
+ Whether or not to trust servers with an expired (but ever authorized) SSL certificates. Defaults to `NO`.
+ */
+@property (nonatomic, assign) BOOL allowExpiredAuthorizedCertificates;
+
+/**
  Whether or not to validate the domain name in the certificate's CN field. Defaults to `YES`.
  */
 @property (nonatomic, assign) BOOL validatesDomainName;

--- a/AFNetworking/AFSecurityPolicy.m
+++ b/AFNetworking/AFSecurityPolicy.m
@@ -23,7 +23,7 @@
 
 #import <AssertMacros.h>
 
-#if !TARGET_OS_IOS && !TARGET_OS_WATCH
+#if !TARGET_OS_IPHONE && !TARGET_OS_IOS && !TARGET_OS_WATCH
 static NSData * AFSecKeyGetData(SecKeyRef key) {
     CFDataRef data = NULL;
 
@@ -41,7 +41,7 @@ _out:
 #endif
 
 static BOOL AFSecKeyIsEqualToKey(SecKeyRef key1, SecKeyRef key2) {
-#if TARGET_OS_IOS || TARGET_OS_WATCH
+#if TARGET_OS_IPHONE || TARGET_OS_IOS || TARGET_OS_WATCH
     return [(__bridge id)key1 isEqual:(__bridge id)key2];
 #else
     return [AFSecKeyGetData(key1) isEqual:AFSecKeyGetData(key2)];


### PR DESCRIPTION
fix TARGET_OS_IPHONE missing, cause error on Xcode6.x