### PR TITLE
Network activity indicator delay

### DIFF
--- a/UIKit+AFNetworking/AFNetworkActivityIndicatorManager.h
+++ b/UIKit+AFNetworking/AFNetworkActivityIndicatorManager.h
@@ -57,6 +57,11 @@ NS_EXTENSION_UNAVAILABLE_IOS("Use view controller based solutions where appropri
 @property (readonly, nonatomic, assign) BOOL isNetworkActivityIndicatorVisible;
 
 /**
+ *  A time to wait before showing the network activity indicator. The default value is 0.
+ */
+@property (nonatomic, assign) NSTimeInterval visibilityDelay;
+
+/**
  Returns the shared network activity indicator manager object for the system.
 
  @return The systemwide network activity indicator manager.

--- a/UIKit+AFNetworking/AFNetworkActivityIndicatorManager.m
+++ b/UIKit+AFNetworking/AFNetworkActivityIndicatorManager.m
@@ -101,10 +101,22 @@ static NSURLRequest * AFNetworkRequestFromNotification(NSNotification *notificat
         
         // Delay hiding of activity indicator for a short interval, to avoid flickering
         // or delay showing of activity indicator for a defined interval
-        NSTimeInterval delay = self.isNetworkActivityIndicatorVisible ? self.visibilityDelay : kAFNetworkActivityIndicatorInvisibilityDelay;
+        NSTimeInterval delay = 0.0;
         
-        self.activityIndicatorVisibilityTimer = [NSTimer timerWithTimeInterval:delay target:self selector:@selector(updateNetworkActivityIndicatorVisibility) userInfo:nil repeats:NO];
-        [[NSRunLoop mainRunLoop] addTimer:self.activityIndicatorVisibilityTimer forMode:NSRunLoopCommonModes];
+        if (self.isNetworkActivityIndicatorVisible) {
+            delay = self.visibilityDelay;
+        } else if (self.visibilityDelay == 0.0) {
+            delay = kAFNetworkActivityIndicatorInvisibilityDelay;
+        }
+        
+        NSLog(@"delay: %lf", delay);
+        
+        if (delay == 0.0) {
+            [self performSelectorOnMainThread:@selector(updateNetworkActivityIndicatorVisibility) withObject:nil waitUntilDone:NO modes:@[NSRunLoopCommonModes]];
+        } else {
+            self.activityIndicatorVisibilityTimer = [NSTimer timerWithTimeInterval:delay target:self selector:@selector(updateNetworkActivityIndicatorVisibility) userInfo:nil repeats:NO];
+            [[NSRunLoop mainRunLoop] addTimer:self.activityIndicatorVisibilityTimer forMode:NSRunLoopCommonModes];
+        }
     }
 }
 

--- a/UIKit+AFNetworking/AFNetworkActivityIndicatorManager.m
+++ b/UIKit+AFNetworking/AFNetworkActivityIndicatorManager.m
@@ -97,14 +97,14 @@ static NSURLRequest * AFNetworkRequestFromNotification(NSNotification *notificat
 
 - (void)updateNetworkActivityIndicatorVisibilityDelayed {
     if (self.enabled) {
+        [self.activityIndicatorVisibilityTimer invalidate];
+        
         // Delay hiding of activity indicator for a short interval, to avoid flickering
-        if (![self isNetworkActivityIndicatorVisible]) {
-            [self.activityIndicatorVisibilityTimer invalidate];
-            self.activityIndicatorVisibilityTimer = [NSTimer timerWithTimeInterval:kAFNetworkActivityIndicatorInvisibilityDelay target:self selector:@selector(updateNetworkActivityIndicatorVisibility) userInfo:nil repeats:NO];
-            [[NSRunLoop mainRunLoop] addTimer:self.activityIndicatorVisibilityTimer forMode:NSRunLoopCommonModes];
-        } else {
-            [self performSelectorOnMainThread:@selector(updateNetworkActivityIndicatorVisibility) withObject:nil waitUntilDone:NO modes:@[NSRunLoopCommonModes]];
-        }
+        // or delay showing of activity indicator for a defined interval
+        NSTimeInterval delay = self.isNetworkActivityIndicatorVisible ? self.visibilityDelay : kAFNetworkActivityIndicatorInvisibilityDelay;
+        
+        self.activityIndicatorVisibilityTimer = [NSTimer timerWithTimeInterval:delay target:self selector:@selector(updateNetworkActivityIndicatorVisibility) userInfo:nil repeats:NO];
+        [[NSRunLoop mainRunLoop] addTimer:self.activityIndicatorVisibilityTimer forMode:NSRunLoopCommonModes];
     }
 }
 


### PR DESCRIPTION
When `visibilityDelay` is used then the default delay is not necessary.
This allows greater control over when the indicator should show.

It relates to this pull request: https://github.com/AFNetworking/AFNetworking/pull/3085.
Only this time it turns off the default 0.17 delay when `visibilityDelay` is used.

Please notice that iOS Human Interface Guidelines say that the delay should be “a couple of seconds”.

This changes don’t affect the default behaviour of the class until we intentionally adjust `visibilityDelay`.