### PR TITLE
Fix for iOS 7 background upload tasks not updating progress

### DIFF
--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -222,7 +222,7 @@ typedef void (^AFURLSessionTaskCompletionHandler)(NSURLResponse *response, id re
 }
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary<NSString *,id> *)change context:(void *)context {
-    if ([object isKindOfClass:[NSURLSessionTask class]] || [object isKindOfClass:[NSURLSessionDownloadTask class]]) {
+    if ([object isKindOfClass:[NSURLSessionTask class]] || [object isKindOfClass:[NSURLSessionDownloadTask class]] || [object isKindOfClass:[NSURLSessionUploadTask class]]) {
         if ([keyPath isEqualToString:NSStringFromSelector(@selector(countOfBytesReceived))]) {
             self.downloadProgress.completedUnitCount = [change[@"new"] longLongValue];
         } else if ([keyPath isEqualToString:NSStringFromSelector(@selector(countOfBytesExpectedToReceive))]) {


### PR DESCRIPTION
In iOS 7 a background upload task returns false for isKindOfClass:[NSURLSessionTask class].  However in iOS 8 & 9 isKindOfClass:[NSURLSessionTask class] returns true.

The observeValueForKeyPath in iOS 7 for the background upload task won't update values and therefore the NSProgress won't be updated.

Added checking if the task object isKindOfClass:[NSURLSessionUploadTask class] in observeValueForKeyPath to fix this behaviour.
