### PR TITLE
AF created file when http server return 404

### DIFF
--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -655,7 +655,12 @@ static NSString * const AFNSURLSessionTaskDidSuspendNotification = @"com.alamofi
 
     if (destination) {
         delegate.downloadTaskDidFinishDownloading = ^NSURL * (NSURLSession * __unused session, NSURLSessionDownloadTask *task, NSURL *location) {
-            return destination(location, task.response);
+            if(((NSHTTPURLResponse *) task.response).statusCode != 200) {
+                return location;
+            }
+            else {
+                return destination(location, task.response);
+            }
         };
     }
 


### PR DESCRIPTION
Like that, I want download file from `http://localhost/1.dmg`, server not have this file and return 404. I use AF and got `1.dmg` file that contains 404.html info. The file is't i want, so i think it's a bug, and fix it.
Here's my code
```
 NSString *downloadUrl = @"http://localhost/1.dmg";
    NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:downloadUrl]];
    AFHTTPSessionManager *manager = [AFHTTPSessionManager manager];
    NSURLSessionDownloadTask *task = [manager downloadTaskWithRequest:request progress:^(NSProgress * _Nonnull downloadProgress) {
        NSLog(@"%f", downloadProgress.fractionCompleted);
    } destination:^NSURL * _Nonnull(NSURL * _Nonnull targetPath, NSURLResponse * _Nonnull response) {
        NSString *filePath = [[BGNetworkCache sharedCache] defaultCachePathForFileName:@"1.dmg"];
        return [NSURL fileURLWithPath:filePath];
    } completionHandler:^(NSURLResponse * _Nonnull response, NSURL * _Nullable filePath, NSError * _Nullable error) {
        NSLog(@"%@", error);
    }];
    [task resume];
    self.task = task;
```