### PR TITLE
Prevent AFImageDownloader crashing when passing invalid NSURLRequest (#3343)

### DIFF
--- a/Tests/Tests/AFImageDownloaderTests.m
+++ b/Tests/Tests/AFImageDownloaderTests.m
@@ -64,6 +64,22 @@
     XCTAssertNil(self.downloader, @"Downloader should be nil");
 }
 
+- (void)testThatImageDownloaderReturnsNilWithInvalidURL
+{
+    NSURL *pngURL = [NSURL URLWithString:@"https://httpbin.org/image/png"];
+    NSMutableURLRequest *mutableURLRequest = [NSMutableURLRequest requestWithURL:pngURL];
+    [mutableURLRequest setURL:nil];
+    /** NSURLRequest nor NSMutableURLRequest can be initialized with a nil URL, 
+     *  but NSMutableURLRequest can have its URL set to nil 
+     **/
+    NSURLRequest *invalidRequest = [mutableURLRequest copy];
+    AFImageDownloadReceipt *downloadReceipt = [self.downloader downloadImageForURLRequest:invalidRequest
+                                                                                  success:nil
+                                                                                  failure:nil];
+    
+    XCTAssertNil(downloadReceipt, @"downloadReceipt should be nil");
+}
+
 - (void)testThatImageDownloaderCanDownloadImage {
     XCTestExpectation *expectation = [self expectationWithDescription:@"image download should succeed"];
 

--- a/UIKit+AFNetworking/AFImageDownloader.m
+++ b/UIKit+AFNetworking/AFImageDownloader.m
@@ -189,6 +189,9 @@
     __block NSURLSessionDataTask *task = nil;
     dispatch_sync(self.synchronizationQueue, ^{
         NSString *URLIdentifier = request.URL.absoluteString;
+        if (URLIdentifier == nil) {
+            return;
+        }
 
         // 1) Append the success and failure blocks to a pre-existing request if it already exists
         AFImageDownloaderMergedTask *existingMergedTask = self.mergedTasks[URLIdentifier];


### PR DESCRIPTION
This references issues #3343, where an image download request can crash if it doesn't have a valid URL. Whether this should be handled by the framework or by the implementer is a design decision. It appears that NSAssert is not used for cases like this in the framework, so we are failing by returning a nil image download receipt instead. And given the rest of the behavior in the method, it is suggested the failure block should not be called (or a task created in the first place given invalid inputs). I hope this commit aligns with the solution the authors of AFNetworking would suggest for this scenario.

Feedback is greatly appreciated. 