### PR TITLE
add @"text/html" will solve some special request

### DIFF
--- a/AFNetworking/AFURLResponseSerialization.m
+++ b/AFNetworking/AFURLResponseSerialization.m
@@ -223,7 +223,7 @@ static id AFJSONObjectByRemovingKeysWithNullValues(id JSONObject, NSJSONReadingO
         return nil;
     }
 
-    self.acceptableContentTypes = [NSSet setWithObjects:@"application/json", @"text/json", @"text/javascript", nil];
+    self.acceptableContentTypes = [NSSet setWithObjects:@"application/json", @"text/json", @"text/javascript",@"text/html", nil];
 
     return self;
 }


### PR DESCRIPTION
some json will include the type @"text/html",if here not add this,this type request can't return any data for us.
I have encountered this error,NSLocalizedDescription=Request failed: unacceptable content-type: text/html.
so I hope will check it out ,and accept it soon!