### PR TITLE
Added deprecated attribute to  `dataTaskWithRequest:completionHandler:`

### DIFF
--- a/AFNetworking/AFURLSessionManager.h
+++ b/AFNetworking/AFURLSessionManager.h
@@ -208,7 +208,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param completionHandler A block object to be executed when the task finishes. This block has no return value and takes three arguments: the server response, the response object created by that serializer, and the error that occurred, if any.
  */
 - (NSURLSessionDataTask *)dataTaskWithRequest:(NSURLRequest *)request
-                            completionHandler:(nullable void (^)(NSURLResponse *response, id _Nullable responseObject,  NSError * _Nullable error))completionHandler;
+                            completionHandler:(nullable void (^)(NSURLResponse *response, id _Nullable responseObject,  NSError * _Nullable error))completionHandler DEPRECATED_ATTRIBUTE;
 
 /**
  Creates an `NSURLSessionDataTask` with the specified request.

--- a/Tests/Tests/AFHTTPSessionManagerTests.m
+++ b/Tests/Tests/AFHTTPSessionManagerTests.m
@@ -54,7 +54,8 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"Request should succeed"];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"/get" relativeToURL:self.baseURL]];
-    NSURLSessionDataTask *task = [self.manager dataTaskWithRequest:request completionHandler:^(NSURLResponse *response, id responseObject, NSError *error) {
+    NSURLSessionDataTask *task = [self.manager dataTaskWithRequest:request uploadProgress:nil downloadProgress:nil
+                                                 completionHandler:^(NSURLResponse *response, id responseObject, NSError *error) {
         blockResponseObject = responseObject;
         blockError = error;
         [expectation fulfill];
@@ -75,7 +76,8 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"Request should succeed"];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"/status/404" relativeToURL:self.baseURL]];
-    NSURLSessionDataTask *task = [self.manager dataTaskWithRequest:request completionHandler:^(NSURLResponse *response, id responseObject, NSError *error) {
+    NSURLSessionDataTask *task = [self.manager dataTaskWithRequest:request uploadProgress:nil downloadProgress:nil
+                                                 completionHandler:^(NSURLResponse *response, id responseObject, NSError *error) {
         blockError = error;
         [expectation fulfill];
     }];
@@ -95,7 +97,8 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"Request should succeed"];
 
     NSURLRequest *redirectRequest = [NSURLRequest requestWithURL:[NSURL URLWithString:@"/redirect/1" relativeToURL:self.baseURL]];
-    NSURLSessionDataTask *redirectTask = [self.manager dataTaskWithRequest:redirectRequest completionHandler:^(NSURLResponse *response, id responseObject, NSError *error) {
+    NSURLSessionDataTask *redirectTask = [self.manager dataTaskWithRequest:redirectRequest uploadProgress:nil downloadProgress:nil
+                                                         completionHandler:^(NSURLResponse *response, id responseObject, NSError *error) {
         blockError = error;
         [expectation fulfill];
     }];

--- a/Tests/Tests/AFUIActivityIndicatorViewTests.m
+++ b/Tests/Tests/AFUIActivityIndicatorViewTests.m
@@ -49,6 +49,8 @@
     [self expectationForNotification:AFNetworkingTaskDidResumeNotification object:nil handler:nil];
     NSURLSessionDataTask *task = [self.sessionManager
                                   dataTaskWithRequest:self.request
+                                  uploadProgress:nil
+                                  downloadProgress:nil
                                   completionHandler:^(NSURLResponse *response, id responseObject, NSError *error) {
                                       [expectation fulfill];
                                   }];
@@ -67,6 +69,8 @@
     [self expectationForNotification:AFNetworkingTaskDidCompleteNotification object:nil handler:nil];
     NSURLSessionDataTask *task = [self.sessionManager
                                   dataTaskWithRequest:self.request
+                                  uploadProgress:nil
+                                  downloadProgress:nil
                                   completionHandler:^(NSURLResponse *response, id responseObject, NSError *error) {
                                       //Without the dispatch after, this test would PASS errorenously because the test
                                       //would finish before the notification was posted to all objects that were
@@ -89,6 +93,8 @@
     [self expectationForNotification:AFNetworkingTaskDidSuspendNotification object:nil handler:nil];
     NSURLSessionDataTask *task = [self.sessionManager
                                   dataTaskWithRequest:self.request
+                                  uploadProgress:nil
+                                  downloadProgress:nil
                                   completionHandler:^(NSURLResponse *response, id responseObject, NSError *error) {
                                       //Without the dispatch after, this test would PASS errorenously because the test
                                       //would finish before the notification was posted to all objects that were

--- a/Tests/Tests/AFUIRefreshControlTests.m
+++ b/Tests/Tests/AFUIRefreshControlTests.m
@@ -49,6 +49,8 @@
     [self expectationForNotification:AFNetworkingTaskDidResumeNotification object:nil handler:nil];
     NSURLSessionDataTask *task = [self.sessionManager
                                   dataTaskWithRequest:self.request
+                                  uploadProgress:nil
+                                  downloadProgress:nil
                                   completionHandler:^(NSURLResponse *response, id responseObject, NSError *error) {
                                       [expectation fulfill];
                                   }];
@@ -66,6 +68,8 @@
     [self expectationForNotification:AFNetworkingTaskDidCompleteNotification object:nil handler:nil];
     NSURLSessionDataTask *task = [self.sessionManager
                                   dataTaskWithRequest:self.request
+                                  uploadProgress:nil
+                                  downloadProgress:nil
                                   completionHandler:^(NSURLResponse *response, id responseObject, NSError *error) {
                                       //Without the dispatch after, this test would PASS errorenously because the test
                                       //would finish before the notification was posted to all objects that were
@@ -88,6 +92,8 @@
     [self expectationForNotification:AFNetworkingTaskDidSuspendNotification object:nil handler:nil];
     NSURLSessionDataTask *task = [self.sessionManager
                                   dataTaskWithRequest:self.request
+                                  uploadProgress:nil
+                                  downloadProgress:nil
                                   completionHandler:^(NSURLResponse *response, id responseObject, NSError *error) {
                                       //Without the dispatch after, this test would PASS errorenously because the test
                                       //would finish before the notification was posted to all objects that were

--- a/Tests/Tests/AFURLSessionManagerTests.m
+++ b/Tests/Tests/AFURLSessionManagerTests.m
@@ -187,6 +187,8 @@
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
             task = [self.localManager
                     dataTaskWithRequest:[NSURLRequest requestWithURL:self.baseURL]
+                    uploadProgress:nil
+                    downloadProgress:nil
                     completionHandler:nil];
             dispatch_sync(serial_queue, ^{
                 XCTAssertFalse([taskIDs containsObject:@(task.taskIdentifier)]);
@@ -204,19 +206,25 @@
 
 - (void)testDidResumeNotificationIsReceivedByLocalDataTaskAfterResume {
     NSURLSessionDataTask *task = [self.localManager dataTaskWithRequest:[self _delayURLRequest]
-                                                 completionHandler:nil];
+                                                         uploadProgress:nil
+                                                       downloadProgress:nil
+                                                      completionHandler:nil];
     [self _testResumeNotificationForTask:task];
 }
 
 - (void)testDidSuspendNotificationIsReceivedByLocalDataTaskAfterSuspend {
     NSURLSessionDataTask *task = [self.localManager dataTaskWithRequest:[self _delayURLRequest]
-                                                 completionHandler:nil];
+                                                         uploadProgress:nil
+                                                       downloadProgress:nil
+                                                      completionHandler:nil];
     [self _testSuspendNotificationForTask:task];
 }
 
 - (void)testDidResumeNotificationIsReceivedByBackgroundDataTaskAfterResume {
     if (self.backgroundManager) {
         NSURLSessionDataTask *task = [self.backgroundManager dataTaskWithRequest:[self _delayURLRequest]
+                                                                  uploadProgress:nil
+                                                                downloadProgress:nil
                                                                completionHandler:nil];
         [self _testResumeNotificationForTask:task];
     }
@@ -225,6 +233,8 @@
 - (void)testDidSuspendNotificationIsReceivedByBackgroundDataTaskAfterSuspend {
     if (self.backgroundManager) {
         NSURLSessionDataTask *task = [self.backgroundManager dataTaskWithRequest:[self _delayURLRequest]
+                                                                  uploadProgress:nil
+                                                                downloadProgress:nil
                                                                completionHandler:nil];
         [self _testSuspendNotificationForTask:task];
     }
@@ -232,17 +242,17 @@
 
 - (void)testDidResumeNotificationIsReceivedByLocalUploadTaskAfterResume {
     NSURLSessionUploadTask *task = [self.localManager uploadTaskWithRequest:[self _delayURLRequest]
-                                                              fromData:[NSData data]
-                                                              progress:nil
-                                                     completionHandler:nil];
+                                                                   fromData:[NSData data]
+                                                                   progress:nil
+                                                          completionHandler:nil];
     [self _testResumeNotificationForTask:task];
 }
 
 - (void)testDidSuspendNotificationIsReceivedByLocalUploadTaskAfterSuspend {
     NSURLSessionUploadTask *task = [self.localManager uploadTaskWithRequest:[self _delayURLRequest]
-                                                              fromData:[NSData data]
-                                                              progress:nil
-                                                     completionHandler:nil];
+                                                                   fromData:[NSData data]
+                                                                   progress:nil
+                                                          completionHandler:nil];
     [self _testSuspendNotificationForTask:task];
 }
 
@@ -318,7 +328,9 @@
 
 - (void)testSwizzlingIsWorkingAsExpectedForForegroundDataTask {
     NSURLSessionTask *task = [self.localManager dataTaskWithRequest:[self _delayURLRequest]
-                                             completionHandler:nil];
+                                                     uploadProgress:nil
+                                                   downloadProgress:nil
+                                                  completionHandler:nil];
     [self _testSwizzlingForTask:task];
     [task cancel];
 }
@@ -368,6 +380,8 @@
 - (void)testBackgroundManagerReturnsExpectedClassForDataTask {
     if (self.backgroundManager) {
         NSURLSessionTask *task = [self.backgroundManager dataTaskWithRequest:[self _delayURLRequest]
+                                                              uploadProgress:nil
+                                                            downloadProgress:nil
                                                            completionHandler:nil];
         XCTAssert([NSStringFromClass([task class]) isEqualToString:@"__NSCFBackgroundDataTask"]);
     } else {

--- a/UIKit+AFNetworking/AFImageDownloader.m
+++ b/UIKit+AFNetworking/AFImageDownloader.m
@@ -235,6 +235,8 @@
 
         createdTask = [self.sessionManager
                        dataTaskWithRequest:request
+                       uploadProgress:nil
+                       downloadProgress:nil
                        completionHandler:^(NSURLResponse * _Nonnull response, id  _Nullable responseObject, NSError * _Nullable error) {
                            dispatch_async(self.responseQueue, ^{
                                __strong __typeof__(weakSelf) strongSelf = weakSelf;


### PR DESCRIPTION
It's dangers to leave `dataTaskWithRequest:completionHandler:` method without deprecated mark, as this method is now overloaded, and calling a different one, it breaks compatibility with previous overridden methods.