### PR TITLE
Update AFHTTPSessionManager.h

### DIFF
--- a/AFNetworking/AFHTTPSessionManager.h
+++ b/AFNetworking/AFHTTPSessionManager.h
@@ -158,7 +158,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (nullable NSURLSessionDataTask *)GET:(NSString *)URLString
                             parameters:(nullable id)parameters
-                              progress:(nullable void (^)(NSProgress *downloadProgress)) downloadProgress
+                              progress:(nullable void (^ __nullable)(NSProgress *downloadProgress)) downloadProgress
                                success:(nullable void (^)(NSURLSessionDataTask *task, id _Nullable responseObject))success
                                failure:(nullable void (^)(NSURLSessionDataTask * _Nullable task, NSError *error))failure;
 


### PR DESCRIPTION
Mark progress block as nullable.

There may be other blocks that require this, but I'm not sure which ones. I am still migrating to 3.0 and I didn't use AFNetworking much to know it better.