### PR TITLE
Updated character

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2011–2016 Alamofire Software Foundation (http://alamofire.org/)
+Copyright (c) 2011-2016 Alamofire Software Foundation (http://alamofire.org/)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Updated to a different unicode dash (`U+002D` rather than `U+2013`) so that text is parsed correctly by markdown (when converting the CocoaPods `Acknowledgements.markdown` to HTML). 

Prior to the adjustment, this was the result upon conversion to HTML:

<img width="356" alt="markdown-issue-prior" src="https://cloud.githubusercontent.com/assets/337963/14944513/5707120c-0fc3-11e6-8b58-67edf51af2d4.png">


With the adjustment, issue corrected: 

<img width="361" alt="markdown-issue-after" src="https://cloud.githubusercontent.com/assets/337963/14944508/08a9bd80-0fc3-11e6-8013-3715d8884f9a.png">
