### PR TITLE
Fixed race condition in Reachability

### DIFF
--- a/AFNetworking/AFNetworkReachabilityManager.m
+++ b/AFNetworking/AFNetworkReachabilityManager.m
@@ -188,8 +188,12 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {
         return;
     }
 
+    __block BOOL receivedReachabilityUpdate = NO;
+
     __weak __typeof(self)weakSelf = self;
     AFNetworkReachabilityStatusBlock callback = ^(AFNetworkReachabilityStatus status) {
+        receivedReachabilityUpdate = YES;
+
         __strong __typeof(weakSelf)strongSelf = weakSelf;
 
         strongSelf.networkReachabilityStatus = status;
@@ -215,11 +219,12 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {
                 SCNetworkReachabilityGetFlags((__bridge SCNetworkReachabilityRef)networkReachability, &flags);
                 AFNetworkReachabilityStatus status = AFNetworkReachabilityStatusForFlags(flags);
                 dispatch_async(dispatch_get_main_queue(), ^{
-                    callback(status);
+                    if (!receivedReachabilityUpdate) {
+                        callback(status);
 
-                    NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
-                    [notificationCenter postNotificationName:AFNetworkingReachabilityDidChangeNotification object:nil userInfo:@{ AFNetworkingReachabilityNotificationStatusItem: @(status) }];
-
+                        NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
+                        [notificationCenter postNotificationName:AFNetworkingReachabilityDidChangeNotification object:nil userInfo:@{ AFNetworkingReachabilityNotificationStatusItem: @(status) }];
+                    }
 
                 });
             });


### PR DESCRIPTION
If a reachability update occurs at the right time after calling `-startMonitoring`, the `AFNetworkReachabilityCallback` function can be called before the first-time reachability update is posted. Therefore, a race condition existed that could cause the incorrect reachability status to be reported.

This change works around the issue by tracking whether the callback has yet been invoked, and if so, balking during the first-time reachability update. 

I tested this with an iPhone 6 running iOS 9.0.2, and toggling Airplane Mode during app launch (when we call `-startMonitoring`).