### PR TITLE
Fixed static analyzer warnings on AFNetworkReachabilityManager

### DIFF
--- a/AFNetworking/AFNetworkReachabilityManager.m
+++ b/AFNetworking/AFNetworkReachabilityManager.m
@@ -176,11 +176,11 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {
 }
 
 - (void)dealloc {
+    [self stopMonitoring];
+    
     if (_networkReachability != NULL) {
         CFRelease(_networkReachability);
     }
-    
-    [self stopMonitoring];
 }
 
 #pragma mark -

--- a/AFNetworking/AFNetworkReachabilityManager.m
+++ b/AFNetworking/AFNetworkReachabilityManager.m
@@ -106,7 +106,7 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {
 }
 
 @interface AFNetworkReachabilityManager ()
-@property (readwrite, nonatomic, strong) id networkReachability;
+@property (readonly, nonatomic, assign) SCNetworkReachabilityRef networkReachability;
 @property (readwrite, nonatomic, assign) AFNetworkReachabilityStatus networkReachabilityStatus;
 @property (readwrite, nonatomic, copy) AFNetworkReachabilityStatusBlock networkReachabilityStatusBlock;
 @end
@@ -123,24 +123,24 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {
     return _sharedManager;
 }
 
-#ifndef __clang_analyzer__
 + (instancetype)managerForDomain:(NSString *)domain {
     SCNetworkReachabilityRef reachability = SCNetworkReachabilityCreateWithName(kCFAllocatorDefault, [domain UTF8String]);
 
     AFNetworkReachabilityManager *manager = [[self alloc] initWithReachability:reachability];
+    
+    CFRelease(reachability);
 
     return manager;
 }
-#endif
 
-#ifndef __clang_analyzer__
 + (instancetype)managerForAddress:(const void *)address {
     SCNetworkReachabilityRef reachability = SCNetworkReachabilityCreateWithAddress(kCFAllocatorDefault, (const struct sockaddr *)address);
     AFNetworkReachabilityManager *manager = [[self alloc] initWithReachability:reachability];
 
+    CFRelease(reachability);
+    
     return manager;
 }
-#endif
 
 + (instancetype)manager
 {
@@ -164,7 +164,7 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {
         return nil;
     }
 
-    self.networkReachability = CFBridgingRelease(reachability);
+    _networkReachability = CFRetain(reachability);
     self.networkReachabilityStatus = AFNetworkReachabilityStatusUnknown;
 
     return self;
@@ -176,6 +176,10 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {
 }
 
 - (void)dealloc {
+    if (_networkReachability != NULL) {
+        CFRelease(_networkReachability);
+    }
+    
     [self stopMonitoring];
 }
 
@@ -213,14 +217,13 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {
 
     };
 
-    id networkReachability = self.networkReachability;
     SCNetworkReachabilityContext context = {0, (__bridge void *)callback, AFNetworkReachabilityRetainCallback, AFNetworkReachabilityReleaseCallback, NULL};
-    SCNetworkReachabilitySetCallback((__bridge SCNetworkReachabilityRef)networkReachability, AFNetworkReachabilityCallback, &context);
-    SCNetworkReachabilityScheduleWithRunLoop((__bridge SCNetworkReachabilityRef)networkReachability, CFRunLoopGetMain(), kCFRunLoopCommonModes);
+    SCNetworkReachabilitySetCallback(self.networkReachability, AFNetworkReachabilityCallback, &context);
+    SCNetworkReachabilityScheduleWithRunLoop(self.networkReachability, CFRunLoopGetMain(), kCFRunLoopCommonModes);
 
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0),^{
         SCNetworkReachabilityFlags flags;
-        if (SCNetworkReachabilityGetFlags((__bridge SCNetworkReachabilityRef)networkReachability, &flags)) {
+        if (SCNetworkReachabilityGetFlags(self.networkReachability, &flags)) {
             AFPostReachabilityStatusChange(flags, callback);
         }
     });
@@ -231,7 +234,7 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {
         return;
     }
 
-    SCNetworkReachabilityUnscheduleFromRunLoop((__bridge SCNetworkReachabilityRef)self.networkReachability, CFRunLoopGetMain(), kCFRunLoopCommonModes);
+    SCNetworkReachabilityUnscheduleFromRunLoop(self.networkReachability, CFRunLoopGetMain(), kCFRunLoopCommonModes);
 }
 
 #pragma mark -


### PR DESCRIPTION
The current version of `AFNetworkReachabilityManager` fixes some static analyzer warnings by using `#ifndef __clang_analyzer__` to hide the errors. This PR removes that conditional code in favor of fixing the analyzer issue.

Instead of bridging the reachability reference to ARC, this PR sets the type of `networkReachability` to `SCNetworkReachabilityRef`, which not only allows for cleaner memory management as far as the analyzer is concerned, but also gets rid of a lot of unnecessary bridging further into the file.