### PR TITLE
Adding extension point to customize User-Agent

### DIFF
--- a/AFNetworking.xcodeproj/project.pbxproj
+++ b/AFNetworking.xcodeproj/project.pbxproj
@@ -194,6 +194,14 @@
 		5F4323DD1BF63CCC003B8749 /* GeoTrust_Global_CA_Root.cer in Resources */ = {isa = PBXBuildFile; fileRef = 5F4323DC1BF63CCC003B8749 /* GeoTrust_Global_CA_Root.cer */; };
 		5F4323DE1BF63CCC003B8749 /* GeoTrust_Global_CA_Root.cer in Resources */ = {isa = PBXBuildFile; fileRef = 5F4323DC1BF63CCC003B8749 /* GeoTrust_Global_CA_Root.cer */; };
 		5F4323DF1BF63CCC003B8749 /* GeoTrust_Global_CA_Root.cer in Resources */ = {isa = PBXBuildFile; fileRef = 5F4323DC1BF63CCC003B8749 /* GeoTrust_Global_CA_Root.cer */; };
+		F1EBBCD51CA1D5D000DE16EE /* AFHTTPRequestSerializer+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = F1EBBCD31CA1D5D000DE16EE /* AFHTTPRequestSerializer+Protected.h */; };
+		F1EBBCD61CA1D5D000DE16EE /* AFHTTPRequestSerializer+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = F1EBBCD31CA1D5D000DE16EE /* AFHTTPRequestSerializer+Protected.h */; };
+		F1EBBCD71CA1D5D000DE16EE /* AFHTTPRequestSerializer+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = F1EBBCD31CA1D5D000DE16EE /* AFHTTPRequestSerializer+Protected.h */; };
+		F1EBBCD81CA1D5D000DE16EE /* AFHTTPRequestSerializer+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = F1EBBCD31CA1D5D000DE16EE /* AFHTTPRequestSerializer+Protected.h */; };
+		F1EBBCD91CA1D5D000DE16EE /* AFHTTPRequestSerializer+Protected.m in Sources */ = {isa = PBXBuildFile; fileRef = F1EBBCD41CA1D5D000DE16EE /* AFHTTPRequestSerializer+Protected.m */; };
+		F1EBBCDA1CA1D5D000DE16EE /* AFHTTPRequestSerializer+Protected.m in Sources */ = {isa = PBXBuildFile; fileRef = F1EBBCD41CA1D5D000DE16EE /* AFHTTPRequestSerializer+Protected.m */; };
+		F1EBBCDB1CA1D5D000DE16EE /* AFHTTPRequestSerializer+Protected.m in Sources */ = {isa = PBXBuildFile; fileRef = F1EBBCD41CA1D5D000DE16EE /* AFHTTPRequestSerializer+Protected.m */; };
+		F1EBBCDC1CA1D5D000DE16EE /* AFHTTPRequestSerializer+Protected.m in Sources */ = {isa = PBXBuildFile; fileRef = F1EBBCD41CA1D5D000DE16EE /* AFHTTPRequestSerializer+Protected.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -301,6 +309,8 @@
 		5F4323D41BF63CB0003B8749 /* GoogleComServerTrustChainPath1 */ = {isa = PBXFileReference; lastKnownFileType = folder; path = GoogleComServerTrustChainPath1; sourceTree = "<group>"; };
 		5F4323D81BF63CBA003B8749 /* GoogleComServerTrustChainPath2 */ = {isa = PBXFileReference; lastKnownFileType = folder; path = GoogleComServerTrustChainPath2; sourceTree = "<group>"; };
 		5F4323DC1BF63CCC003B8749 /* GeoTrust_Global_CA_Root.cer */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = GeoTrust_Global_CA_Root.cer; sourceTree = "<group>"; };
+		F1EBBCD31CA1D5D000DE16EE /* AFHTTPRequestSerializer+Protected.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "AFHTTPRequestSerializer+Protected.h"; sourceTree = "<group>"; };
+		F1EBBCD41CA1D5D000DE16EE /* AFHTTPRequestSerializer+Protected.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "AFHTTPRequestSerializer+Protected.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -504,6 +514,8 @@
 				2995224C1BBF125A00859F49 /* AFSecurityPolicy.m */,
 				2995224D1BBF125A00859F49 /* AFURLRequestSerialization.h */,
 				2995224E1BBF125A00859F49 /* AFURLRequestSerialization.m */,
+				F1EBBCD31CA1D5D000DE16EE /* AFHTTPRequestSerializer+Protected.h */,
+				F1EBBCD41CA1D5D000DE16EE /* AFHTTPRequestSerializer+Protected.m */,
 				2995224F1BBF125A00859F49 /* AFURLResponseSerialization.h */,
 				299522501BBF125A00859F49 /* AFURLResponseSerialization.m */,
 				299522511BBF125A00859F49 /* AFURLSessionManager.h */,
@@ -570,6 +582,7 @@
 				29D96E951BCC406B00F571A5 /* AFImageDownloader.h in Headers */,
 				29D96E961BCC406B00F571A5 /* UIActivityIndicatorView+AFNetworking.h in Headers */,
 				29D96E971BCC406B00F571A5 /* UIButton+AFNetworking.h in Headers */,
+				F1EBBCD81CA1D5D000DE16EE /* AFHTTPRequestSerializer+Protected.h in Headers */,
 				29D96E981BCC406B00F571A5 /* UIImage+AFNetworking.h in Headers */,
 				29D96E991BCC406B00F571A5 /* UIImageView+AFNetworking.h in Headers */,
 				29D96E9A1BCC406B00F571A5 /* UIProgressView+AFNetworking.h in Headers */,
@@ -594,6 +607,7 @@
 				299522A21BBF13C700859F49 /* UIActivityIndicatorView+AFNetworking.h in Headers */,
 				2995223D1BBF104D00859F49 /* AFNetworking.h in Headers */,
 				299522B01BBF13C700859F49 /* UIWebView+AFNetworking.h in Headers */,
+				F1EBBCD51CA1D5D000DE16EE /* AFHTTPRequestSerializer+Protected.h in Headers */,
 				299522AC1BBF13C700859F49 /* UIProgressView+AFNetworking.h in Headers */,
 				299522A61BBF13C700859F49 /* UIButton+AFNetworking.h in Headers */,
 				299522A01BBF13C700859F49 /* AFNetworkActivityIndicatorManager.h in Headers */,
@@ -607,6 +621,7 @@
 			files = (
 				29D96E7A1BCC3D6000F571A5 /* AFHTTPSessionManager.h in Headers */,
 				29D96E7C1BCC3D6000F571A5 /* AFSecurityPolicy.h in Headers */,
+				F1EBBCD61CA1D5D000DE16EE /* AFHTTPRequestSerializer+Protected.h in Headers */,
 				29D96E7D1BCC3D6000F571A5 /* AFURLRequestSerialization.h in Headers */,
 				29D96E7E1BCC3D6000F571A5 /* AFURLResponseSerialization.h in Headers */,
 				29D96E7F1BCC3D6000F571A5 /* AFURLSessionManager.h in Headers */,
@@ -619,6 +634,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				29D96E811BCC3D7200F571A5 /* AFHTTPSessionManager.h in Headers */,
+				F1EBBCD71CA1D5D000DE16EE /* AFHTTPRequestSerializer+Protected.h in Headers */,
 				29D96E821BCC3D7200F571A5 /* AFNetworkReachabilityManager.h in Headers */,
 				29D96E831BCC3D7200F571A5 /* AFSecurityPolicy.h in Headers */,
 				29D96E841BCC3D7200F571A5 /* AFURLRequestSerialization.h in Headers */,
@@ -930,6 +946,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2987B0BD1BC408D900179A4C /* AFNetworkReachabilityManager.m in Sources */,
+				F1EBBCDC1CA1D5D000DE16EE /* AFHTTPRequestSerializer+Protected.m in Sources */,
 				2987B0BE1BC408D900179A4C /* AFSecurityPolicy.m in Sources */,
 				2987B0BC1BC408D900179A4C /* AFHTTPSessionManager.m in Sources */,
 				2987B0C11BC408D900179A4C /* AFURLSessionManager.m in Sources */,
@@ -1017,6 +1034,7 @@
 				299522AA1BBF13C700859F49 /* UIImageView+AFNetworking.m in Sources */,
 				299522B11BBF13C700859F49 /* UIWebView+AFNetworking.m in Sources */,
 				299522591BBF125A00859F49 /* AFSecurityPolicy.m in Sources */,
+				F1EBBCD91CA1D5D000DE16EE /* AFHTTPRequestSerializer+Protected.m in Sources */,
 				299522A71BBF13C700859F49 /* UIButton+AFNetworking.m in Sources */,
 				299522541BBF125A00859F49 /* AFHTTPSessionManager.m in Sources */,
 				2995225F1BBF125A00859F49 /* AFURLSessionManager.m in Sources */,
@@ -1037,6 +1055,7 @@
 				2995226F1BBF133400859F49 /* AFURLRequestSerialization.m in Sources */,
 				2995226E1BBF133400859F49 /* AFSecurityPolicy.m in Sources */,
 				299522701BBF133400859F49 /* AFURLResponseSerialization.m in Sources */,
+				F1EBBCDA1CA1D5D000DE16EE /* AFHTTPRequestSerializer+Protected.m in Sources */,
 				2995226D1BBF133400859F49 /* AFHTTPSessionManager.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1051,6 +1070,7 @@
 				299522841BBF13A100859F49 /* AFURLSessionManager.m in Sources */,
 				299522821BBF13A100859F49 /* AFURLRequestSerialization.m in Sources */,
 				299522831BBF13A100859F49 /* AFURLResponseSerialization.m in Sources */,
+				F1EBBCDB1CA1D5D000DE16EE /* AFHTTPRequestSerializer+Protected.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AFNetworking/AFHTTPRequestSerializer+Protected.h
+++ b/AFNetworking/AFHTTPRequestSerializer+Protected.h
@@ -1,0 +1,21 @@
+//
+//  AFHTTPRequestSerializer+Protected.h
+//  AFNetworking
+//
+//  Created by Diego Chohfi on 3/22/16.
+//  Copyright © 2016 AFNetworking. All rights reserved.
+//
+
+#import <AFNetworking/AFNetworking.h>
+
+@interface AFHTTPRequestSerializer (Protected)
+
+- (void)addUserAgentHeaderField;
+
+- (NSString *)bundleIdentifier;
+- (NSString *)bundleVersion;
+- (NSString *)deviceModel;
+- (NSString *)systemVersion;
+- (float)screenScale;
+
+@end

--- a/AFNetworking/AFHTTPRequestSerializer+Protected.m
+++ b/AFNetworking/AFHTTPRequestSerializer+Protected.m
@@ -1,0 +1,86 @@
+//
+//  AFHTTPRequestSerializer+Protected.m
+//  AFNetworking
+//
+//  Created by Diego Chohfi on 3/22/16.
+//  Copyright © 2016 AFNetworking. All rights reserved.
+//
+
+#import "AFHTTPRequestSerializer+Protected.h"
+
+@implementation AFHTTPRequestSerializer (Protected)
+
+- (void)addUserAgentHeaderField {
+    NSString *userAgent = nil;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wgnu"
+#if TARGET_OS_IOS
+    // User-Agent Header; see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.43
+    userAgent = [NSString stringWithFormat:@"%@/%@ (%@; iOS %@; Scale/%0.2f)",
+                 self.bundleIdentifier,
+                 self.bundleVersion,
+                 self.deviceModel,
+                 self.systemVersion,
+                 self.screenScale];
+#elif TARGET_OS_WATCH
+    // User-Agent Header; see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.43
+    userAgent = [NSString stringWithFormat:@"%@/%@ (%@; watchOS %@; Scale/%0.2f)",
+                 self.bundleIdentifier,
+                 self.bundleVersion,
+                 self.deviceModel,
+                 self.systemVersion,
+                 self.screenScale];
+#elif defined(__MAC_OS_X_VERSION_MIN_REQUIRED)
+    userAgent = [NSString stringWithFormat:@"%@/%@ (Mac OS X %@)",
+                 self.bundleIdentifier,
+                 self.bundleVersion,
+                 self.systemVersion];
+#endif
+#pragma clang diagnostic pop
+    if (userAgent) {
+        if (![userAgent canBeConvertedToEncoding:NSASCIIStringEncoding]) {
+            NSMutableString *mutableUserAgent = [userAgent mutableCopy];
+            if (CFStringTransform((__bridge CFMutableStringRef)(mutableUserAgent), NULL, (__bridge CFStringRef)@"Any-Latin; Latin-ASCII; [:^ASCII:] Remove", false)) {
+                userAgent = mutableUserAgent;
+            }
+        }
+        [self setValue:userAgent forHTTPHeaderField:@"User-Agent"];
+    }
+}
+
+- (NSString *)bundleIdentifier {
+    return [[NSBundle mainBundle] infoDictionary][(__bridge NSString *)kCFBundleExecutableKey] ?: [[NSBundle mainBundle] infoDictionary][(__bridge NSString *)kCFBundleIdentifierKey];
+}
+
+- (NSString *)bundleVersion {
+    return [[NSBundle mainBundle] infoDictionary][@"CFBundleShortVersionString"] ?: [[NSBundle mainBundle] infoDictionary][(__bridge NSString *)kCFBundleVersionKey];
+}
+
+- (NSString *)deviceModel {
+#if TARGET_OS_IOS
+    return [[UIDevice currentDevice] model];
+#elif TARGET_OS_WATCH
+    return [[WKInterfaceDevice currentDevice] model];
+#endif
+}
+
+- (NSString *)systemVersion {
+#if TARGET_OS_IOS
+    return [[UIDevice currentDevice] systemVersion];
+#elif TARGET_OS_WATCH
+    return [[WKInterfaceDevice currentDevice] systemVersion];
+#elif defined(__MAC_OS_X_VERSION_MIN_REQUIRED)
+    return [[NSProcessInfo processInfo] operatingSystemVersionString];
+#endif
+}
+
+- (float)screenScale {
+#if TARGET_OS_IOS
+    return [[UIScreen mainScreen] scale];
+#elif TARGET_OS_WATCH
+    return [[WKInterfaceDevice currentDevice] screenScale];
+#endif
+}
+
+
+@end

--- a/AFNetworking/AFHTTPRequestSerializer+Protected.m
+++ b/AFNetworking/AFHTTPRequestSerializer+Protected.m
@@ -62,6 +62,7 @@
 #elif TARGET_OS_WATCH
     return [[WKInterfaceDevice currentDevice] model];
 #endif
+    return nil;
 }
 
 - (NSString *)systemVersion {
@@ -80,6 +81,7 @@
 #elif TARGET_OS_WATCH
     return [[WKInterfaceDevice currentDevice] screenScale];
 #endif
+    return 1.f;
 }
 
 

--- a/AFNetworking/AFURLRequestSerialization.h
+++ b/AFNetworking/AFURLRequestSerialization.h
@@ -151,6 +151,8 @@ typedef NS_ENUM(NSUInteger, AFHTTPRequestQueryStringSerializationStyle) {
 
  - `Accept-Language` with the contents of `NSLocale +preferredLanguages`
  - `User-Agent` with the contents of various bundle identifiers and OS designations
+        You can subclass `AFHTTPRequestSerializer` and overried `addUserAgentHeaderField` method declared on
+        `AFHTTPRequestSerializer+Protected` to have an extension point over default behavior
 
  @discussion To add or remove default request headers, use `setValue:forHTTPHeaderField:`.
  */

--- a/AFNetworking/AFURLRequestSerialization.m
+++ b/AFNetworking/AFURLRequestSerialization.m
@@ -20,6 +20,7 @@
 // THE SOFTWARE.
 
 #import "AFURLRequestSerialization.h"
+#import "AFHTTPRequestSerializer+Protected.h"
 
 #if TARGET_OS_IOS || TARGET_OS_WATCH || TARGET_OS_TV
 #import <MobileCoreServices/MobileCoreServices.h>
@@ -218,28 +219,7 @@ static void *AFHTTPRequestSerializerObserverContext = &AFHTTPRequestSerializerOb
     }];
     [self setValue:[acceptLanguagesComponents componentsJoinedByString:@", "] forHTTPHeaderField:@"Accept-Language"];
 
-    NSString *userAgent = nil;
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wgnu"
-#if TARGET_OS_IOS
-    // User-Agent Header; see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.43
-    userAgent = [NSString stringWithFormat:@"%@/%@ (%@; iOS %@; Scale/%0.2f)", [[NSBundle mainBundle] infoDictionary][(__bridge NSString *)kCFBundleExecutableKey] ?: [[NSBundle mainBundle] infoDictionary][(__bridge NSString *)kCFBundleIdentifierKey], [[NSBundle mainBundle] infoDictionary][@"CFBundleShortVersionString"] ?: [[NSBundle mainBundle] infoDictionary][(__bridge NSString *)kCFBundleVersionKey], [[UIDevice currentDevice] model], [[UIDevice currentDevice] systemVersion], [[UIScreen mainScreen] scale]];
-#elif TARGET_OS_WATCH
-    // User-Agent Header; see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.43
-    userAgent = [NSString stringWithFormat:@"%@/%@ (%@; watchOS %@; Scale/%0.2f)", [[NSBundle mainBundle] infoDictionary][(__bridge NSString *)kCFBundleExecutableKey] ?: [[NSBundle mainBundle] infoDictionary][(__bridge NSString *)kCFBundleIdentifierKey], [[NSBundle mainBundle] infoDictionary][@"CFBundleShortVersionString"] ?: [[NSBundle mainBundle] infoDictionary][(__bridge NSString *)kCFBundleVersionKey], [[WKInterfaceDevice currentDevice] model], [[WKInterfaceDevice currentDevice] systemVersion], [[WKInterfaceDevice currentDevice] screenScale]];
-#elif defined(__MAC_OS_X_VERSION_MIN_REQUIRED)
-    userAgent = [NSString stringWithFormat:@"%@/%@ (Mac OS X %@)", [[NSBundle mainBundle] infoDictionary][(__bridge NSString *)kCFBundleExecutableKey] ?: [[NSBundle mainBundle] infoDictionary][(__bridge NSString *)kCFBundleIdentifierKey], [[NSBundle mainBundle] infoDictionary][@"CFBundleShortVersionString"] ?: [[NSBundle mainBundle] infoDictionary][(__bridge NSString *)kCFBundleVersionKey], [[NSProcessInfo processInfo] operatingSystemVersionString]];
-#endif
-#pragma clang diagnostic pop
-    if (userAgent) {
-        if (![userAgent canBeConvertedToEncoding:NSASCIIStringEncoding]) {
-            NSMutableString *mutableUserAgent = [userAgent mutableCopy];
-            if (CFStringTransform((__bridge CFMutableStringRef)(mutableUserAgent), NULL, (__bridge CFStringRef)@"Any-Latin; Latin-ASCII; [:^ASCII:] Remove", false)) {
-                userAgent = mutableUserAgent;
-            }
-        }
-        [self setValue:userAgent forHTTPHeaderField:@"User-Agent"];
-    }
+    [self addUserAgentHeaderField];
 
     // HTTP Method Definitions; see http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html
     self.HTTPMethodsEncodingParametersInURI = [NSSet setWithObjects:@"GET", @"HEAD", @"DELETE", nil];

--- a/Tests/Tests/AFHTTPRequestSerializationTests.m
+++ b/Tests/Tests/AFHTTPRequestSerializationTests.m
@@ -20,8 +20,20 @@
 // THE SOFTWARE.
 
 #import "AFTestCase.h"
+#import "AFHTTPRequestSerializer+Protected.h"
 
 #import "AFURLRequestSerialization.h"
+
+@interface AFCustomHTTPREquestSerializer : AFHTTPRequestSerializer
+
+@end
+@implementation AFCustomHTTPREquestSerializer
+
+- (void)addUserAgentHeaderField {
+    [self setValue:@"customer-header-field" forHTTPHeaderField:@"User-Agent"];
+}
+
+@end
 
 @interface AFMultipartBodyStream : NSInputStream <NSStreamDelegate>
 @property (readwrite, nonatomic, strong) NSMutableArray *HTTPBodyParts;
@@ -187,6 +199,17 @@
     XCTAssertTrue([serializer.HTTPRequestHeaders[headerField] isEqualToString:headerValue]);
     [serializer setValue:nil forHTTPHeaderField:headerField];
     XCTAssertFalse([serializer.HTTPRequestHeaders.allKeys containsObject:headerField]);
+}
+
+#pragma mark - extension points tests
+
+- (void)testThatCustomUserAgentHeaderFieldIsCalledToCustomizeHeader {
+    AFHTTPRequestSerializer *serializer = [AFHTTPRequestSerializer serializer];
+    XCTAssertNotNil(serializer.HTTPRequestHeaders[@"User-Agent"]);
+    
+    AFHTTPRequestSerializer *customSerializer = [AFCustomHTTPREquestSerializer serializer];
+    XCTAssertNotEqualObjects(customSerializer.HTTPRequestHeaders[@"User-Agent"], serializer.HTTPRequestHeaders[@"User-Agent"]);
+    XCTAssertEqualObjects(customSerializer.HTTPRequestHeaders[@"User-Agent"], @"customer-header-field");
 }
 
 #pragma mark - Helper Methods

--- a/Tests/Tests/AFHTTPRequestSerializationTests.m
+++ b/Tests/Tests/AFHTTPRequestSerializationTests.m
@@ -24,10 +24,10 @@
 
 #import "AFURLRequestSerialization.h"
 
-@interface AFCustomHTTPREquestSerializer : AFHTTPRequestSerializer
+@interface AFCustomHTTPRequestSerializer : AFHTTPRequestSerializer
 
 @end
-@implementation AFCustomHTTPREquestSerializer
+@implementation AFCustomHTTPRequestSerializer
 
 - (void)addUserAgentHeaderField {
     [self setValue:@"customer-header-field" forHTTPHeaderField:@"User-Agent"];
@@ -207,7 +207,7 @@
     AFHTTPRequestSerializer *serializer = [AFHTTPRequestSerializer serializer];
     XCTAssertNotNil(serializer.HTTPRequestHeaders[@"User-Agent"]);
     
-    AFHTTPRequestSerializer *customSerializer = [AFCustomHTTPREquestSerializer serializer];
+    AFHTTPRequestSerializer *customSerializer = [AFCustomHTTPRequestSerializer serializer];
     XCTAssertNotEqualObjects(customSerializer.HTTPRequestHeaders[@"User-Agent"], serializer.HTTPRequestHeaders[@"User-Agent"]);
     XCTAssertEqualObjects(customSerializer.HTTPRequestHeaders[@"User-Agent"], @"customer-header-field");
 }


### PR DESCRIPTION
Adding category over `AFHTTPRequestSerializer` declaring `addUserAgentHeaderField` method that can be overridden by a subclass to customize values added to `User-Agent` header field.

I had to customize that value to add the specific device model on my requests, ended coping and pasting the logic contained on the `init` method.

What you guys think? Any changes or thoughts on that? Thank you.