### PR TITLE
Fix - Image Cache Tests

### DIFF
--- a/Tests/Tests/AFAutoPurgingImageCacheTests.m
+++ b/Tests/Tests/AFAutoPurgingImageCacheTests.m
@@ -170,7 +170,7 @@
     NSString *identifier = @"logo";
     XCTAssertTrue(self.cache.memoryUsage == 0);
     [self.cache addImage:self.testImage withIdentifier:identifier];
-    XCTAssertTrue(self.cache.memoryUsage == 13600);
+    XCTAssertTrue(self.cache.memoryUsage == 1020000);
 }
 
 - (void)testThatMemoryUsageDecreasesWhenRemovingImage {
@@ -183,7 +183,7 @@
 
 #pragma mark - Purging
 - (void)testThatImagesArePurgedWhenCapcityIsReached {
-    UInt64 imageSize = 13600;
+    UInt64 imageSize = 1020000;
     NSInteger numberOfImages = 10;
     NSInteger numberOfImagesAfterPurge = 6;
     self.cache = [[AFAutoPurgingImageCache alloc] initWithMemoryCapacity:numberOfImages * imageSize preferredMemoryCapacity:numberOfImagesAfterPurge * imageSize];
@@ -202,7 +202,7 @@
 }
 
 - (void)testThatPrioritizedImagesWithOldestLastAccessDatesAreRemovedDuringPurge {
-    UInt64 imageSize = 13600;
+    UInt64 imageSize = 1020000;
     NSInteger numberOfImages = 10;
     NSInteger numberOfImagesAfterPurge = 6;
     self.cache = [[AFAutoPurgingImageCache alloc] initWithMemoryCapacity:numberOfImages * imageSize preferredMemoryCapacity:numberOfImagesAfterPurge * imageSize];


### PR DESCRIPTION
This PR fixes the auto-purging image cache tests that were broken by merging #3344. I've verified the changes are accurate. The logo image is 850 x 300 px with a pixel size of 4 bytes which totals 1020000 bytes.