### PR TITLE
为acceptableContentTypes添加两种常用类型

### DIFF
--- a/AFNetworking/AFURLResponseSerialization.m
+++ b/AFNetworking/AFURLResponseSerialization.m
@@ -225,7 +225,7 @@ static id AFJSONObjectByRemovingKeysWithNullValues(id JSONObject, NSJSONReadingO
         return nil;
     }
 
-    self.acceptableContentTypes = [NSSet setWithObjects:@"application/json", @"text/json", @"text/javascript", nil];
+    self.acceptableContentTypes = [NSSet setWithObjects:@"application/json", @"text/json", @"text/javascript", @"text/plain", @"text/html", nil];
 
     return self;
 }


### PR DESCRIPTION
为acceptableContentTypes添加两种常用类型  : @"text/plain", @"text/html"

Add two types of commonly used for acceptableContentTypes.
Reasons: we in the use of this framework, often not analysis from the server to the data type. Prompt content is the type is not supported. Which need us to write a class to inherit, manual for acceptableContentTypes add we need the type. And updated every frame, we all need to double check these types. This resulted in the a lot of unnecessary trouble. It is recommended that the author add we used type.