### PR TITLE
Fixed AFImageDownloader stalling after numerous failures

### DIFF
--- a/UIKit+AFNetworking/AFImageDownloader.m
+++ b/UIKit+AFNetworking/AFImageDownloader.m
@@ -244,9 +244,10 @@
                                            });
                                        }
                                    }
-                                   [strongSelf safelyDecrementActiveTaskCount];
-                                   [strongSelf safelyStartNextTaskIfNecessary];
+
                                }
+                               [strongSelf safelyDecrementActiveTaskCount];
+                               [strongSelf safelyStartNextTaskIfNecessary];
                            });
                        }];
 


### PR DESCRIPTION
The active task count was only being decremented after success. Once the number of failures reaches the maximumActiveDownloads, no more tasks were being started.