### PR TITLE
Fixed crash if bad URL was passed into the image downloader

### DIFF
--- a/Tests/Tests/AFImageDownloaderTests.m
+++ b/Tests/Tests/AFImageDownloaderTests.m
@@ -73,10 +73,17 @@
      *  but NSMutableURLRequest can have its URL set to nil 
      **/
     NSURLRequest *invalidRequest = [mutableURLRequest copy];
-    AFImageDownloadReceipt *downloadReceipt = [self.downloader downloadImageForURLRequest:invalidRequest
-                                                                                  success:nil
-                                                                                  failure:nil];
-    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Request should fail"];
+    AFImageDownloadReceipt *downloadReceipt = [self.downloader
+                                               downloadImageForURLRequest:invalidRequest
+                                               success:nil
+                                               failure:^(NSURLRequest * _Nonnull request, NSHTTPURLResponse * _Nullable response, NSError * _Nonnull error) {
+                                                   XCTAssertNotNil(error);
+                                                   XCTAssertTrue([error.domain isEqualToString:NSURLErrorDomain]);
+                                                   XCTAssertTrue(error.code == NSURLErrorBadURL);
+                                                   [expectation fulfill];
+                                               }];
+    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
     XCTAssertNil(downloadReceipt, @"downloadReceipt should be nil");
 }
 

--- a/Tests/Tests/AFImageDownloaderTests.m
+++ b/Tests/Tests/AFImageDownloaderTests.m
@@ -64,6 +64,22 @@
     XCTAssertNil(self.downloader, @"Downloader should be nil");
 }
 
+- (void)testThatImageDownloaderReturnsNilWithInvalidURL
+{
+    NSURL *pngURL = [NSURL URLWithString:@"https://httpbin.org/image/png"];
+    NSMutableURLRequest *mutableURLRequest = [NSMutableURLRequest requestWithURL:pngURL];
+    [mutableURLRequest setURL:nil];
+    /** NSURLRequest nor NSMutableURLRequest can be initialized with a nil URL, 
+     *  but NSMutableURLRequest can have its URL set to nil 
+     **/
+    NSURLRequest *invalidRequest = [mutableURLRequest copy];
+    AFImageDownloadReceipt *downloadReceipt = [self.downloader downloadImageForURLRequest:invalidRequest
+                                                                                  success:nil
+                                                                                  failure:nil];
+    
+    XCTAssertNil(downloadReceipt, @"downloadReceipt should be nil");
+}
+
 - (void)testThatImageDownloaderCanDownloadImage {
     XCTestExpectation *expectation = [self expectationWithDescription:@"image download should succeed"];
 

--- a/UIKit+AFNetworking/AFImageDownloader.m
+++ b/UIKit+AFNetworking/AFImageDownloader.m
@@ -189,6 +189,9 @@
     __block NSURLSessionDataTask *task = nil;
     dispatch_sync(self.synchronizationQueue, ^{
         NSString *URLIdentifier = request.URL.absoluteString;
+        if (URLIdentifier == nil) {
+            return;
+        }
 
         // 1) Append the success and failure blocks to a pre-existing request if it already exists
         AFImageDownloaderMergedTask *existingMergedTask = self.mergedTasks[URLIdentifier];

--- a/UIKit+AFNetworking/AFImageDownloader.m
+++ b/UIKit+AFNetworking/AFImageDownloader.m
@@ -190,6 +190,12 @@
     dispatch_sync(self.synchronizationQueue, ^{
         NSString *URLIdentifier = request.URL.absoluteString;
         if (URLIdentifier == nil) {
+            if (failure) {
+                NSError *error = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorBadURL userInfo:nil];
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    failure(request, nil, error);
+                });
+            }
             return;
         }
 


### PR DESCRIPTION
A continuation of #3356 and #3343 