### PR TITLE
[WIP] AFSSLPinningModePublicKey allows request to proceed when server trust is invalid

### DIFF
--- a/Tests/Tests/AFHTTPSessionManagerTests.m
+++ b/Tests/Tests/AFHTTPSessionManagerTests.m
@@ -517,7 +517,7 @@
     NSData *googleCertificateData = [NSData dataWithContentsOfURL:googleCertificateURL];
     AFHTTPSessionManager *manager = [[AFHTTPSessionManager alloc] initWithBaseURL:[NSURL URLWithString:@"https://apple.com/"]];
     [manager setResponseSerializer:[AFHTTPResponseSerializer serializer]];
-    manager.securityPolicy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModeCertificate withPinnedCertificates:[NSSet setWithObject:googleCertificateData]];
+    manager.securityPolicy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModePublicKey withPinnedCertificates:[NSSet setWithObject:googleCertificateData]];
     [manager
      GET:@"AFNetworking/AFNetworking"
      parameters:nil


### PR DESCRIPTION
When using an `AFSecurityPolicy` with pinning mode `AFSSLPinningModePublicKey`, when I make an HTTP request such that `-[AFSecurityPolicy evaluateServerTrust:forDomain:]` returns `NO`, then the request nevertheless proceeds and succeeds.

To demonstrate this, I've modified the test `-testInvalidServerTrustProducesCorrectError` in such a way that I believe it should still succeed, [but it fails](https://travis-ci.org/AFNetworking/AFNetworking/jobs/119416832).

This issue is apparently resolved by reverting #3191, but it's not clear to me that this is the correct thing to do.