### PR TITLE
Removed workaround for NSJSONSerialization bug that was fixed in iOS 7

### DIFF
--- a/AFNetworking/AFURLResponseSerialization.m
+++ b/AFNetworking/AFURLResponseSerialization.m
@@ -240,41 +240,15 @@ static id AFJSONObjectByRemovingKeysWithNullValues(id JSONObject, NSJSONReadingO
         }
     }
 
-    NSStringEncoding stringEncoding = self.stringEncoding;
-    if (response.textEncodingName) {
-        CFStringEncoding encoding = CFStringConvertIANACharSetNameToEncoding((CFStringRef)response.textEncodingName);
-        if (encoding != kCFStringEncodingInvalidId) {
-            stringEncoding = CFStringConvertEncodingToNSStringEncoding(encoding);
-        }
-    }
-
     id responseObject = nil;
     NSError *serializationError = nil;
-    @autoreleasepool {
-        NSString *responseString = [[NSString alloc] initWithData:data encoding:stringEncoding];
-        if (responseString) {
-            // Workaround for a bug in NSJSONSerialization when Unicode character escape codes are used instead of the actual character
-            // See http://stackoverflow.com/a/12843465/157142
-            data = [responseString dataUsingEncoding:NSUTF8StringEncoding];
-
-            if (data) {
-                // Workaround for behavior of Rails to return a single space for `head :ok` (a workaround for a bug in Safari), which is not interpreted as valid input by NSJSONSerialization.
-                // See https://github.com/rails/rails/issues/1742
-                BOOL isSpace = [data isEqualToData:[NSData dataWithBytes:" " length:1]];
-                if (data.length > 0 && !isSpace) {
-                    responseObject = [NSJSONSerialization JSONObjectWithData:data options:self.readingOptions error:&serializationError];
-                } else {
-                    return nil;
-                }
-            } else {
-                NSDictionary *userInfo = @{
-                                           NSLocalizedDescriptionKey: NSLocalizedStringFromTable(@"Data failed decoding as a UTF-8 string", @"AFNetworking", nil),
-                                           NSLocalizedFailureReasonErrorKey: [NSString stringWithFormat:NSLocalizedStringFromTable(@"Could not decode string: %@", @"AFNetworking", nil), responseString]
-                                           };
-
-                serializationError = [NSError errorWithDomain:AFURLResponseSerializationErrorDomain code:NSURLErrorCannotDecodeContentData userInfo:userInfo];
-            }
-        }
+    // Workaround for behavior of Rails to return a single space for `head :ok` (a workaround for a bug in Safari), which is not interpreted as valid input by NSJSONSerialization.
+    // See https://github.com/rails/rails/issues/1742
+    BOOL isSpace = [data isEqualToData:[NSData dataWithBytes:" " length:1]];
+    if (data.length > 0 && !isSpace) {
+        responseObject = [NSJSONSerialization JSONObjectWithData:data options:self.readingOptions error:&serializationError];
+    } else {
+        return nil;
     }
 
     if (self.removesKeysWithNullValues && responseObject) {

--- a/Tests/Tests/AFJSONSerializationTests.m
+++ b/Tests/Tests/AFJSONSerializationTests.m
@@ -133,6 +133,24 @@ static NSData * AFJSONTestData() {
     XCTAssertNotNil(error, @"Serialization error should not be nil");
 }
 
+- (void)testThatJSONResponseSerializerReturnsNilObjectAndNilErrorForEmptyData {
+    NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:self.baseURL statusCode:200 HTTPVersion:@"1.1" headerFields:@{@"Content-Type":@"text/json"}];
+    NSData *data = [NSData data];
+    NSError *error = nil;
+    id responseObject = [self.responseSerializer responseObjectForResponse:response data:data error:&error];
+    XCTAssertNil(responseObject);
+    XCTAssertNil(error);
+}
+
+- (void)testThatJSONResponseSerializerReturnsNilObjectAndNilErrorForSingleSpace {
+    NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:self.baseURL statusCode:200 HTTPVersion:@"1.1" headerFields:@{@"Content-Type":@"text/json"}];
+    NSData *data = [@" " dataUsingEncoding:NSUTF8StringEncoding];
+    NSError *error = nil;
+    id responseObject = [self.responseSerializer responseObjectForResponse:response data:data error:&error];
+    XCTAssertNil(responseObject);
+    XCTAssertNil(error);
+}
+
 - (void)testThatJSONRemovesKeysWithNullValues {
     self.responseSerializer.removesKeysWithNullValues = YES;
     NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:self.baseURL statusCode:200 HTTPVersion:@"1.1" headerFields:@{@"Content-Type":@"text/json"}];


### PR DESCRIPTION
The NSJSONSerialization bug with Unicode character escape codes has been fixed in iOS 7, see http://openradar.appspot.com/radar?id=2397401#ag9zfm9wZW5yYWRhci1ocmRyFAsSB0NvbW1lbnQYgICAgIDdwwgM

Removing the NSData -> NSString -> NSData roundtrip is also likely a nice performance boost.