### PR TITLE
Fixed status code 204/205 handling

### DIFF
--- a/AFNetworking/AFURLResponseSerialization.m
+++ b/AFNetworking/AFURLResponseSerialization.m
@@ -115,7 +115,9 @@ static id AFJSONObjectByRemovingKeysWithNullValues(id JSONObject, NSJSONReadingO
     NSError *validationError = nil;
 
     if (response && [response isKindOfClass:[NSHTTPURLResponse class]]) {
-        if (self.acceptableContentTypes && ![self.acceptableContentTypes containsObject:[response MIMEType]]) {
+        if (self.acceptableContentTypes && ![self.acceptableContentTypes containsObject:[response MIMEType]] &&
+            !([response MIMEType] == nil && [data length] == 0)) {
+
             if ([data length] > 0 && [response URL]) {
                 NSMutableDictionary *mutableUserInfo = [@{
                                                           NSLocalizedDescriptionKey: [NSString stringWithFormat:NSLocalizedStringFromTable(@"Request failed: unacceptable content-type: %@", @"AFNetworking", nil), [response MIMEType]],

--- a/Tests/Tests/AFHTTPResponseSerializationTests.m
+++ b/Tests/Tests/AFHTTPResponseSerializationTests.m
@@ -50,6 +50,34 @@
     }];
 }
 
+- (void)testThatAFHTTPResponseSerializationSucceedsWith205WithNoResponseContentTypeAndNoResponseData {
+    NSInteger statusCode = 205;
+    NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:self.baseURL statusCode:statusCode HTTPVersion:@"1.1" headerFields:@{}];
+
+    XCTAssert([self.responseSerializer.acceptableStatusCodes containsIndex:statusCode], @"Status code %@ should be acceptable", @(statusCode));
+
+    NSError *error = nil;
+    self.responseSerializer.acceptableContentTypes = [NSSet setWithObject:@"text/html"];
+
+    XCTAssertTrue([self.responseSerializer validateResponse:response data:nil error:&error]);
+    XCTAssertNil(error, @"Error handling status code %@", @(statusCode));
+
+    XCTAssertFalse([self.responseSerializer validateResponse:response data:[@"test" dataUsingEncoding:NSUTF8StringEncoding] error:&error]);
+}
+
+- (void)testThatAFHTTPResponseSerializationFailsWith205WithNoResponseContentTypeAndResponseData {
+    NSInteger statusCode = 205;
+    NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:self.baseURL statusCode:statusCode HTTPVersion:@"1.1" headerFields:@{}];
+
+    XCTAssert([self.responseSerializer.acceptableStatusCodes containsIndex:statusCode], @"Status code %@ should be acceptable", @(statusCode));
+
+    NSError *error = nil;
+    self.responseSerializer.acceptableContentTypes = [NSSet setWithObject:@"text/html"];
+
+    XCTAssertFalse([self.responseSerializer validateResponse:response data:[@"test" dataUsingEncoding:NSUTF8StringEncoding] error:&error]);
+    XCTAssertNotNil(error, @"Error handling status code %@", @(statusCode));
+}
+
 - (void)testThatAFHTTPResponseSerializationFailsAll4XX5XXStatusCodes {
     NSIndexSet *indexSet = [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(400, 200)];
     [indexSet enumerateIndexesUsingBlock:^(NSUInteger statusCode, BOOL *stop) {


### PR DESCRIPTION
If a server returned a 204/205 with no response content type and no response data, the response serializer would fail. This patch allows response serialization to continue without error if no response content type header is defined, and there are zero bytes of response of data.

If the server returns a response content type header OR response data, the serializer will respect the old serialization logic. This means that if a response content type is listed in the header, we are expecting some type of data response.

This patches #2797 