### PR TITLE
Correct serizalization of NSArray of NSDictionary

### DIFF
--- a/AFNetworking/AFURLRequestSerialization.m
+++ b/AFNetworking/AFURLRequestSerialization.m
@@ -148,8 +148,9 @@ NSArray * AFQueryStringPairsFromKeyAndValue(NSString *key, id value) {
         }
     } else if ([value isKindOfClass:[NSArray class]]) {
         NSArray *array = value;
+        int i = 0;
         for (id nestedValue in array) {
-            [mutableQueryStringComponents addObjectsFromArray:AFQueryStringPairsFromKeyAndValue([NSString stringWithFormat:@"%@[]", key], nestedValue)];
+            [mutableQueryStringComponents addObjectsFromArray:AFQueryStringPairsFromKeyAndValue([NSString stringWithFormat:@"%@[%d]", key, i++], nestedValue)];
         }
     } else if ([value isKindOfClass:[NSSet class]]) {
         NSSet *set = value;


### PR DESCRIPTION
Before this fix, an NSArray of NSDictionary containing the same keys was wrongly serizalized as an array containing multiple elementsserialized 

Declaration :
NSArray *array = @[@{@"id":1, @"name" : @"one"}, @{@"id":2, @"name": @"two"}, @{@"id":3, @"name" : @"three"}]
NSDictionary *params = @{@"myArray" : array}

Serialization :

https://myApi.com/myPath?myArray[][id]=1&myArray[][name]=one&myArray[][id]=2&myArray[][name]=two&myArray[][id]=3&myArray[][name]=three

Which, for example in php would be interpreted as an array inexed by number, each containing only one key :
array(6) {
  [0]=>
  array(1) {
    [id]=>
    int(1)
    }
    [1]=>
  array(1) {
    [name]=>
    string(3) "one"
    }
    [2]=>
  array(1) {
    [id]=>
    int(2)
    }
    [3]=>
  array(1) {
    [name]=>
    string(3) "two"
    }
    [4]=>
  array(1) {
    [id]=>
    int(3)
    }
    [5]=>
  array(1) {
    [name]=>
    string(5) "three"
    }  
}

Which is wrong as we should have an array containing 3 elements, each being an associative array with two keys, etc.
