### PR TITLE
Custom collection field name formatter

### DIFF
--- a/AFNetworking/AFURLRequestSerialization.h
+++ b/AFNetworking/AFURLRequestSerialization.h
@@ -59,6 +59,9 @@ typedef NS_ENUM(NSUInteger, AFHTTPRequestQueryStringSerializationStyle) {
     AFHTTPRequestQueryStringDefaultStyle = 0,
 };
 
+typedef NSString * __nullable (^AFQueryStringNestedFieldNameFormatterBlock)(NSString * __nullable key, NSString *nestedKey);
+typedef NSString * __nullable (^AFQueryStringArrayFieldNameFormatterBlock)(NSString * key);
+
 @protocol AFMultipartFormData;
 
 /**
@@ -114,6 +117,16 @@ typedef NS_ENUM(NSUInteger, AFHTTPRequestQueryStringSerializationStyle) {
  @see NSMutableURLRequest -setTimeoutInterval:
  */
 @property (nonatomic, assign) NSTimeInterval timeoutInterval;
+
+/**
+ The field name formatter for nested field in query string.
+ */
+@property (nonatomic, copy) AFQueryStringNestedFieldNameFormatterBlock nestedFieldNameFormatterBlock;
+
+/**
+ The field name formatter for array field in query string.
+ */
+@property (nonatomic, copy) AFQueryStringArrayFieldNameFormatterBlock arrayFieldNameFormatterBlock;
 
 ///---------------------------------------
 /// @name Configuring HTTP Request Headers

--- a/AFNetworking/AFURLRequestSerialization.m
+++ b/AFNetworking/AFURLRequestSerialization.m
@@ -143,44 +143,63 @@ static NSString * AFPercentEscapedStringFromString(NSString *string) {
 #pragma mark -
 
 FOUNDATION_EXPORT NSArray * AFQueryStringPairsFromDictionary(NSDictionary *dictionary);
-FOUNDATION_EXPORT NSArray * AFQueryStringPairsFromKeyAndValue(NSString *key, id value);
+FOUNDATION_EXPORT NSArray * AFQueryStringPairsFromDictionaryAndFieldNameFormatters(NSDictionary *dictionary, AFQueryStringNestedFieldNameFormatterBlock nestedFieldNameFormatter, AFQueryStringArrayFieldNameFormatterBlock arrayFieldNameFormatter);
+FOUNDATION_EXPORT NSArray * AFQueryStringPairsFromKeyAndValueAndFieldNameFormatters(NSString *key, id value, AFQueryStringNestedFieldNameFormatterBlock nestedFieldNameFormatter, AFQueryStringArrayFieldNameFormatterBlock arrayFieldNameFormatter);
 
-static NSString * AFQueryStringFromParameters(NSDictionary *parameters) {
+static NSString * AFQueryStringFromParametersAndFieldNameFormatters(NSDictionary *parameters, AFQueryStringNestedFieldNameFormatterBlock nestedFieldNameFormatter, AFQueryStringArrayFieldNameFormatterBlock arrayFieldNameFormatter) {
     NSMutableArray *mutablePairs = [NSMutableArray array];
-    for (AFQueryStringPair *pair in AFQueryStringPairsFromDictionary(parameters)) {
+    for (AFQueryStringPair *pair in AFQueryStringPairsFromDictionaryAndFieldNameFormatters(parameters, nestedFieldNameFormatter, arrayFieldNameFormatter)) {
         [mutablePairs addObject:[pair URLEncodedStringValue]];
     }
 
     return [mutablePairs componentsJoinedByString:@"&"];
 }
 
+static AFQueryStringNestedFieldNameFormatterBlock AFDefaultQueryStringNestedFieldNameFormatterBlock = ^NSString * __nullable (NSString * __nullable key, NSString *nestedKey) {
+    return [NSString stringWithFormat:@"%@[%@]", key, nestedKey];
+};
+
+static AFQueryStringArrayFieldNameFormatterBlock AFDefaultQueryStringArrayFieldNameFormatterBlock = ^NSString * __nullable (NSString *key) {
+    return [NSString stringWithFormat:@"%@[]", key];
+};
+
 NSArray * AFQueryStringPairsFromDictionary(NSDictionary *dictionary) {
-    return AFQueryStringPairsFromKeyAndValue(nil, dictionary);
+    return AFQueryStringPairsFromDictionaryAndFieldNameFormatters(dictionary, AFDefaultQueryStringNestedFieldNameFormatterBlock, AFDefaultQueryStringArrayFieldNameFormatterBlock);
 }
 
-NSArray * AFQueryStringPairsFromKeyAndValue(NSString *key, id value) {
+NSArray * AFQueryStringPairsFromDictionaryAndFieldNameFormatters(NSDictionary *dictionary, AFQueryStringNestedFieldNameFormatterBlock nestedFieldNameFormatter, AFQueryStringArrayFieldNameFormatterBlock arrayFieldNameFormatter) {
+    return AFQueryStringPairsFromKeyAndValueAndFieldNameFormatters(nil, dictionary, nestedFieldNameFormatter, arrayFieldNameFormatter);
+}
+
+NSArray * AFQueryStringPairsFromKeyAndValueAndFieldNameFormatters(NSString *key, id value, AFQueryStringNestedFieldNameFormatterBlock nestedFieldNameFormatter, AFQueryStringArrayFieldNameFormatterBlock arrayFieldNameFormatter) {
     NSMutableArray *mutableQueryStringComponents = [NSMutableArray array];
 
     NSSortDescriptor *sortDescriptor = [NSSortDescriptor sortDescriptorWithKey:@"description" ascending:YES selector:@selector(compare:)];
 
     if ([value isKindOfClass:[NSDictionary class]]) {
         NSDictionary *dictionary = value;
+        
+        if (!nestedFieldNameFormatter) nestedFieldNameFormatter = AFDefaultQueryStringNestedFieldNameFormatterBlock;
+        
         // Sort dictionary keys to ensure consistent ordering in query string, which is important when deserializing potentially ambiguous sequences, such as an array of dictionaries
         for (id nestedKey in [dictionary.allKeys sortedArrayUsingDescriptors:@[ sortDescriptor ]]) {
             id nestedValue = dictionary[nestedKey];
             if (nestedValue) {
-                [mutableQueryStringComponents addObjectsFromArray:AFQueryStringPairsFromKeyAndValue((key ? [NSString stringWithFormat:@"%@[%@]", key, nestedKey] : nestedKey), nestedValue)];
+                [mutableQueryStringComponents addObjectsFromArray:AFQueryStringPairsFromKeyAndValueAndFieldNameFormatters((key)? nestedFieldNameFormatter(key, nestedKey) : nestedKey, nestedValue, nestedFieldNameFormatter, arrayFieldNameFormatter)];
             }
         }
     } else if ([value isKindOfClass:[NSArray class]]) {
         NSArray *array = value;
+
+        if (!arrayFieldNameFormatter) arrayFieldNameFormatter = AFDefaultQueryStringArrayFieldNameFormatterBlock;
+        
         for (id nestedValue in array) {
-            [mutableQueryStringComponents addObjectsFromArray:AFQueryStringPairsFromKeyAndValue([NSString stringWithFormat:@"%@[]", key], nestedValue)];
+            [mutableQueryStringComponents addObjectsFromArray:AFQueryStringPairsFromKeyAndValueAndFieldNameFormatters(arrayFieldNameFormatter(key), nestedValue, nestedFieldNameFormatter, arrayFieldNameFormatter)];
         }
     } else if ([value isKindOfClass:[NSSet class]]) {
         NSSet *set = value;
         for (id obj in [set sortedArrayUsingDescriptors:@[ sortDescriptor ]]) {
-            [mutableQueryStringComponents addObjectsFromArray:AFQueryStringPairsFromKeyAndValue(key, obj)];
+            [mutableQueryStringComponents addObjectsFromArray:AFQueryStringPairsFromKeyAndValueAndFieldNameFormatters(key, obj, nestedFieldNameFormatter, arrayFieldNameFormatter)];
         }
     } else {
         [mutableQueryStringComponents addObject:[[AFQueryStringPair alloc] initWithField:key value:value]];
@@ -428,7 +447,7 @@ forHTTPHeaderField:(NSString *)field
     __block AFStreamingMultipartFormData *formData = [[AFStreamingMultipartFormData alloc] initWithURLRequest:mutableRequest stringEncoding:NSUTF8StringEncoding];
 
     if (parameters) {
-        for (AFQueryStringPair *pair in AFQueryStringPairsFromDictionary(parameters)) {
+        for (AFQueryStringPair *pair in AFQueryStringPairsFromDictionaryAndFieldNameFormatters(parameters, self.nestedFieldNameFormatterBlock, self.arrayFieldNameFormatterBlock)) {
             NSData *data = nil;
             if ([pair.value isKindOfClass:[NSData class]]) {
                 data = pair.value;
@@ -537,7 +556,7 @@ forHTTPHeaderField:(NSString *)field
         } else {
             switch (self.queryStringSerializationStyle) {
                 case AFHTTPRequestQueryStringDefaultStyle:
-                    query = AFQueryStringFromParameters(parameters);
+                    query = AFQueryStringFromParametersAndFieldNameFormatters(parameters, self.nestedFieldNameFormatterBlock, self.arrayFieldNameFormatterBlock);
                     break;
             }
         }

--- a/Tests/AFNetworking Tests.xcodeproj/project.pbxproj
+++ b/Tests/AFNetworking Tests.xcodeproj/project.pbxproj
@@ -370,6 +370,7 @@
 				2902D27517DF4E1100C81C5A /* Frameworks */,
 				2902D27617DF4E1100C81C5A /* Resources */,
 				DFF6BB8B6C8D4F8ABC235667 /* Copy Pods Resources */,
+				C0F4F8D15988FF0D5023FCE5 /* Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -389,6 +390,7 @@
 				2902D28917DF4E2900C81C5A /* Frameworks */,
 				2902D28A17DF4E2900C81C5A /* Resources */,
 				D728EB5862164B87922C9B80 /* Copy Pods Resources */,
+				9DB920E8CF99BCD7D1E4E3D6 /* Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -500,6 +502,36 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		9DB920E8CF99BCD7D1E4E3D6 /* Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-osx/Pods-osx-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		C0F4F8D15988FF0D5023FCE5 /* Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ios/Pods-ios-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		D728EB5862164B87922C9B80 /* Copy Pods Resources */ = {

--- a/Tests/Tests/AFHTTPRequestSerializationTests.m
+++ b/Tests/Tests/AFHTTPRequestSerializationTests.m
@@ -194,4 +194,59 @@
     XCTAssertTrue([request.URL.query isEqualToString:@"test=%21%F0%9F%91%B4%F0%9F%8F%BF%F0%9F%91%B7%F0%9F%8F%BB%F0%9F%91%AE%F0%9F%8F%BD%F0%9F%91%B4%F0%9F%8F%BF%F0%9F%91%B7%F0%9F%8F%BB%F0%9F%91%AE%F0%9F%8F%BD%F0%9F%91%B4%F0%9F%8F%BF%F0%9F%91%B7%F0%9F%8F%BB%F0%9F%91%AE%F0%9F%8F%BD%F0%9F%91%B4%F0%9F%8F%BF%F0%9F%91%B7%F0%9F%8F%BB%F0%9F%91%AE%F0%9F%8F%BD%F0%9F%91%B4%F0%9F%8F%BF%F0%9F%91%B7%F0%9F%8F%BB%F0%9F%91%AE%F0%9F%8F%BD"]);
 }
 
+- (void)testThatAFHTTPRequestSerialiationHandlesParametersArray {
+    NSArray *parameter = @[@"value1", @"value2"];
+    
+    AFHTTPRequestSerializer *serializer = [AFHTTPRequestSerializer serializer];
+    
+    NSURLRequest *request = [serializer requestWithMethod:@"GET"
+                                                URLString:@"http://test.com"
+                                               parameters:@{@"test":parameter}
+                                                    error:nil];
+    XCTAssertTrue([request.URL.query isEqualToString:@"test%5B%5D=value1&test%5B%5D=value2"]);
+}
+
+- (void)testThatAFHTTPRequestSerialiationHandlesParametersArrayWithFieldNameFormatter {
+    NSArray *parameter = @[@"value1", @"value2"];
+    
+    AFHTTPRequestSerializer *serializer = [AFHTTPRequestSerializer serializer];
+    [serializer setArrayFieldNameFormatterBlock:^(NSString *key) {
+        return key;
+    }];
+    
+    NSURLRequest *request = [serializer requestWithMethod:@"GET"
+                                                URLString:@"http://test.com"
+                                               parameters:@{@"test":parameter}
+                                                    error:nil];
+    XCTAssertTrue([request.URL.query isEqualToString:@"test=value1&test=value2"]);
+}
+
+
+- (void)testThatAFHTTPRequestSerialiationHandlesParametersDictionary {
+    NSDictionary *parameter = @{ @"key1" : @"value1", @"key2" : @"value2" };
+    
+    AFHTTPRequestSerializer *serializer = [AFHTTPRequestSerializer serializer];
+    
+    NSURLRequest *request = [serializer requestWithMethod:@"GET"
+                                                URLString:@"http://test.com"
+                                               parameters:@{@"test":parameter}
+                                                    error:nil];
+    XCTAssertTrue([request.URL.query isEqualToString:@"test%5Bkey1%5D=value1&test%5Bkey2%5D=value2"]);
+}
+
+- (void)testThatAFHTTPRequestSerialiationHandlesParametersDictionaryWithFieldNameFormatter {
+    NSDictionary *parameter = @{ @"key1" : @"value1", @"key2" : @"value2" };
+    
+    AFHTTPRequestSerializer *serializer = [AFHTTPRequestSerializer serializer];
+    [serializer setNestedFieldNameFormatterBlock:^(NSString *key, NSString *nestedKey) {
+        return [NSString stringWithFormat:@"%@{%@}", key, nestedKey];
+    }];
+    
+    NSURLRequest *request = [serializer requestWithMethod:@"GET"
+                                                URLString:@"http://test.com"
+                                               parameters:@{@"test":parameter}
+                                                    error:nil];
+    XCTAssertTrue([request.URL.query isEqualToString:@"test%7Bkey1%7D=value1&test%7Bkey2%7D=value2"]);
+}
+
 @end


### PR DESCRIPTION
I have been working with APIs that only take array parameters by repeating the name of variable without need of appending brackets '[]'. For example, http://test.com?test=value1&test=value2.

By applying these changes, developers will be able to customize the naming convention for collection parameters in query string.