### PR TITLE
Add error parameter to the examples of AFHTTPRequestSerializer on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ NSDictionary *parameters = @{@"foo": @"bar", @"baz": @[@1, @2, @3]};
 #### URL Form Parameter Encoding
 
 ```objective-c
-[[AFHTTPRequestSerializer serializer] requestWithMethod:@"POST" URLString:URLString parameters:parameters];
+[[AFHTTPRequestSerializer serializer] requestWithMethod:@"POST" URLString:URLString parameters:parameters error:nil];
 ```
 
     POST http://example.com/
@@ -247,7 +247,7 @@ NSDictionary *parameters = @{@"foo": @"bar", @"baz": @[@1, @2, @3]};
 #### JSON Parameter Encoding
 
 ```objective-c
-[[AFJSONRequestSerializer serializer] requestWithMethod:@"POST" URLString:URLString parameters:parameters];
+[[AFJSONRequestSerializer serializer] requestWithMethod:@"POST" URLString:URLString parameters:parameters error:nil];
 ```
 
     POST http://example.com/


### PR DESCRIPTION
Now AFHTTPRequestSerializer always requires error parameter, but the examples on README.md don't follow the change.