### PR TITLE
Adds Carthage/Build into .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ AFNetworking.framework.zip
 /fastlane/report.xml
 /fastlane/.env*private*
 fastlane/test-output/*
+
+Carthage/Build


### PR DESCRIPTION
This is to make AFNetworking play nicer with Carthage.