### PR TITLE
AWS analytics for iOS app crash in AFNetworking

### DIFF
--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -328,7 +328,7 @@ static NSString * const AFNSURLSessionTaskDidSuspendNotification = @"com.alamofi
 #pragma GCC diagnostic ignored "-Wnonnull"
         NSURLSessionDataTask *localDataTask = [[NSURLSession sessionWithConfiguration:nil] dataTaskWithURL:nil];
 #pragma clang diagnostic pop
-        IMP originalAFResumeIMP = method_getImplementation(class_getInstanceMethod([_AFURLSessionTaskSwizzling class], @selector(af_resume)));
+        IMP originalAFResumeIMP = method_getImplementation(class_getInstanceMethod([self class], @selector(af_resume)));
         Class currentClass = [localDataTask class];
         
         while (class_getInstanceMethod(currentClass, @selector(resume))) {
@@ -349,12 +349,14 @@ static NSString * const AFNSURLSessionTaskDidSuspendNotification = @"com.alamofi
 + (void)swizzleResumeAndSuspendMethodForClass:(Class)class {
     Method afResumeMethod = class_getInstanceMethod(self, @selector(af_resume));
     Method afSuspendMethod = class_getInstanceMethod(self, @selector(af_suspend));
-    
-    af_addMethod(class, @selector(af_resume), afResumeMethod);
-    af_addMethod(class, @selector(af_suspend), afSuspendMethod);
-    
-    af_swizzleSelector(class, @selector(resume), @selector(af_resume));
-    af_swizzleSelector(class, @selector(suspend), @selector(af_suspend));
+
+    if (af_addMethod(class, @selector(af_resume), afResumeMethod)) {
+        af_swizzleSelector(class, @selector(resume), @selector(af_resume));
+    }
+
+    if (af_addMethod(class, @selector(af_suspend), afSuspendMethod)) {
+        af_swizzleSelector(class, @selector(suspend), @selector(af_suspend));
+    }
 }
 
 - (NSURLSessionTaskState)state {


### PR DESCRIPTION
I have integrated AWS analytics(2.1.1), Facebook SDK(4.1.0) and AFNetworking(2.5.4) in one application. but app is crashing while launching itself

tried many ways to resolve this
1. commented line number 357 in screen shot its working fine
2. downgrade to AFNetworking 2.4.0 working fine.

![screen shot 2015-05-22 at 4 55 13 pm](https://cloud.githubusercontent.com/assets/7932890/7772021/0ea9ae58-00b9-11e5-94ca-cc24eedca362.png)
