### PR TITLE
Fixed crash in `AFURLRequestSerialization` if `stringByAddingPercentEncodingWithAllowedCharacters:` returned a nil string

### DIFF
--- a/AFNetworking/AFURLRequestSerialization.m
+++ b/AFNetworking/AFURLRequestSerialization.m
@@ -71,8 +71,10 @@ NSString * AFPercentEscapedStringFromString(NSString *string) {
 
         NSString *substring = [string substringWithRange:range];
         NSString *encoded = [substring stringByAddingPercentEncodingWithAllowedCharacters:allowedCharacterSet];
-        [escaped appendString:encoded];
-
+        if(encoded){
+            [escaped appendString:encoded];	
+        }
+        
         index += range.length;
     }
 


### PR DESCRIPTION
fixed crash when  encoded = nil,  My App have this Crash sometimes, but i don't know how to it appearance.
