### PR TITLE
Fixed issue where `AFNSURLSessionTaskDidResumeNotification` was removed twice

### DIFF
--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -744,7 +744,7 @@ static NSString * const AFNSURLSessionTaskDidSuspendNotification = @"com.alamofi
 }
 
 - (void)removeNotificationObserverForTask:(NSURLSessionTask *)task {
-    [[NSNotificationCenter defaultCenter] removeObserver:self name:AFNSURLSessionTaskDidResumeNotification object:task];
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:AFNSURLSessionTaskDidSuspendNotification object:task];
     [[NSNotificationCenter defaultCenter] removeObserver:self name:AFNSURLSessionTaskDidResumeNotification object:task];
 }
 


### PR DESCRIPTION
version: 3.0.3
file: AFURLSessionManager.m
[line: 747,748](https://github.com/AFNetworking/AFNetworking/blob/3.0.3/AFNetworking/AFURLSessionManager.m#L747-L748)

AFNSURLSessionTaskDidResumeNotification was removed twice, why?