### PR TITLE
Added white space to URLs in code comment to allow Xcode to properly parse them

### DIFF
--- a/AFNetworking/AFHTTPSessionManager.h
+++ b/AFNetworking/AFHTTPSessionManager.h
@@ -1,5 +1,5 @@
 // AFHTTPSessionManager.h
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/AFNetworking/AFHTTPSessionManager.h
+++ b/AFNetworking/AFHTTPSessionManager.h
@@ -1,5 +1,5 @@
 // AFHTTPSessionManager.h
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/AFNetworking/AFHTTPSessionManager.m
+++ b/AFNetworking/AFHTTPSessionManager.m
@@ -1,5 +1,5 @@
 // AFHTTPSessionManager.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/AFNetworking/AFHTTPSessionManager.m
+++ b/AFNetworking/AFHTTPSessionManager.m
@@ -1,5 +1,5 @@
 // AFHTTPSessionManager.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/AFNetworking/AFNetworkReachabilityManager.h
+++ b/AFNetworking/AFNetworkReachabilityManager.h
@@ -1,5 +1,5 @@
 // AFNetworkReachabilityManager.h
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  Reachability can be used to determine background information about why a network operation failed, or to trigger a network operation retrying when a connection is established. It should not be used to prevent a user from initiating a network request, as it's possible that an initial request may be required to establish reachability.
 
- See Apple's Reachability Sample Code (https://developer.apple.com/library/ios/samplecode/reachability/)
+ See Apple's Reachability Sample Code (https://developer.apple.com/library/ios/samplecode/reachability/ )
 
  @warning Instances of `AFNetworkReachabilityManager` must be started with `-startMonitoring` before reachability status can be determined.
  */

--- a/AFNetworking/AFNetworkReachabilityManager.h
+++ b/AFNetworking/AFNetworkReachabilityManager.h
@@ -1,5 +1,5 @@
 // AFNetworkReachabilityManager.h
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  Reachability can be used to determine background information about why a network operation failed, or to trigger a network operation retrying when a connection is established. It should not be used to prevent a user from initiating a network request, as it's possible that an initial request may be required to establish reachability.
 
- See Apple's Reachability Sample Code (https://developer.apple.com/library/ios/samplecode/reachability/ )
+ See Apple's Reachability Sample Code ( https://developer.apple.com/library/ios/samplecode/reachability/ )
 
  @warning Instances of `AFNetworkReachabilityManager` must be started with `-startMonitoring` before reachability status can be determined.
  */

--- a/AFNetworking/AFNetworkReachabilityManager.m
+++ b/AFNetworking/AFNetworkReachabilityManager.m
@@ -1,5 +1,5 @@
 // AFNetworkReachabilityManager.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/AFNetworking/AFNetworkReachabilityManager.m
+++ b/AFNetworking/AFNetworkReachabilityManager.m
@@ -1,5 +1,5 @@
 // AFNetworkReachabilityManager.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/AFNetworking/AFSecurityPolicy.h
+++ b/AFNetworking/AFSecurityPolicy.h
@@ -1,5 +1,5 @@
 // AFSecurityPolicy.h
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/AFNetworking/AFSecurityPolicy.h
+++ b/AFNetworking/AFSecurityPolicy.h
@@ -1,5 +1,5 @@
 // AFSecurityPolicy.h
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/AFNetworking/AFSecurityPolicy.m
+++ b/AFNetworking/AFSecurityPolicy.m
@@ -1,5 +1,5 @@
 // AFSecurityPolicy.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/AFNetworking/AFSecurityPolicy.m
+++ b/AFNetworking/AFSecurityPolicy.m
@@ -1,5 +1,5 @@
 // AFSecurityPolicy.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/AFNetworking/AFURLRequestSerialization.h
+++ b/AFNetworking/AFURLRequestSerialization.h
@@ -1,5 +1,5 @@
 // AFURLRequestSerialization.h
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/AFNetworking/AFURLRequestSerialization.h
+++ b/AFNetworking/AFURLRequestSerialization.h
@@ -1,5 +1,5 @@
 // AFURLRequestSerialization.h
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/AFNetworking/AFURLRequestSerialization.m
+++ b/AFNetworking/AFURLRequestSerialization.m
@@ -1,5 +1,5 @@
 // AFURLRequestSerialization.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/AFNetworking/AFURLRequestSerialization.m
+++ b/AFNetworking/AFURLRequestSerialization.m
@@ -1,5 +1,5 @@
 // AFURLRequestSerialization.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/AFNetworking/AFURLResponseSerialization.h
+++ b/AFNetworking/AFURLResponseSerialization.h
@@ -1,5 +1,5 @@
 // AFURLResponseSerialization.h
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/AFNetworking/AFURLResponseSerialization.h
+++ b/AFNetworking/AFURLResponseSerialization.h
@@ -1,5 +1,5 @@
 // AFURLResponseSerialization.h
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/AFNetworking/AFURLResponseSerialization.m
+++ b/AFNetworking/AFURLResponseSerialization.m
@@ -1,5 +1,5 @@
 // AFURLResponseSerialization.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/AFNetworking/AFURLResponseSerialization.m
+++ b/AFNetworking/AFURLResponseSerialization.m
@@ -1,5 +1,5 @@
 // AFURLResponseSerialization.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/AFNetworking/AFURLSessionManager.h
+++ b/AFNetworking/AFURLSessionManager.h
@@ -1,5 +1,5 @@
 // AFURLSessionManager.h
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/AFNetworking/AFURLSessionManager.h
+++ b/AFNetworking/AFURLSessionManager.h
@@ -1,5 +1,5 @@
 // AFURLSessionManager.h
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -1,5 +1,5 @@
 // AFURLSessionManager.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -1,5 +1,5 @@
 // AFURLSessionManager.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Example/Classes/Models/Post.h
+++ b/Example/Classes/Models/Post.h
@@ -1,6 +1,6 @@
 // Post.h
 //
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Example/Classes/Models/Post.h
+++ b/Example/Classes/Models/Post.h
@@ -1,6 +1,6 @@
 // Post.h
 //
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Example/Classes/Models/Post.m
+++ b/Example/Classes/Models/Post.m
@@ -1,6 +1,6 @@
 // Post.m
 //
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Example/Classes/Models/Post.m
+++ b/Example/Classes/Models/Post.m
@@ -1,6 +1,6 @@
 // Post.m
 //
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Example/Classes/Models/User.h
+++ b/Example/Classes/Models/User.h
@@ -1,6 +1,6 @@
 // User.h
 //
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Example/Classes/Models/User.h
+++ b/Example/Classes/Models/User.h
@@ -1,6 +1,6 @@
 // User.h
 //
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Example/Classes/Models/User.m
+++ b/Example/Classes/Models/User.m
@@ -1,6 +1,6 @@
 // User.m
 //
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Example/Classes/Models/User.m
+++ b/Example/Classes/Models/User.m
@@ -1,6 +1,6 @@
 // User.m
 //
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Example/Classes/Networking Extensions/AFAppDotNetAPIClient.h
+++ b/Example/Classes/Networking Extensions/AFAppDotNetAPIClient.h
@@ -1,6 +1,6 @@
 // AFAppDotNetAPIClient.h
 //
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Example/Classes/Networking Extensions/AFAppDotNetAPIClient.h
+++ b/Example/Classes/Networking Extensions/AFAppDotNetAPIClient.h
@@ -1,6 +1,6 @@
 // AFAppDotNetAPIClient.h
 //
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Example/Classes/Networking Extensions/AFAppDotNetAPIClient.m
+++ b/Example/Classes/Networking Extensions/AFAppDotNetAPIClient.m
@@ -1,6 +1,6 @@
 // AFAppDotNetAPIClient.h
 //
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Example/Classes/Networking Extensions/AFAppDotNetAPIClient.m
+++ b/Example/Classes/Networking Extensions/AFAppDotNetAPIClient.m
@@ -1,6 +1,6 @@
 // AFAppDotNetAPIClient.h
 //
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Example/OS X Example/AppDelegate.h
+++ b/Example/OS X Example/AppDelegate.h
@@ -1,6 +1,6 @@
 // AppDelegate.h
 //
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Example/OS X Example/AppDelegate.h
+++ b/Example/OS X Example/AppDelegate.h
@@ -1,6 +1,6 @@
 // AppDelegate.h
 //
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Example/OS X Example/AppDelegate.m
+++ b/Example/OS X Example/AppDelegate.m
@@ -1,6 +1,6 @@
 // AppDelegate.m
 //
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Example/OS X Example/AppDelegate.m
+++ b/Example/OS X Example/AppDelegate.m
@@ -1,6 +1,6 @@
 // AppDelegate.m
 //
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Example/OS X Example/main.m
+++ b/Example/OS X Example/main.m
@@ -1,5 +1,5 @@
 // main.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Example/OS X Example/main.m
+++ b/Example/OS X Example/main.m
@@ -1,5 +1,5 @@
 // main.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Example/Today Extension Example/TodayViewController.h
+++ b/Example/Today Extension Example/TodayViewController.h
@@ -1,6 +1,6 @@
 // TodayViewController.h
 //
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Example/Today Extension Example/TodayViewController.h
+++ b/Example/Today Extension Example/TodayViewController.h
@@ -1,6 +1,6 @@
 // TodayViewController.h
 //
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Example/Today Extension Example/TodayViewController.m
+++ b/Example/Today Extension Example/TodayViewController.m
@@ -1,6 +1,6 @@
 //  TodayViewController.m
 //
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Example/Today Extension Example/TodayViewController.m
+++ b/Example/Today Extension Example/TodayViewController.m
@@ -1,6 +1,6 @@
 //  TodayViewController.m
 //
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Example/iOS Example/AppDelegate.h
+++ b/Example/iOS Example/AppDelegate.h
@@ -1,6 +1,6 @@
 // AppDelegate.h
 //
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Example/iOS Example/AppDelegate.h
+++ b/Example/iOS Example/AppDelegate.h
@@ -1,6 +1,6 @@
 // AppDelegate.h
 //
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Example/iOS Example/AppDelegate.m
+++ b/Example/iOS Example/AppDelegate.m
@@ -1,6 +1,6 @@
 // AppDelegate.m
 //
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Example/iOS Example/AppDelegate.m
+++ b/Example/iOS Example/AppDelegate.m
@@ -1,6 +1,6 @@
 // AppDelegate.m
 //
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Example/iOS Example/Controllers/GlobalTimelineViewController.h
+++ b/Example/iOS Example/Controllers/GlobalTimelineViewController.h
@@ -1,6 +1,6 @@
 // GlobalTimelineViewController.h
 //
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Example/iOS Example/Controllers/GlobalTimelineViewController.h
+++ b/Example/iOS Example/Controllers/GlobalTimelineViewController.h
@@ -1,6 +1,6 @@
 // GlobalTimelineViewController.h
 //
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Example/iOS Example/Controllers/GlobalTimelineViewController.m
+++ b/Example/iOS Example/Controllers/GlobalTimelineViewController.m
@@ -1,6 +1,6 @@
 // GlobalTimelineViewController.m
 //
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Example/iOS Example/Controllers/GlobalTimelineViewController.m
+++ b/Example/iOS Example/Controllers/GlobalTimelineViewController.m
@@ -1,6 +1,6 @@
 // GlobalTimelineViewController.m
 //
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Example/iOS Example/Views/PostTableViewCell.h
+++ b/Example/iOS Example/Views/PostTableViewCell.h
@@ -1,6 +1,6 @@
 // TweetTableViewCell.h
 //
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Example/iOS Example/Views/PostTableViewCell.h
+++ b/Example/iOS Example/Views/PostTableViewCell.h
@@ -1,6 +1,6 @@
 // TweetTableViewCell.h
 //
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Example/iOS Example/Views/PostTableViewCell.m
+++ b/Example/iOS Example/Views/PostTableViewCell.m
@@ -1,6 +1,6 @@
 // TweetTableViewCell.m
 //
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Example/iOS Example/Views/PostTableViewCell.m
+++ b/Example/iOS Example/Views/PostTableViewCell.m
@@ -1,6 +1,6 @@
 // TweetTableViewCell.m
 //
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Example/main.m
+++ b/Example/main.m
@@ -1,5 +1,5 @@
 // main.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Example/main.m
+++ b/Example/main.m
@@ -1,5 +1,5 @@
 // main.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Example/tvOS Example/AppDelegate.swift
+++ b/Example/tvOS Example/AppDelegate.swift
@@ -1,5 +1,5 @@
 // AppDelegate.swift
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Example/tvOS Example/AppDelegate.swift
+++ b/Example/tvOS Example/AppDelegate.swift
@@ -1,5 +1,5 @@
 // AppDelegate.swift
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Example/tvOS Example/Gravatar.swift
+++ b/Example/tvOS Example/Gravatar.swift
@@ -1,6 +1,6 @@
 // Gravatar.swift
 //
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Example/tvOS Example/Gravatar.swift
+++ b/Example/tvOS Example/Gravatar.swift
@@ -1,6 +1,6 @@
 // Gravatar.swift
 //
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Example/tvOS Example/ViewController.swift
+++ b/Example/tvOS Example/ViewController.swift
@@ -1,5 +1,5 @@
 // ViewController.swift
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Example/tvOS Example/ViewController.swift
+++ b/Example/tvOS Example/ViewController.swift
@@ -1,5 +1,5 @@
 // ViewController.swift
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Example/watchOS Example Extension/ExtensionDelegate.h
+++ b/Example/watchOS Example Extension/ExtensionDelegate.h
@@ -1,5 +1,5 @@
 // ExtensionDelegate.h
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Example/watchOS Example Extension/ExtensionDelegate.h
+++ b/Example/watchOS Example Extension/ExtensionDelegate.h
@@ -1,5 +1,5 @@
 // ExtensionDelegate.h
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Example/watchOS Example Extension/ExtensionDelegate.m
+++ b/Example/watchOS Example Extension/ExtensionDelegate.m
@@ -1,5 +1,5 @@
 // ExtensionDelegate.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Example/watchOS Example Extension/ExtensionDelegate.m
+++ b/Example/watchOS Example Extension/ExtensionDelegate.m
@@ -1,5 +1,5 @@
 // ExtensionDelegate.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Example/watchOS Example Extension/InterfaceController.h
+++ b/Example/watchOS Example Extension/InterfaceController.h
@@ -1,5 +1,5 @@
 //  InterfaceController.h
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Example/watchOS Example Extension/InterfaceController.h
+++ b/Example/watchOS Example Extension/InterfaceController.h
@@ -1,5 +1,5 @@
 //  InterfaceController.h
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Example/watchOS Example Extension/InterfaceController.m
+++ b/Example/watchOS Example Extension/InterfaceController.m
@@ -1,5 +1,5 @@
 // InterfaceController.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Example/watchOS Example Extension/InterfaceController.m
+++ b/Example/watchOS Example Extension/InterfaceController.m
@@ -1,5 +1,5 @@
 // InterfaceController.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Framework/AFNetworking.h
+++ b/Framework/AFNetworking.h
@@ -1,5 +1,5 @@
 // AFNetworking.h
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Framework/AFNetworking.h
+++ b/Framework/AFNetworking.h
@@ -1,5 +1,5 @@
 // AFNetworking.h
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/Tests/AFAutoPurgingImageCacheTests.m
+++ b/Tests/Tests/AFAutoPurgingImageCacheTests.m
@@ -1,5 +1,5 @@
 // AFAutoPurgingImageCacheTests.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/Tests/AFAutoPurgingImageCacheTests.m
+++ b/Tests/Tests/AFAutoPurgingImageCacheTests.m
@@ -1,5 +1,5 @@
 // AFAutoPurgingImageCacheTests.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/Tests/AFCompoundResponseSerializerTests.m
+++ b/Tests/Tests/AFCompoundResponseSerializerTests.m
@@ -1,5 +1,5 @@
 // AFURLSessionManagerTests.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/Tests/AFCompoundResponseSerializerTests.m
+++ b/Tests/Tests/AFCompoundResponseSerializerTests.m
@@ -1,5 +1,5 @@
 // AFURLSessionManagerTests.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/Tests/AFHTTPRequestSerializationTests.m
+++ b/Tests/Tests/AFHTTPRequestSerializationTests.m
@@ -1,5 +1,5 @@
 // AFHTTPRequestSerializationTests.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/Tests/AFHTTPRequestSerializationTests.m
+++ b/Tests/Tests/AFHTTPRequestSerializationTests.m
@@ -1,5 +1,5 @@
 // AFHTTPRequestSerializationTests.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/Tests/AFHTTPResponseSerializationTests.m
+++ b/Tests/Tests/AFHTTPResponseSerializationTests.m
@@ -1,5 +1,5 @@
 // AFHTTPResponseSerializationTests.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/Tests/AFHTTPResponseSerializationTests.m
+++ b/Tests/Tests/AFHTTPResponseSerializationTests.m
@@ -1,5 +1,5 @@
 // AFHTTPResponseSerializationTests.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/Tests/AFHTTPSessionManagerTests.m
+++ b/Tests/Tests/AFHTTPSessionManagerTests.m
@@ -1,5 +1,5 @@
 // AFHTTPSessionManagerTests.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/Tests/AFHTTPSessionManagerTests.m
+++ b/Tests/Tests/AFHTTPSessionManagerTests.m
@@ -1,5 +1,5 @@
 // AFHTTPSessionManagerTests.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/Tests/AFImageDownloaderTests.m
+++ b/Tests/Tests/AFImageDownloaderTests.m
@@ -1,5 +1,5 @@
 // AFImageDownloaderTests.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/Tests/AFImageDownloaderTests.m
+++ b/Tests/Tests/AFImageDownloaderTests.m
@@ -1,5 +1,5 @@
 // AFImageDownloaderTests.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/Tests/AFJSONSerializationTests.m
+++ b/Tests/Tests/AFJSONSerializationTests.m
@@ -1,5 +1,5 @@
 // AFJSONSerializationTests.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/Tests/AFJSONSerializationTests.m
+++ b/Tests/Tests/AFJSONSerializationTests.m
@@ -1,5 +1,5 @@
 // AFJSONSerializationTests.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/Tests/AFNetworkActivityManagerTests.m
+++ b/Tests/Tests/AFNetworkActivityManagerTests.m
@@ -1,5 +1,5 @@
 // AFNetworkActivityManagerTests.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/Tests/AFNetworkActivityManagerTests.m
+++ b/Tests/Tests/AFNetworkActivityManagerTests.m
@@ -1,5 +1,5 @@
 // AFNetworkActivityManagerTests.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/Tests/AFNetworkReachabilityManagerTests.m
+++ b/Tests/Tests/AFNetworkReachabilityManagerTests.m
@@ -1,5 +1,5 @@
 // AFNetworkReachabilityManagerTests.h
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/Tests/AFNetworkReachabilityManagerTests.m
+++ b/Tests/Tests/AFNetworkReachabilityManagerTests.m
@@ -1,5 +1,5 @@
 // AFNetworkReachabilityManagerTests.h
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/Tests/AFPropertyListResponseSerializerTests.m
+++ b/Tests/Tests/AFPropertyListResponseSerializerTests.m
@@ -1,5 +1,5 @@
 // AFPropertyListResponseSerializerTests.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/Tests/AFPropertyListResponseSerializerTests.m
+++ b/Tests/Tests/AFPropertyListResponseSerializerTests.m
@@ -1,5 +1,5 @@
 // AFPropertyListResponseSerializerTests.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/Tests/AFSecurityPolicyTests.m
+++ b/Tests/Tests/AFSecurityPolicyTests.m
@@ -1,5 +1,5 @@
 // AFSecurityPolicyTests.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/Tests/AFSecurityPolicyTests.m
+++ b/Tests/Tests/AFSecurityPolicyTests.m
@@ -1,5 +1,5 @@
 // AFSecurityPolicyTests.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/Tests/AFTestCase.h
+++ b/Tests/Tests/AFTestCase.h
@@ -1,5 +1,5 @@
 // AFTestCase.h
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/Tests/AFTestCase.h
+++ b/Tests/Tests/AFTestCase.h
@@ -1,5 +1,5 @@
 // AFTestCase.h
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/Tests/AFTestCase.m
+++ b/Tests/Tests/AFTestCase.m
@@ -1,5 +1,5 @@
 // AFTestCase.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/Tests/AFTestCase.m
+++ b/Tests/Tests/AFTestCase.m
@@ -1,5 +1,5 @@
 // AFTestCase.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/Tests/AFUIActivityIndicatorViewTests.m
+++ b/Tests/Tests/AFUIActivityIndicatorViewTests.m
@@ -1,5 +1,5 @@
 // AFUIActivityIndicatorViewTests.h
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/Tests/AFUIActivityIndicatorViewTests.m
+++ b/Tests/Tests/AFUIActivityIndicatorViewTests.m
@@ -1,5 +1,5 @@
 // AFUIActivityIndicatorViewTests.h
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/Tests/AFUIButtonTests.m
+++ b/Tests/Tests/AFUIButtonTests.m
@@ -1,5 +1,5 @@
 // AFUIButtonTests.h
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/Tests/AFUIButtonTests.m
+++ b/Tests/Tests/AFUIButtonTests.m
@@ -1,5 +1,5 @@
 // AFUIButtonTests.h
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/Tests/AFUIImageViewTests.m
+++ b/Tests/Tests/AFUIImageViewTests.m
@@ -1,5 +1,5 @@
 // AFUIImageViewTests.h
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/Tests/AFUIImageViewTests.m
+++ b/Tests/Tests/AFUIImageViewTests.m
@@ -1,5 +1,5 @@
 // AFUIImageViewTests.h
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/Tests/AFUIRefreshControlTests.m
+++ b/Tests/Tests/AFUIRefreshControlTests.m
@@ -1,5 +1,5 @@
 // AFUIRefreshControlTests.h
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/Tests/AFUIRefreshControlTests.m
+++ b/Tests/Tests/AFUIRefreshControlTests.m
@@ -1,5 +1,5 @@
 // AFUIRefreshControlTests.h
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/Tests/AFUIWebViewTests.m
+++ b/Tests/Tests/AFUIWebViewTests.m
@@ -1,5 +1,5 @@
 // AFUIWebViewTests.h
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/Tests/AFUIWebViewTests.m
+++ b/Tests/Tests/AFUIWebViewTests.m
@@ -1,5 +1,5 @@
 // AFUIWebViewTests.h
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/Tests/AFURLSessionManagerTests.m
+++ b/Tests/Tests/AFURLSessionManagerTests.m
@@ -1,5 +1,5 @@
 // AFURLSessionManagerTests.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/Tests/AFURLSessionManagerTests.m
+++ b/Tests/Tests/AFURLSessionManagerTests.m
@@ -1,5 +1,5 @@
 // AFURLSessionManagerTests.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/UIKit+AFNetworking/AFAutoPurgingImageCache.h
+++ b/UIKit+AFNetworking/AFAutoPurgingImageCache.h
@@ -1,5 +1,5 @@
 // AFAutoPurgingImageCache.h
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/UIKit+AFNetworking/AFAutoPurgingImageCache.h
+++ b/UIKit+AFNetworking/AFAutoPurgingImageCache.h
@@ -1,5 +1,5 @@
 // AFAutoPurgingImageCache.h
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/UIKit+AFNetworking/AFAutoPurgingImageCache.m
+++ b/UIKit+AFNetworking/AFAutoPurgingImageCache.m
@@ -1,5 +1,5 @@
 // AFAutoPurgingImageCache.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/UIKit+AFNetworking/AFAutoPurgingImageCache.m
+++ b/UIKit+AFNetworking/AFAutoPurgingImageCache.m
@@ -1,5 +1,5 @@
 // AFAutoPurgingImageCache.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/UIKit+AFNetworking/AFImageDownloader.h
+++ b/UIKit+AFNetworking/AFImageDownloader.h
@@ -1,5 +1,5 @@
 // AFImageDownloader.h
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/UIKit+AFNetworking/AFImageDownloader.h
+++ b/UIKit+AFNetworking/AFImageDownloader.h
@@ -1,5 +1,5 @@
 // AFImageDownloader.h
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/UIKit+AFNetworking/AFImageDownloader.m
+++ b/UIKit+AFNetworking/AFImageDownloader.m
@@ -1,5 +1,5 @@
 // AFImageDownloader.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -183,7 +183,7 @@
 }
 
 - (nullable AFImageDownloadReceipt *)downloadImageForURLRequest:(NSURLRequest *)request
-                                                 withReceiptID:(nonnull NSUUID *)receiptID
+                                                  withReceiptID:(nonnull NSUUID *)receiptID
                                                         success:(nullable void (^)(NSURLRequest *request, NSHTTPURLResponse  * _Nullable response, UIImage *responseObject))success
                                                         failure:(nullable void (^)(NSURLRequest *request, NSHTTPURLResponse * _Nullable response, NSError *error))failure {
     __block NSURLSessionDataTask *task = nil;

--- a/UIKit+AFNetworking/AFImageDownloader.m
+++ b/UIKit+AFNetworking/AFImageDownloader.m
@@ -1,5 +1,5 @@
 // AFImageDownloader.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/UIKit+AFNetworking/AFNetworkActivityIndicatorManager.h
+++ b/UIKit+AFNetworking/AFNetworkActivityIndicatorManager.h
@@ -1,5 +1,5 @@
 // AFNetworkActivityIndicatorManager.h
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/UIKit+AFNetworking/AFNetworkActivityIndicatorManager.h
+++ b/UIKit+AFNetworking/AFNetworkActivityIndicatorManager.h
@@ -1,5 +1,5 @@
 // AFNetworkActivityIndicatorManager.h
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/UIKit+AFNetworking/AFNetworkActivityIndicatorManager.m
+++ b/UIKit+AFNetworking/AFNetworkActivityIndicatorManager.m
@@ -1,5 +1,5 @@
 // AFNetworkActivityIndicatorManager.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/UIKit+AFNetworking/AFNetworkActivityIndicatorManager.m
+++ b/UIKit+AFNetworking/AFNetworkActivityIndicatorManager.m
@@ -1,5 +1,5 @@
 // AFNetworkActivityIndicatorManager.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/UIKit+AFNetworking/UIActivityIndicatorView+AFNetworking.h
+++ b/UIKit+AFNetworking/UIActivityIndicatorView+AFNetworking.h
@@ -1,5 +1,5 @@
 // UIActivityIndicatorView+AFNetworking.h
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/UIKit+AFNetworking/UIActivityIndicatorView+AFNetworking.h
+++ b/UIKit+AFNetworking/UIActivityIndicatorView+AFNetworking.h
@@ -1,5 +1,5 @@
 // UIActivityIndicatorView+AFNetworking.h
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/UIKit+AFNetworking/UIActivityIndicatorView+AFNetworking.m
+++ b/UIKit+AFNetworking/UIActivityIndicatorView+AFNetworking.m
@@ -1,5 +1,5 @@
 // UIActivityIndicatorView+AFNetworking.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/UIKit+AFNetworking/UIActivityIndicatorView+AFNetworking.m
+++ b/UIKit+AFNetworking/UIActivityIndicatorView+AFNetworking.m
@@ -1,5 +1,5 @@
 // UIActivityIndicatorView+AFNetworking.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/UIKit+AFNetworking/UIButton+AFNetworking.h
+++ b/UIKit+AFNetworking/UIButton+AFNetworking.h
@@ -1,5 +1,5 @@
 // UIButton+AFNetworking.h
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/UIKit+AFNetworking/UIButton+AFNetworking.h
+++ b/UIKit+AFNetworking/UIButton+AFNetworking.h
@@ -1,5 +1,5 @@
 // UIButton+AFNetworking.h
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/UIKit+AFNetworking/UIButton+AFNetworking.m
+++ b/UIKit+AFNetworking/UIButton+AFNetworking.m
@@ -1,5 +1,5 @@
 // UIButton+AFNetworking.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/UIKit+AFNetworking/UIButton+AFNetworking.m
+++ b/UIKit+AFNetworking/UIButton+AFNetworking.m
@@ -1,5 +1,5 @@
 // UIButton+AFNetworking.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/UIKit+AFNetworking/UIImageView+AFNetworking.h
+++ b/UIKit+AFNetworking/UIImageView+AFNetworking.h
@@ -1,5 +1,5 @@
 // UIImageView+AFNetworking.h
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/UIKit+AFNetworking/UIImageView+AFNetworking.h
+++ b/UIKit+AFNetworking/UIImageView+AFNetworking.h
@@ -1,5 +1,5 @@
 // UIImageView+AFNetworking.h
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/UIKit+AFNetworking/UIImageView+AFNetworking.m
+++ b/UIKit+AFNetworking/UIImageView+AFNetworking.m
@@ -1,5 +1,5 @@
 // UIImageView+AFNetworking.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/UIKit+AFNetworking/UIImageView+AFNetworking.m
+++ b/UIKit+AFNetworking/UIImageView+AFNetworking.m
@@ -1,5 +1,5 @@
 // UIImageView+AFNetworking.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/UIKit+AFNetworking/UIKit+AFNetworking.h
+++ b/UIKit+AFNetworking/UIKit+AFNetworking.h
@@ -1,6 +1,6 @@
 // UIKit+AFNetworking.h
 //
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/UIKit+AFNetworking/UIKit+AFNetworking.h
+++ b/UIKit+AFNetworking/UIKit+AFNetworking.h
@@ -1,6 +1,6 @@
 // UIKit+AFNetworking.h
 //
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/UIKit+AFNetworking/UIProgressView+AFNetworking.h
+++ b/UIKit+AFNetworking/UIProgressView+AFNetworking.h
@@ -1,5 +1,5 @@
 // UIProgressView+AFNetworking.h
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/UIKit+AFNetworking/UIProgressView+AFNetworking.h
+++ b/UIKit+AFNetworking/UIProgressView+AFNetworking.h
@@ -1,5 +1,5 @@
 // UIProgressView+AFNetworking.h
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/UIKit+AFNetworking/UIProgressView+AFNetworking.m
+++ b/UIKit+AFNetworking/UIProgressView+AFNetworking.m
@@ -1,5 +1,5 @@
 // UIProgressView+AFNetworking.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/UIKit+AFNetworking/UIProgressView+AFNetworking.m
+++ b/UIKit+AFNetworking/UIProgressView+AFNetworking.m
@@ -1,5 +1,5 @@
 // UIProgressView+AFNetworking.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/UIKit+AFNetworking/UIRefreshControl+AFNetworking.h
+++ b/UIKit+AFNetworking/UIRefreshControl+AFNetworking.h
@@ -1,6 +1,6 @@
 // UIRefreshControl+AFNetworking.m
 //
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/UIKit+AFNetworking/UIRefreshControl+AFNetworking.h
+++ b/UIKit+AFNetworking/UIRefreshControl+AFNetworking.h
@@ -1,6 +1,6 @@
 // UIRefreshControl+AFNetworking.m
 //
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/UIKit+AFNetworking/UIRefreshControl+AFNetworking.m
+++ b/UIKit+AFNetworking/UIRefreshControl+AFNetworking.m
@@ -1,6 +1,6 @@
 // UIRefreshControl+AFNetworking.m
 //
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/UIKit+AFNetworking/UIRefreshControl+AFNetworking.m
+++ b/UIKit+AFNetworking/UIRefreshControl+AFNetworking.m
@@ -1,6 +1,6 @@
 // UIRefreshControl+AFNetworking.m
 //
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/UIKit+AFNetworking/UIWebView+AFNetworking.h
+++ b/UIKit+AFNetworking/UIWebView+AFNetworking.h
@@ -1,5 +1,5 @@
 // UIWebView+AFNetworking.h
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/UIKit+AFNetworking/UIWebView+AFNetworking.h
+++ b/UIKit+AFNetworking/UIWebView+AFNetworking.h
@@ -1,5 +1,5 @@
 // UIWebView+AFNetworking.h
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/UIKit+AFNetworking/UIWebView+AFNetworking.m
+++ b/UIKit+AFNetworking/UIWebView+AFNetworking.m
@@ -1,5 +1,5 @@
 // UIWebView+AFNetworking.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/UIKit+AFNetworking/UIWebView+AFNetworking.m
+++ b/UIKit+AFNetworking/UIWebView+AFNetworking.m
@@ -1,5 +1,5 @@
 // UIWebView+AFNetworking.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/ )
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
If there is not a whitespace, Xcode will misunderstand the whole url is 

```
https://developer.apple.com/library/ios/samplecode/reachability/)
```
instead of 

```
https://developer.apple.com/library/ios/samplecode/reachability/
```