### PR TITLE
Fixed crash that occurred if you passed a nil URL to the image view

### DIFF
--- a/Tests/Tests/AFUIImageViewTests.m
+++ b/Tests/Tests/AFUIImageViewTests.m
@@ -131,4 +131,12 @@
     [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
 }
 
+- (void)testThatNilURLDoesntCrash {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
+    [self.imageView setImageWithURL:nil];
+#pragma clang diagnostic pop
+
+}
+
 @end

--- a/UIKit+AFNetworking/UIImageView+AFNetworking.m
+++ b/UIKit+AFNetworking/UIImageView+AFNetworking.m
@@ -79,6 +79,13 @@
                        success:(void (^)(NSURLRequest *request, NSHTTPURLResponse * _Nullable response, UIImage *image))success
                        failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse * _Nullable response, NSError *error))failure
 {
+
+    if ([urlRequest URL] == nil) {
+        [self cancelImageDownloadTask];
+        self.image = placeholderImage;
+        return;
+    }
+
     if ([self isActiveTaskURLEqualToURLRequest:urlRequest]){
         return;
     }


### PR DESCRIPTION
Fix for #3145