### PR TITLE
Better error when the server trust is invalid

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,10 @@ script:
   - set -o pipefail
   - fastlane $FASTLANE_LANE configuration:Debug --env $FASTLANE_ENV
   - fastlane $FASTLANE_LANE configuration:Release --env $FASTLANE_ENV
+after_failure:
+  - cat -n ~/Library/Logs/scan/*
+  - cat -n $TMPDIR/com.apple.dt.XCTest-status/Session*.log
+  - cat -n ~/Library/Logs/DiagnosticReports/xctest*.crash
 # Commenting Deploy out until out of beta
 # deploy:
 #   provider: script

--- a/AFNetworking/AFSecurityPolicy.m
+++ b/AFNetworking/AFSecurityPolicy.m
@@ -94,6 +94,7 @@ static BOOL AFServerTrustIsValid(SecTrustRef serverTrust) {
     SecTrustResultType result;
     __Require_noErr_Quiet(SecTrustEvaluate(serverTrust, &result), _out);
 
+    NSLog(@"✳️ %s %d ✳️ SecTrustEvaluate -> %d", __PRETTY_FUNCTION__, __LINE__, result);
     isValid = (result == kSecTrustResultUnspecified || result == kSecTrustResultProceed);
 
 _out:
@@ -269,9 +270,11 @@ static NSArray * AFPublicKeyTrustChainForServerTrust(SecTrustRef serverTrust) {
             for (NSData *certificateData in self.pinnedCertificates) {
                 [pinnedCertificates addObject:(__bridge_transfer id)SecCertificateCreateWithData(NULL, (__bridge CFDataRef)certificateData)];
             }
+			NSLog(@"✳️ %s %d ✳️ pinnedCertificates = %@", __PRETTY_FUNCTION__, __LINE__, pinnedCertificates);
             SecTrustSetAnchorCertificates(serverTrust, (__bridge CFArrayRef)pinnedCertificates);
 
             if (!AFServerTrustIsValid(serverTrust)) {
+				NSLog(@"✳️ %s %d ✳️ !AFServerTrustIsValid", __PRETTY_FUNCTION__, __LINE__);
                 return NO;
             }
 
@@ -280,10 +283,12 @@ static NSArray * AFPublicKeyTrustChainForServerTrust(SecTrustRef serverTrust) {
             
             for (NSData *trustChainCertificate in [serverCertificates reverseObjectEnumerator]) {
                 if ([self.pinnedCertificates containsObject:trustChainCertificate]) {
+					NSLog(@"✳️ %s %d ✳️ pinnedCertificates contains trustChainCertificate", __PRETTY_FUNCTION__, __LINE__);
                     return YES;
                 }
             }
             
+            NSLog(@"✳️ %s %d ✳️ pinnedCertificates does NOT contain trustChainCertificate", __PRETTY_FUNCTION__, __LINE__);
             return NO;
         }
         case AFSSLPinningModePublicKey: {

--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -126,6 +126,7 @@ typedef void (^AFURLSessionTaskCompletionHandler)(NSURLResponse *response, id re
     totalBytesSent:(int64_t)totalBytesSent
 totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend
 {
+    NSLog(@"ℹ️ %s %@", __PRETTY_FUNCTION__, session);
     self.progress.totalUnitCount = totalBytesExpectedToSend;
     self.progress.completedUnitCount = totalBytesSent;
 }
@@ -134,6 +135,7 @@ totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend
               task:(NSURLSessionTask *)task
 didCompleteWithError:(NSError *)error
 {
+    NSLog(@"ℹ️ %s %@", __PRETTY_FUNCTION__, session);
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wgnu"
     __strong AFURLSessionManager *manager = self.manager;
@@ -206,6 +208,7 @@ didCompleteWithError:(NSError *)error
           dataTask:(__unused NSURLSessionDataTask *)dataTask
     didReceiveData:(NSData *)data
 {
+    NSLog(@"ℹ️ %s %@", __PRETTY_FUNCTION__, session);
     NSUInteger length = data.length;
     long long expectedLength = dataTask.response.expectedContentLength;
     if(expectedLength != -1) {
@@ -221,6 +224,7 @@ didCompleteWithError:(NSError *)error
       downloadTask:(NSURLSessionDownloadTask *)downloadTask
 didFinishDownloadingToURL:(NSURL *)location
 {
+    NSLog(@"ℹ️ %s %@", __PRETTY_FUNCTION__, session);
     NSError *fileManagerError = nil;
     self.downloadFileURL = nil;
 
@@ -242,6 +246,7 @@ didFinishDownloadingToURL:(NSURL *)location
  totalBytesWritten:(int64_t)totalBytesWritten
 totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite
 {
+    NSLog(@"ℹ️ %s %@", __PRETTY_FUNCTION__, session);
     self.progress.totalUnitCount = totalBytesExpectedToWrite;
     self.progress.completedUnitCount = totalBytesWritten;
 }
@@ -250,6 +255,7 @@ totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite
       downloadTask:(__unused NSURLSessionDownloadTask *)downloadTask
  didResumeAtOffset:(int64_t)fileOffset
 expectedTotalBytes:(int64_t)expectedTotalBytes {
+    NSLog(@"ℹ️ %s %@", __PRETTY_FUNCTION__, session);
     self.progress.totalUnitCount = expectedTotalBytes;
     self.progress.completedUnitCount = fileOffset;
 }

--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -893,6 +893,7 @@ static NSString * const AFNSURLSessionTaskDidSuspendNotification = @"com.alamofi
 - (void)URLSession:(NSURLSession *)session
 didBecomeInvalidWithError:(NSError *)error
 {
+    NSLog(@"ℹ️ %s", __PRETTY_FUNCTION__);
     if (self.sessionDidBecomeInvalid) {
         self.sessionDidBecomeInvalid(session, error);
     }
@@ -905,6 +906,7 @@ didBecomeInvalidWithError:(NSError *)error
 didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
  completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition disposition, NSURLCredential *credential))completionHandler
 {
+    NSLog(@"ℹ️ %s", __PRETTY_FUNCTION__);
     NSURLSessionAuthChallengeDisposition disposition = NSURLSessionAuthChallengePerformDefaultHandling;
     __block NSURLCredential *credential = nil;
 
@@ -941,6 +943,7 @@ willPerformHTTPRedirection:(NSHTTPURLResponse *)response
         newRequest:(NSURLRequest *)request
  completionHandler:(void (^)(NSURLRequest *))completionHandler
 {
+    NSLog(@"ℹ️ %s", __PRETTY_FUNCTION__);
     NSURLRequest *redirectRequest = request;
 
     if (self.taskWillPerformHTTPRedirection) {
@@ -957,6 +960,7 @@ willPerformHTTPRedirection:(NSHTTPURLResponse *)response
 didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
  completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition disposition, NSURLCredential *credential))completionHandler
 {
+    NSLog(@"ℹ️ %s", __PRETTY_FUNCTION__);
     NSURLSessionAuthChallengeDisposition disposition = NSURLSessionAuthChallengePerformDefaultHandling;
     __block NSURLCredential *credential = nil;
 
@@ -984,6 +988,7 @@ didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
               task:(NSURLSessionTask *)task
  needNewBodyStream:(void (^)(NSInputStream *bodyStream))completionHandler
 {
+    NSLog(@"ℹ️ %s", __PRETTY_FUNCTION__);
     NSInputStream *inputStream = nil;
 
     if (self.taskNeedNewBodyStream) {
@@ -1003,7 +1008,7 @@ didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
     totalBytesSent:(int64_t)totalBytesSent
 totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend
 {
-
+    NSLog(@"ℹ️ %s", __PRETTY_FUNCTION__);
     int64_t totalUnitCount = totalBytesExpectedToSend;
     if(totalUnitCount == NSURLSessionTransferSizeUnknown) {
         NSString *contentLength = [task.originalRequest valueForHTTPHeaderField:@"Content-Length"];
@@ -1024,6 +1029,7 @@ totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend
               task:(NSURLSessionTask *)task
 didCompleteWithError:(NSError *)error
 {
+    NSLog(@"ℹ️ %s", __PRETTY_FUNCTION__);
     AFURLSessionManagerTaskDelegate *delegate = [self delegateForTask:task];
 
     // delegate may be nil when completing a task in the background
@@ -1047,6 +1053,7 @@ didCompleteWithError:(NSError *)error
 didReceiveResponse:(NSURLResponse *)response
  completionHandler:(void (^)(NSURLSessionResponseDisposition disposition))completionHandler
 {
+    NSLog(@"ℹ️ %s", __PRETTY_FUNCTION__);
     NSURLSessionResponseDisposition disposition = NSURLSessionResponseAllow;
 
     if (self.dataTaskDidReceiveResponse) {
@@ -1062,6 +1069,7 @@ didReceiveResponse:(NSURLResponse *)response
           dataTask:(NSURLSessionDataTask *)dataTask
 didBecomeDownloadTask:(NSURLSessionDownloadTask *)downloadTask
 {
+    NSLog(@"ℹ️ %s", __PRETTY_FUNCTION__);
     AFURLSessionManagerTaskDelegate *delegate = [self delegateForTask:dataTask];
     if (delegate) {
         [self removeDelegateForTask:dataTask];
@@ -1080,8 +1088,7 @@ didBecomeDownloadTask:(NSURLSessionDownloadTask *)downloadTask
           dataTask:(NSURLSessionDataTask *)dataTask
     didReceiveData:(NSData *)data
 {
-
-
+    NSLog(@"ℹ️ %s", __PRETTY_FUNCTION__);
     AFURLSessionManagerTaskDelegate *delegate = [self delegateForTask:dataTask];
     [delegate URLSession:session dataTask:dataTask didReceiveData:data];
 
@@ -1095,6 +1102,7 @@ didBecomeDownloadTask:(NSURLSessionDownloadTask *)downloadTask
  willCacheResponse:(NSCachedURLResponse *)proposedResponse
  completionHandler:(void (^)(NSCachedURLResponse *cachedResponse))completionHandler
 {
+    NSLog(@"ℹ️ %s", __PRETTY_FUNCTION__);
     NSCachedURLResponse *cachedResponse = proposedResponse;
 
     if (self.dataTaskWillCacheResponse) {
@@ -1107,6 +1115,7 @@ didBecomeDownloadTask:(NSURLSessionDownloadTask *)downloadTask
 }
 
 - (void)URLSessionDidFinishEventsForBackgroundURLSession:(NSURLSession *)session {
+    NSLog(@"ℹ️ %s", __PRETTY_FUNCTION__);
     if (self.didFinishEventsForBackgroundURLSession) {
         dispatch_async(dispatch_get_main_queue(), ^{
             self.didFinishEventsForBackgroundURLSession(session);
@@ -1120,6 +1129,7 @@ didBecomeDownloadTask:(NSURLSessionDownloadTask *)downloadTask
       downloadTask:(NSURLSessionDownloadTask *)downloadTask
 didFinishDownloadingToURL:(NSURL *)location
 {
+    NSLog(@"ℹ️ %s", __PRETTY_FUNCTION__);
     AFURLSessionManagerTaskDelegate *delegate = [self delegateForTask:downloadTask];
     if (self.downloadTaskDidFinishDownloading) {
         NSURL *fileURL = self.downloadTaskDidFinishDownloading(session, downloadTask, location);
@@ -1148,6 +1158,7 @@ didFinishDownloadingToURL:(NSURL *)location
  totalBytesWritten:(int64_t)totalBytesWritten
 totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite
 {
+    NSLog(@"ℹ️ %s", __PRETTY_FUNCTION__);
     AFURLSessionManagerTaskDelegate *delegate = [self delegateForTask:downloadTask];
     [delegate URLSession:session downloadTask:downloadTask didWriteData:bytesWritten totalBytesWritten:totalBytesWritten totalBytesExpectedToWrite:totalBytesExpectedToWrite];
 
@@ -1161,6 +1172,7 @@ totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite
  didResumeAtOffset:(int64_t)fileOffset
 expectedTotalBytes:(int64_t)expectedTotalBytes
 {
+    NSLog(@"ℹ️ %s", __PRETTY_FUNCTION__);
     AFURLSessionManagerTaskDelegate *delegate = [self delegateForTask:downloadTask];
     [delegate URLSession:session downloadTask:downloadTask didResumeAtOffset:fileOffset expectedTotalBytes:expectedTotalBytes];
 

--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -920,7 +920,7 @@ didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
                     disposition = NSURLSessionAuthChallengePerformDefaultHandling;
                 }
             } else {
-                disposition = NSURLSessionAuthChallengeCancelAuthenticationChallenge;
+                disposition = NSURLSessionAuthChallengeRejectProtectionSpace;
             }
         } else {
             disposition = NSURLSessionAuthChallengePerformDefaultHandling;
@@ -967,7 +967,7 @@ didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
                 disposition = NSURLSessionAuthChallengeUseCredential;
                 credential = [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust];
             } else {
-                disposition = NSURLSessionAuthChallengeCancelAuthenticationChallenge;
+                disposition = NSURLSessionAuthChallengeRejectProtectionSpace;
             }
         } else {
             disposition = NSURLSessionAuthChallengePerformDefaultHandling;

--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -893,7 +893,7 @@ static NSString * const AFNSURLSessionTaskDidSuspendNotification = @"com.alamofi
 - (void)URLSession:(NSURLSession *)session
 didBecomeInvalidWithError:(NSError *)error
 {
-    NSLog(@"ℹ️ %s", __PRETTY_FUNCTION__);
+    NSLog(@"ℹ️ %s %@", __PRETTY_FUNCTION__, session);
     if (self.sessionDidBecomeInvalid) {
         self.sessionDidBecomeInvalid(session, error);
     }
@@ -906,7 +906,7 @@ didBecomeInvalidWithError:(NSError *)error
 didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
  completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition disposition, NSURLCredential *credential))completionHandler
 {
-    NSLog(@"ℹ️ %s", __PRETTY_FUNCTION__);
+    NSLog(@"ℹ️ %s %@", __PRETTY_FUNCTION__, session);
     NSURLSessionAuthChallengeDisposition disposition = NSURLSessionAuthChallengePerformDefaultHandling;
     __block NSURLCredential *credential = nil;
 
@@ -943,7 +943,7 @@ willPerformHTTPRedirection:(NSHTTPURLResponse *)response
         newRequest:(NSURLRequest *)request
  completionHandler:(void (^)(NSURLRequest *))completionHandler
 {
-    NSLog(@"ℹ️ %s", __PRETTY_FUNCTION__);
+    NSLog(@"ℹ️ %s %@", __PRETTY_FUNCTION__, session);
     NSURLRequest *redirectRequest = request;
 
     if (self.taskWillPerformHTTPRedirection) {
@@ -960,7 +960,7 @@ willPerformHTTPRedirection:(NSHTTPURLResponse *)response
 didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
  completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition disposition, NSURLCredential *credential))completionHandler
 {
-    NSLog(@"ℹ️ %s", __PRETTY_FUNCTION__);
+    NSLog(@"ℹ️ %s %@", __PRETTY_FUNCTION__, session);
     NSURLSessionAuthChallengeDisposition disposition = NSURLSessionAuthChallengePerformDefaultHandling;
     __block NSURLCredential *credential = nil;
 
@@ -988,7 +988,7 @@ didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
               task:(NSURLSessionTask *)task
  needNewBodyStream:(void (^)(NSInputStream *bodyStream))completionHandler
 {
-    NSLog(@"ℹ️ %s", __PRETTY_FUNCTION__);
+    NSLog(@"ℹ️ %s %@", __PRETTY_FUNCTION__, session);
     NSInputStream *inputStream = nil;
 
     if (self.taskNeedNewBodyStream) {
@@ -1008,7 +1008,7 @@ didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
     totalBytesSent:(int64_t)totalBytesSent
 totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend
 {
-    NSLog(@"ℹ️ %s", __PRETTY_FUNCTION__);
+    NSLog(@"ℹ️ %s %@", __PRETTY_FUNCTION__, session);
     int64_t totalUnitCount = totalBytesExpectedToSend;
     if(totalUnitCount == NSURLSessionTransferSizeUnknown) {
         NSString *contentLength = [task.originalRequest valueForHTTPHeaderField:@"Content-Length"];
@@ -1029,7 +1029,7 @@ totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend
               task:(NSURLSessionTask *)task
 didCompleteWithError:(NSError *)error
 {
-    NSLog(@"ℹ️ %s", __PRETTY_FUNCTION__);
+    NSLog(@"ℹ️ %s %@", __PRETTY_FUNCTION__, session);
     AFURLSessionManagerTaskDelegate *delegate = [self delegateForTask:task];
 
     // delegate may be nil when completing a task in the background
@@ -1053,7 +1053,7 @@ didCompleteWithError:(NSError *)error
 didReceiveResponse:(NSURLResponse *)response
  completionHandler:(void (^)(NSURLSessionResponseDisposition disposition))completionHandler
 {
-    NSLog(@"ℹ️ %s", __PRETTY_FUNCTION__);
+    NSLog(@"ℹ️ %s %@", __PRETTY_FUNCTION__, session);
     NSURLSessionResponseDisposition disposition = NSURLSessionResponseAllow;
 
     if (self.dataTaskDidReceiveResponse) {
@@ -1069,7 +1069,7 @@ didReceiveResponse:(NSURLResponse *)response
           dataTask:(NSURLSessionDataTask *)dataTask
 didBecomeDownloadTask:(NSURLSessionDownloadTask *)downloadTask
 {
-    NSLog(@"ℹ️ %s", __PRETTY_FUNCTION__);
+    NSLog(@"ℹ️ %s %@", __PRETTY_FUNCTION__, session);
     AFURLSessionManagerTaskDelegate *delegate = [self delegateForTask:dataTask];
     if (delegate) {
         [self removeDelegateForTask:dataTask];
@@ -1088,7 +1088,7 @@ didBecomeDownloadTask:(NSURLSessionDownloadTask *)downloadTask
           dataTask:(NSURLSessionDataTask *)dataTask
     didReceiveData:(NSData *)data
 {
-    NSLog(@"ℹ️ %s", __PRETTY_FUNCTION__);
+    NSLog(@"ℹ️ %s %@", __PRETTY_FUNCTION__, session);
     AFURLSessionManagerTaskDelegate *delegate = [self delegateForTask:dataTask];
     [delegate URLSession:session dataTask:dataTask didReceiveData:data];
 
@@ -1102,7 +1102,7 @@ didBecomeDownloadTask:(NSURLSessionDownloadTask *)downloadTask
  willCacheResponse:(NSCachedURLResponse *)proposedResponse
  completionHandler:(void (^)(NSCachedURLResponse *cachedResponse))completionHandler
 {
-    NSLog(@"ℹ️ %s", __PRETTY_FUNCTION__);
+    NSLog(@"ℹ️ %s %@", __PRETTY_FUNCTION__, session);
     NSCachedURLResponse *cachedResponse = proposedResponse;
 
     if (self.dataTaskWillCacheResponse) {
@@ -1115,7 +1115,7 @@ didBecomeDownloadTask:(NSURLSessionDownloadTask *)downloadTask
 }
 
 - (void)URLSessionDidFinishEventsForBackgroundURLSession:(NSURLSession *)session {
-    NSLog(@"ℹ️ %s", __PRETTY_FUNCTION__);
+    NSLog(@"ℹ️ %s %@", __PRETTY_FUNCTION__, session);
     if (self.didFinishEventsForBackgroundURLSession) {
         dispatch_async(dispatch_get_main_queue(), ^{
             self.didFinishEventsForBackgroundURLSession(session);
@@ -1129,7 +1129,7 @@ didBecomeDownloadTask:(NSURLSessionDownloadTask *)downloadTask
       downloadTask:(NSURLSessionDownloadTask *)downloadTask
 didFinishDownloadingToURL:(NSURL *)location
 {
-    NSLog(@"ℹ️ %s", __PRETTY_FUNCTION__);
+    NSLog(@"ℹ️ %s %@", __PRETTY_FUNCTION__, session);
     AFURLSessionManagerTaskDelegate *delegate = [self delegateForTask:downloadTask];
     if (self.downloadTaskDidFinishDownloading) {
         NSURL *fileURL = self.downloadTaskDidFinishDownloading(session, downloadTask, location);
@@ -1158,7 +1158,7 @@ didFinishDownloadingToURL:(NSURL *)location
  totalBytesWritten:(int64_t)totalBytesWritten
 totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite
 {
-    NSLog(@"ℹ️ %s", __PRETTY_FUNCTION__);
+    NSLog(@"ℹ️ %s %@", __PRETTY_FUNCTION__, session);
     AFURLSessionManagerTaskDelegate *delegate = [self delegateForTask:downloadTask];
     [delegate URLSession:session downloadTask:downloadTask didWriteData:bytesWritten totalBytesWritten:totalBytesWritten totalBytesExpectedToWrite:totalBytesExpectedToWrite];
 
@@ -1172,7 +1172,7 @@ totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite
  didResumeAtOffset:(int64_t)fileOffset
 expectedTotalBytes:(int64_t)expectedTotalBytes
 {
-    NSLog(@"ℹ️ %s", __PRETTY_FUNCTION__);
+    NSLog(@"ℹ️ %s %@", __PRETTY_FUNCTION__, session);
     AFURLSessionManagerTaskDelegate *delegate = [self delegateForTask:downloadTask];
     [delegate URLSession:session downloadTask:downloadTask didResumeAtOffset:fileOffset expectedTotalBytes:expectedTotalBytes];
 

--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -928,6 +928,7 @@ didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
     }
 
     if (completionHandler) {
+		NSLog(@"✳️ %s %d ✳️ disposition = %d", __PRETTY_FUNCTION__, __LINE__, disposition);
         completionHandler(disposition, credential);
     }
 }

--- a/Tests/Tests/AFHTTPSessionManagerTests.m
+++ b/Tests/Tests/AFHTTPSessionManagerTests.m
@@ -22,6 +22,7 @@
 #import "AFTestCase.h"
 
 #import "AFHTTPSessionManager.h"
+#import "AFSecurityPolicy.h"
 
 @interface AFHTTPSessionManagerTests : AFTestCase
 @property (readwrite, nonatomic, strong) AFHTTPSessionManager *manager;
@@ -226,5 +227,26 @@
     XCTAssertNil(urlResponseObject);
 }
 
+# pragma mark - Server Trust
+
+- (void)testInvalidServerTrustProducesCorrectError {
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"Request should fail"];
+    NSURL *googleCertificateURL = [[NSBundle bundleForClass:[self class]] URLForResource:@"google.com" withExtension:@"cer"];
+    NSData *googleCertificateData = [NSData dataWithContentsOfURL:googleCertificateURL];
+    self.manager.securityPolicy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModeCertificate withPinnedCertificates:[NSSet setWithObject:googleCertificateData]];
+    [self.manager
+     GET:@"get"
+     parameters:nil
+     success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject) {
+         XCTFail(@"Request should fail");
+         [expectation fulfill];
+     }
+     failure:^(NSURLSessionDataTask * _Nullable task, NSError * _Nonnull error) {
+         XCTAssertEqualObjects(error.domain, NSURLErrorDomain);
+         XCTAssertEqual(error.code, NSURLErrorServerCertificateUntrusted);
+         [expectation fulfill];
+     }];
+    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+}
 
 @end


### PR DESCRIPTION
When the server trust is invalid, using `NSURLSessionAuthChallengeCancelAuthenticationChallenge` terminates the task with an error from `NSURLErrorDomain` with code `NSURLErrorCancelled` (-999) which is indistinguishable from the error you get when calling the `cancel` method on a `NSURLSessionTask`.

Using `NSURLSessionAuthChallengeRejectProtectionSpace` instead produces a much better error:

```
Error Domain:           NSURLErrorDomain
Code:                   NSURLErrorServerCertificateUntrusted (-1202)
NSLocalizedDescription: "The certificate for this server is invalid. You might be connecting to a server that is pretending to be “httpbin.org” which could put your confidential information at risk."
```

Fixes #3165