### PR TITLE
Button image changed instead of background image

### DIFF
--- a/Tests/Tests/AFUIButtonTests.m
+++ b/Tests/Tests/AFUIButtonTests.m
@@ -60,6 +60,20 @@
     
 }
 
+- (void)testThatBackgroundImageChanges {
+    XCTAssertNil([self.button backgroundImageForState:UIControlStateNormal]);
+    [self.button setBackgroundImageForState:UIControlStateNormal withURL:self.jpegURL];
+    NSPredicate *predicate = [NSPredicate predicateWithBlock:^BOOL(UIButton  * _Nonnull button, NSDictionary<NSString *,id> * _Nullable bindings) {
+        return [button backgroundImageForState:UIControlStateNormal] != nil;
+    }];
+    
+    [self expectationForPredicate:predicate
+              evaluatedWithObject:self.button
+                          handler:nil];
+    
+    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+}
+
 - (void)testThatForegroundImageCanBeCancelledAndDownloadedImmediately {
     //https://github.com/Alamofire/AlamofireImage/issues/55
     XCTestExpectation *expectation = [self expectationWithDescription:@"Request should succeed"];

--- a/UIKit+AFNetworking/UIButton+AFNetworking.m
+++ b/UIKit+AFNetworking/UIButton+AFNetworking.m
@@ -231,12 +231,12 @@ static const char * af_backgroundImageDownloadReceiptKeyForState(UIControlState 
         if (success) {
             success(urlRequest, nil, cachedImage);
         } else {
-            [self setImage:cachedImage forState:state];
+            [self setBackgroundImage:cachedImage forState:state];
         }
         [self af_setBackgroundImageDownloadReceipt:nil forState:state];
     } else {
         if (placeholderImage) {
-            [self setImage:placeholderImage forState:state];
+            [self setBackgroundImage:placeholderImage forState:state];
         }
 
         __weak __typeof(self)weakSelf = self;
@@ -251,7 +251,7 @@ static const char * af_backgroundImageDownloadReceiptKeyForState(UIControlState 
                            if (success) {
                                success(request, response, responseObject);
                            } else if(responseObject) {
-                               [strongSelf setImage:responseObject forState:state];
+                               [strongSelf setBackgroundImage:responseObject forState:state];
                            }
                            [strongSelf af_setImageDownloadReceipt:nil forState:state];
                        }


### PR DESCRIPTION
Background image did not change when `setBackgroundImageForState` called as `setImage` was used instead of `setBackgroundImage`.