### PR TITLE
Updates `AFHTTPSessionManager` documentation to reflect v3.x changes

### DIFF
--- a/AFNetworking/AFHTTPSessionManager.h
+++ b/AFNetworking/AFHTTPSessionManager.h
@@ -44,7 +44,7 @@
 
  ## Methods to Override
 
- To change the behavior of all data task operation construction, which is also used in the `GET` / `POST` / et al. convenience methods, override `dataTaskWithRequest:completionHandler:`.
+ To change the behavior of all data task operation construction, which is also used in the `GET` / `POST` / et al. convenience methods, override `dataTaskWithRequest:uploadProgress:downloadProgress:completionHandler:`.
 
  ## Serialization
 


### PR DESCRIPTION
This closes #3412.

The documentation on `AFHTTPSessionManager`, *Methods to Override* section  states that...
> To change the behavior of all data task operation construction, which is also used in the `GET` / `POST` / et al. convenience methods, override `dataTaskWithRequest:completionHandler:` 

But that is no longer accurate, since these convenience methods now go through the new 
`dataTaskWithRequest:uploadProgress:downloadProgress:completionHandler:`. Therefore, overriding `dataTaskWithRequest:completionHandler:` will have no effect since it will never be called.

This PR updates the documentation to reflect the fact that the method to override is now `dataTaskWithRequest:uploadProgress:downloadProgress:completionHandler:`.