### PR TITLE
Reachability support IPv6.

### DIFF
--- a/AFNetworking/AFNetworkReachabilityManager.h
+++ b/AFNetworking/AFNetworkReachabilityManager.h
@@ -93,7 +93,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Creates and returns a network reachability manager for the socket address.
 
- @param address The socket address (`sockaddr_in`) used to evaluate network reachability.
+ @param address The socket address (`sockaddr_in6`) used to evaluate network reachability.
 
  @return An initialized network reachability manager, actively monitoring the specified socket address.
  */

--- a/AFNetworking/AFNetworkReachabilityManager.m
+++ b/AFNetworking/AFNetworkReachabilityManager.m
@@ -116,10 +116,10 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {
     static AFNetworkReachabilityManager *_sharedManager = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        struct sockaddr_in address;
+        struct sockaddr_in6 address;
         bzero(&address, sizeof(address));
-        address.sin_len = sizeof(address);
-        address.sin_family = AF_INET;
+        address.sin6_len = sizeof(address);
+        address.sin6_family = AF_INET;
 
         _sharedManager = [self managerForAddress:&address];
     });

--- a/AFNetworking/AFNetworkReachabilityManager.m
+++ b/AFNetworking/AFNetworkReachabilityManager.m
@@ -116,12 +116,21 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {
     static AFNetworkReachabilityManager *_sharedManager = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
+#if (defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && __IPHONE_OS_VERSION_MIN_REQUIRED >= 90000) || (defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 101100)
         struct sockaddr_in6 address;
         bzero(&address, sizeof(address));
         address.sin6_len = sizeof(address);
-        address.sin6_family = AF_INET;
+        address.sin6_family = AF_INET6;
 
         _sharedManager = [self managerForAddress:&address];
+#else
+        struct sockaddr_in address;
+        bzero(&address, sizeof(address));
+        address.sin_len = sizeof(address);
+        address.sin_family = AF_INET;
+        
+        _sharedManager = [self managerForAddress:&address];
+#endif
     });
 
     return _sharedManager;

--- a/Tests/Tests/AFNetworkReachabilityManagerTests.m
+++ b/Tests/Tests/AFNetworkReachabilityManagerTests.m
@@ -39,10 +39,10 @@
 
     //don't use the shared manager because it retains state between tests
     //but recreate it each time in the same way that the shared manager is created
-    struct sockaddr_in address;
+    struct sockaddr_in6 address;
     bzero(&address, sizeof(address));
-    address.sin_len = sizeof(address);
-    address.sin_family = AF_INET;
+    address.sin6_len = sizeof(address);
+    address.sin6_family = AF_INET6;
     self.addressReachability = [AFNetworkReachabilityManager managerForAddress:&address];
 }
 

--- a/Tests/Tests/AFNetworkReachabilityManagerTests.m
+++ b/Tests/Tests/AFNetworkReachabilityManagerTests.m
@@ -39,11 +39,19 @@
 
     //don't use the shared manager because it retains state between tests
     //but recreate it each time in the same way that the shared manager is created
+#if (defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && __IPHONE_OS_VERSION_MIN_REQUIRED >= 90000) || (defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 101100)
     struct sockaddr_in6 address;
     bzero(&address, sizeof(address));
     address.sin6_len = sizeof(address);
     address.sin6_family = AF_INET6;
     self.addressReachability = [AFNetworkReachabilityManager managerForAddress:&address];
+#else
+    struct sockaddr_in address;
+    bzero(&address, sizeof(address));
+    address.sin_len = sizeof(address);
+    address.sin_family = AF_INET;
+    self.addressReachability = [AFNetworkReachabilityManager managerForAddress:&address];
+#endif
 }
 
 - (void)tearDown


### PR DESCRIPTION
[Apple Document(Supporting IPv6 DNS64/NAT64 Networks)]
(https://developer.apple.com/library/prerelease/ios/documentation/NetworkingInternetWeb/Conceptual/NetworkingOverview/UnderstandingandPreparingfortheIPv6Transition/UnderstandingandPreparingfortheIPv6Transition.html#//apple_ref/doc/uid/TP40010220-CH213-SW26)