### PR TITLE
[*] responseSerializer using fix

### DIFF
--- a/AFNetworking/AFHTTPRequestOperationManager.m
+++ b/AFNetworking/AFHTTPRequestOperationManager.m
@@ -50,25 +50,31 @@
     if (!self) {
         return nil;
     }
-
+    
     // Ensure terminal slash for baseURL path, so that NSURL +URLWithString:relativeToURL: works as expected
     if ([[url path] length] > 0 && ![[url absoluteString] hasSuffix:@"/"]) {
         url = [url URLByAppendingPathComponent:@""];
     }
-
+    
     self.baseURL = url;
-
+    
     self.requestSerializer = [AFHTTPRequestSerializer serializer];
-    self.responseSerializer = [AFJSONResponseSerializer serializer];
-
+    
+    NSArray* responseSerializers = @[[AFHTTPResponseSerializer serializer],
+                                     [AFXMLParserResponseSerializer serializer],
+                                     [AFJSONResponseSerializer serializer],
+                                     [AFPropertyListResponseSerializer serializer]];
+    
+    self.responseSerializer = [AFCompoundResponseSerializer compoundSerializerWithResponseSerializers:responseSerializers];
+    
     self.securityPolicy = [AFSecurityPolicy defaultPolicy];
-
+    
     self.reachabilityManager = [AFNetworkReachabilityManager sharedManager];
-
+    
     self.operationQueue = [[NSOperationQueue alloc] init];
-
+    
     self.shouldUseCredentialStorage = YES;
-
+    
     return self;
 }
 

--- a/AFNetworking/AFHTTPRequestOperationManager.m
+++ b/AFNetworking/AFHTTPRequestOperationManager.m
@@ -60,6 +60,7 @@
 
     self.requestSerializer = [AFHTTPRequestSerializer serializer];
     
+    // It used to be able to work with different types of response
     NSArray* responseSerializers = @[[AFHTTPResponseSerializer serializer],
                                      [AFXMLParserResponseSerializer serializer],
                                      [AFJSONResponseSerializer serializer],

--- a/AFNetworking/AFHTTPRequestOperationManager.m
+++ b/AFNetworking/AFHTTPRequestOperationManager.m
@@ -50,31 +50,31 @@
     if (!self) {
         return nil;
     }
-    
+
     // Ensure terminal slash for baseURL path, so that NSURL +URLWithString:relativeToURL: works as expected
     if ([[url path] length] > 0 && ![[url absoluteString] hasSuffix:@"/"]) {
         url = [url URLByAppendingPathComponent:@""];
     }
-    
+
     self.baseURL = url;
-    
+
     self.requestSerializer = [AFHTTPRequestSerializer serializer];
     
     NSArray* responseSerializers = @[[AFHTTPResponseSerializer serializer],
                                      [AFXMLParserResponseSerializer serializer],
                                      [AFJSONResponseSerializer serializer],
                                      [AFPropertyListResponseSerializer serializer]];
-    
+
     self.responseSerializer = [AFCompoundResponseSerializer compoundSerializerWithResponseSerializers:responseSerializers];
     
     self.securityPolicy = [AFSecurityPolicy defaultPolicy];
-    
+
     self.reachabilityManager = [AFNetworkReachabilityManager sharedManager];
-    
+
     self.operationQueue = [[NSOperationQueue alloc] init];
-    
+
     self.shouldUseCredentialStorage = YES;
-    
+
     return self;
 }
 

--- a/AFNetworking/AFHTTPSessionManager.m
+++ b/AFNetworking/AFHTTPSessionManager.m
@@ -73,17 +73,23 @@
     if (!self) {
         return nil;
     }
-
+    
     // Ensure terminal slash for baseURL path, so that NSURL +URLWithString:relativeToURL: works as expected
     if ([[url path] length] > 0 && ![[url absoluteString] hasSuffix:@"/"]) {
         url = [url URLByAppendingPathComponent:@""];
     }
-
+    
     self.baseURL = url;
-
+    
     self.requestSerializer = [AFHTTPRequestSerializer serializer];
-    self.responseSerializer = [AFJSONResponseSerializer serializer];
-
+    
+    NSArray* responseSerializers = @[[AFHTTPResponseSerializer serializer],
+                                     [AFXMLParserResponseSerializer serializer],
+                                     [AFJSONResponseSerializer serializer],
+                                     [AFPropertyListResponseSerializer serializer]];
+    
+    self.responseSerializer = [AFCompoundResponseSerializer compoundSerializerWithResponseSerializers:responseSerializers];
+    
     return self;
 }
 

--- a/AFNetworking/AFHTTPSessionManager.m
+++ b/AFNetworking/AFHTTPSessionManager.m
@@ -83,6 +83,7 @@
 
     self.requestSerializer = [AFHTTPRequestSerializer serializer];
     
+    // It used to be able to work with different types of response 
     NSArray* responseSerializers = @[[AFHTTPResponseSerializer serializer],
                                      [AFXMLParserResponseSerializer serializer],
                                      [AFJSONResponseSerializer serializer],

--- a/AFNetworking/AFHTTPSessionManager.m
+++ b/AFNetworking/AFHTTPSessionManager.m
@@ -73,23 +73,23 @@
     if (!self) {
         return nil;
     }
-    
+
     // Ensure terminal slash for baseURL path, so that NSURL +URLWithString:relativeToURL: works as expected
     if ([[url path] length] > 0 && ![[url absoluteString] hasSuffix:@"/"]) {
         url = [url URLByAppendingPathComponent:@""];
     }
-    
+
     self.baseURL = url;
-    
+
     self.requestSerializer = [AFHTTPRequestSerializer serializer];
     
     NSArray* responseSerializers = @[[AFHTTPResponseSerializer serializer],
                                      [AFXMLParserResponseSerializer serializer],
                                      [AFJSONResponseSerializer serializer],
                                      [AFPropertyListResponseSerializer serializer]];
-    
+
     self.responseSerializer = [AFCompoundResponseSerializer compoundSerializerWithResponseSerializers:responseSerializers];
-    
+
     return self;
 }
 


### PR DESCRIPTION
Better to use AFCompoundResponseSerializer  instead AFJSONResponsSerializer, because we do not know what type of response the server sends.