### PR TITLE
hasSpaceAvailable become "false" and no failure blocks are called

### DIFF
--- a/AFNetworking/AFURLConnectionOperation.m
+++ b/AFNetworking/AFURLConnectionOperation.m
@@ -669,11 +669,11 @@ didReceiveResponse:(NSURLResponse *)response
             }
 
             break;
-        }
-
-        if (self.outputStream.streamError) {
+        } else {
             [self.connection cancel];
-            [self performSelector:@selector(connection:didFailWithError:) withObject:self.connection withObject:self.outputStream.streamError];
+            if (self.outputStream.streamError) {
+                [self performSelector:@selector(connection:didFailWithError:) withObject:self.connection withObject:self.outputStream.streamError];
+            }
             return;
         }
     }


### PR DESCRIPTION
I'm using AFNetworking (2.5.0) via Cocoapod in an iOS >7.0 application.
I need to download a binary file so i configured the `outputStream` property

```objective-c
AFHTTPRequestOperation *op = [self.operationManager GET:url
                                                 parameters:nil
                                                    success:^(AFHTTPRequestOperation *operation, id responseObject) {
                                                    } failure:^(AFHTTPRequestOperation *operation, NSError *error) {

            }];
op.outputStream = [NSOutputStream outputStreamToFileAtPath:tempPath append:YES];
````

90% of the times it works correctly, but in some case the line AFURLConnectionOperation.m@655 became false (i put a breakpoint) and the library enters in an endless loop and no failure blocks are called.

I put here the current implementation of the method
````objective-c
NSUInteger length = [data length];
    while (YES) {
        NSInteger totalNumberOfBytesWritten = 0;
        if ([self.outputStream hasSpaceAvailable]) {
            const uint8_t *dataBuffer = (uint8_t *)[data bytes];

            NSInteger numberOfBytesWritten = 0;
            while (totalNumberOfBytesWritten < (NSInteger)length) {
                numberOfBytesWritten = [self.outputStream write:&dataBuffer[(NSUInteger)totalNumberOfBytesWritten] maxLength:(length - (NSUInteger)totalNumberOfBytesWritten)];
                if (numberOfBytesWritten == -1) {
                    break;
                }
                
                totalNumberOfBytesWritten += numberOfBytesWritten;
            }

            break;
        } 

        if (self.outputStream.streamError) {
            [self.connection cancel];
            [self performSelector:@selector(connection:didFailWithError:) withObject:self.connection withObject:self.outputStream.streamError];
            return;
        }
    }
````
I think that if `[self.outputStream hasSpaceAvailable]` is false (for some reason) but there is not error on the outputStream the while() enters in an infinite loop.
