### PR TITLE
AFNetworkActivityIndicatorManager visibilityDelay property

### DIFF
--- a/UIKit+AFNetworking/AFNetworkActivityIndicatorManager.h
+++ b/UIKit+AFNetworking/AFNetworkActivityIndicatorManager.h
@@ -57,6 +57,11 @@ NS_EXTENSION_UNAVAILABLE_IOS("Use view controller based solutions where appropri
 @property (readonly, nonatomic, assign) BOOL isNetworkActivityIndicatorVisible;
 
 /**
+ *  A time to wait before showing the network activity indicator. The default value is 0.
+ */
+@property (nonatomic, assign) NSTimeInterval visibilityDelay;
+
+/**
  Returns the shared network activity indicator manager object for the system.
 
  @return The systemwide network activity indicator manager.

--- a/UIKit+AFNetworking/AFNetworkActivityIndicatorManager.m
+++ b/UIKit+AFNetworking/AFNetworkActivityIndicatorManager.m
@@ -97,14 +97,14 @@ static NSURLRequest * AFNetworkRequestFromNotification(NSNotification *notificat
 
 - (void)updateNetworkActivityIndicatorVisibilityDelayed {
     if (self.enabled) {
+        [self.activityIndicatorVisibilityTimer invalidate];
+        
         // Delay hiding of activity indicator for a short interval, to avoid flickering
-        if (![self isNetworkActivityIndicatorVisible]) {
-            [self.activityIndicatorVisibilityTimer invalidate];
-            self.activityIndicatorVisibilityTimer = [NSTimer timerWithTimeInterval:kAFNetworkActivityIndicatorInvisibilityDelay target:self selector:@selector(updateNetworkActivityIndicatorVisibility) userInfo:nil repeats:NO];
-            [[NSRunLoop mainRunLoop] addTimer:self.activityIndicatorVisibilityTimer forMode:NSRunLoopCommonModes];
-        } else {
-            [self performSelectorOnMainThread:@selector(updateNetworkActivityIndicatorVisibility) withObject:nil waitUntilDone:NO modes:@[NSRunLoopCommonModes]];
-        }
+        // or delay showing of activity indicator for a defined interval
+        NSTimeInterval delay = self.isNetworkActivityIndicatorVisible ? self.visibilityDelay : kAFNetworkActivityIndicatorInvisibilityDelay;
+        
+        self.activityIndicatorVisibilityTimer = [NSTimer timerWithTimeInterval:delay target:self selector:@selector(updateNetworkActivityIndicatorVisibility) userInfo:nil repeats:NO];
+        [[NSRunLoop mainRunLoop] addTimer:self.activityIndicatorVisibilityTimer forMode:NSRunLoopCommonModes];
     }
 }
 


### PR DESCRIPTION
A property called visibilityDelay added to
AFNetworkActivityIndicatorManager. It controls the time to wait before
showing the network activity indicator.  This is added to be able to
prevent showing the activity indicator for short periods of time as
suggest iOS Human Interface Guidelines.
https://developer.apple.com/library/ios/documentation/UserExperience/Conceptual/MobileHIG/Controls.html#//apple_ref/doc/uid/TP40006556-CH15-SW44