### PR TITLE
Use a valid version number for framework

### DIFF
--- a/Framework/Info.plist
+++ b/Framework/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.0.0-beta.1</string>
+	<string>3.0.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
iTunes Connect checks the framework versions when you upload your app binary. They need to be three non-negative integers, so you can't include `-beta.1` suffixes, for example.