### PR TITLE
Fixed bug in AFMultipartBodyStream that may cause the input stream to read more bytes than required.

### DIFF
--- a/AFNetworking/AFURLRequestSerialization.m
+++ b/AFNetworking/AFURLRequestSerialization.m
@@ -948,7 +948,7 @@ NSTimeInterval const kAFUploadStream3GSuggestedDelay = 0.2;
                 break;
             }
         } else {
-            NSUInteger maxLength = length - (NSUInteger)totalNumberOfBytesRead;
+            NSUInteger maxLength = MIN(length, self.numberOfBytesInPacket) - (NSUInteger)totalNumberOfBytesRead;
             NSInteger numberOfBytesRead = [self.currentHTTPBodyPart read:&buffer[totalNumberOfBytesRead] maxLength:maxLength];
             if (numberOfBytesRead == -1) {
                 self.streamError = self.currentHTTPBodyPart.inputStream.streamError;


### PR DESCRIPTION
may cause inputStream read more bytes than the setting value numberOfBytesInPacket