### PR TITLE
Fixed retain attribute must be of object type error in 3.0.4

### DIFF
--- a/AFNetworking/AFURLSessionManager.h
+++ b/AFNetworking/AFURLSessionManager.h
@@ -153,15 +153,24 @@ NS_ASSUME_NONNULL_BEGIN
 /// @name Managing Callback Queues
 ///-------------------------------
 
+
 /**
  The dispatch queue for `completionBlock`. If `NULL` (default), the main queue is used.
  */
+#if OS_OBJECT_USE_OBJC
 @property (nonatomic, strong, nullable) dispatch_queue_t completionQueue;
+#else
+@property (nonatomic, assign, nullable) dispatch_queue_t completionQueue;
+#endif
 
 /**
  The dispatch group for `completionBlock`. If `NULL` (default), a private dispatch group is used.
  */
+#if OS_OBJECT_USE_OBJC
 @property (nonatomic, strong, nullable) dispatch_group_t completionGroup;
+#else
+@property (nonatomic, assign, nullable) dispatch_group_t completionGroup;
+#endif
 
 ///---------------------------------
 /// @name Working Around System Bugs


### PR DESCRIPTION
Fixed retain attribute must be of object type error in NSURLSessionManager.h when including AFNetworking as a podspec s.dependency.

Related to #3241 