### PR TITLE
Potential leak of an object stored into 'reachability'

### DIFF
--- a/AFNetworking/AFNetworkReachabilityManager.m
+++ b/AFNetworking/AFNetworkReachabilityManager.m
@@ -128,7 +128,7 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {
     SCNetworkReachabilityRef reachability = SCNetworkReachabilityCreateWithName(kCFAllocatorDefault, [domain UTF8String]);
 
     AFNetworkReachabilityManager *manager = [[self alloc] initWithReachability:reachability];
-
+    CFRelease(reachability);
     return manager;
 }
 #endif


### PR DESCRIPTION
Call to function 'SCNetworkReachabilityCreateWithName' returns a Core Foundation object with a +1 retain count
Object leaked: object allocated and stored into 'reachability' is not referenced later in this execution path and has a retain count of +1