### PR TITLE
Reverted `NSURLSessionAuthChallengeDisposition` to `NSURLSessionAuthChallengeCancelAuthenticationChallenge` for SSL Pinning

### DIFF
--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -983,7 +983,7 @@ didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
                     disposition = NSURLSessionAuthChallengePerformDefaultHandling;
                 }
             } else {
-                disposition = NSURLSessionAuthChallengeRejectProtectionSpace;
+                disposition = NSURLSessionAuthChallengeCancelAuthenticationChallenge;
             }
         } else {
             disposition = NSURLSessionAuthChallengePerformDefaultHandling;
@@ -1030,7 +1030,7 @@ didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
                 disposition = NSURLSessionAuthChallengeUseCredential;
                 credential = [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust];
             } else {
-                disposition = NSURLSessionAuthChallengeRejectProtectionSpace;
+                disposition = NSURLSessionAuthChallengeCancelAuthenticationChallenge;
             }
         } else {
             disposition = NSURLSessionAuthChallengePerformDefaultHandling;

--- a/Tests/Tests/AFHTTPSessionManagerTests.m
+++ b/Tests/Tests/AFHTTPSessionManagerTests.m
@@ -528,7 +528,7 @@
      }
      failure:^(NSURLSessionDataTask * _Nullable task, NSError * _Nonnull error) {
          XCTAssertEqualObjects(error.domain, NSURLErrorDomain);
-         XCTAssertEqual(error.code, NSURLErrorServerCertificateUntrusted);
+         XCTAssertEqual(error.code, NSURLErrorCancelled);
          [expectation fulfill];
      }];
     [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
@@ -552,7 +552,7 @@
      }
      failure:^(NSURLSessionDataTask * _Nullable task, NSError * _Nonnull error) {
          XCTAssertEqualObjects(error.domain, NSURLErrorDomain);
-         XCTAssertEqual(error.code, NSURLErrorServerCertificateUntrusted);
+         XCTAssertEqual(error.code, NSURLErrorCancelled);
          [expectation fulfill];
      }];
     [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];


### PR DESCRIPTION
As first discussed in #3409, there appear to be cases where returning `NSURLSessionAuthChallengeRejectProtectionSpace` does not prevent the request from succeeding in some cases.

A few of us have starting to dig in on this issue. @0xced has seen behavior where the existing code does work in some cases, leading us to believe there may be some issues here related to the TLS cache under the hood that we do not control. However, using `Cancel` instead does give us deterministic control.

The [original intent](https://github.com/AFNetworking/AFNetworking/pull/3169) of moving to `RejectProtectionSpace` was to provide a better error message to the developer to distinguish between a manual cancel and an SSL pinning failure.

I've created a simple playground demonstrating the issue:

[NSURLSessionAuthChallenge.playground.zip](https://github.com/AFNetworking/AFNetworking/files/197891/NSURLSessionAuthChallenge.playground.zip)
 
This PR reverts to using cancel, and adds an additional test for Public Key Pinning error validation.