### PR TITLE
Fixed crashes due to race conditions with NSMutableDictionary access in AFHTTPRequestSerialiser

### DIFF
--- a/AFNetworking/AFURLRequestSerialization.m
+++ b/AFNetworking/AFURLRequestSerialization.m
@@ -189,6 +189,7 @@ static void *AFHTTPRequestSerializerObserverContext = &AFHTTPRequestSerializerOb
 @interface AFHTTPRequestSerializer ()
 @property (readwrite, nonatomic, strong) NSMutableSet *mutableObservedChangedKeyPaths;
 @property (readwrite, nonatomic, strong) NSMutableDictionary *mutableHTTPRequestHeaders;
+@property (readwrite, nonatomic, strong) dispatch_queue_t requestHeaderModificationQueue;
 @property (readwrite, nonatomic, assign) AFHTTPRequestQueryStringSerializationStyle queryStringSerializationStyle;
 @property (readwrite, nonatomic, copy) AFQueryStringSerializationBlock queryStringSerialization;
 @end
@@ -208,6 +209,7 @@ static void *AFHTTPRequestSerializerObserverContext = &AFHTTPRequestSerializerOb
     self.stringEncoding = NSUTF8StringEncoding;
 
     self.mutableHTTPRequestHeaders = [NSMutableDictionary dictionary];
+    self.requestHeaderModificationQueue = dispatch_queue_create("requestHeaderModificationQueue", DISPATCH_QUEUE_CONCURRENT);
 
     // Accept-Language HTTP Header; see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.4
     NSMutableArray *acceptLanguagesComponents = [NSMutableArray array];
@@ -306,17 +308,27 @@ static void *AFHTTPRequestSerializerObserverContext = &AFHTTPRequestSerializerOb
 #pragma mark -
 
 - (NSDictionary *)HTTPRequestHeaders {
-    return [NSDictionary dictionaryWithDictionary:self.mutableHTTPRequestHeaders];
+    NSDictionary __block *value;
+    dispatch_sync(self.requestHeaderModificationQueue, ^{
+        value = [NSDictionary dictionaryWithDictionary:self.mutableHTTPRequestHeaders];
+    });
+    return value;
 }
 
 - (void)setValue:(NSString *)value
 forHTTPHeaderField:(NSString *)field
 {
-	[self.mutableHTTPRequestHeaders setValue:value forKey:field];
+    dispatch_barrier_async(self.requestHeaderModificationQueue, ^{
+        [self.mutableHTTPRequestHeaders setValue:value forKey:field];
+    });
 }
 
 - (NSString *)valueForHTTPHeaderField:(NSString *)field {
-    return [self.mutableHTTPRequestHeaders valueForKey:field];
+    NSString __block *value;
+    dispatch_sync(self.requestHeaderModificationQueue, ^{
+        value = [self.mutableHTTPRequestHeaders valueForKey:field];
+    });
+    return value;
 }
 
 - (void)setAuthorizationHeaderFieldWithUsername:(NSString *)username
@@ -328,7 +340,9 @@ forHTTPHeaderField:(NSString *)field
 }
 
 - (void)clearAuthorizationHeader {
-	[self.mutableHTTPRequestHeaders removeObjectForKey:@"Authorization"];
+    dispatch_barrier_async(self.requestHeaderModificationQueue, ^{
+        [self.mutableHTTPRequestHeaders removeObjectForKey:@"Authorization"];
+    });
 }
 
 #pragma mark -
@@ -560,7 +574,9 @@ forHTTPHeaderField:(NSString *)field
 }
 
 - (void)encodeWithCoder:(NSCoder *)coder {
-    [coder encodeObject:self.mutableHTTPRequestHeaders forKey:NSStringFromSelector(@selector(mutableHTTPRequestHeaders))];
+    dispatch_sync(self.requestHeaderModificationQueue, ^{
+        [coder encodeObject:self.mutableHTTPRequestHeaders forKey:NSStringFromSelector(@selector(mutableHTTPRequestHeaders))];
+    });
     [coder encodeInteger:self.queryStringSerializationStyle forKey:NSStringFromSelector(@selector(queryStringSerializationStyle))];
 }
 
@@ -568,7 +584,9 @@ forHTTPHeaderField:(NSString *)field
 
 - (instancetype)copyWithZone:(NSZone *)zone {
     AFHTTPRequestSerializer *serializer = [[[self class] allocWithZone:zone] init];
-    serializer.mutableHTTPRequestHeaders = [self.mutableHTTPRequestHeaders mutableCopyWithZone:zone];
+    dispatch_sync(self.requestHeaderModificationQueue, ^{
+        serializer.mutableHTTPRequestHeaders = [self.mutableHTTPRequestHeaders mutableCopyWithZone:zone];
+    });
     serializer.queryStringSerializationStyle = self.queryStringSerializationStyle;
     serializer.queryStringSerialization = self.queryStringSerialization;
 

--- a/Tests/Tests/AFHTTPRequestSerializationTests.m
+++ b/Tests/Tests/AFHTTPRequestSerializationTests.m
@@ -183,6 +183,28 @@
     XCTAssertFalse([serializer.HTTPRequestHeaders.allKeys containsObject:headerField]);
 }
 
+- (void)testThatHTTPHeaderValueCanBeSetToReferenceCountedStringFromMultipleThreadsWithoutCrashing {
+    @autoreleasepool {
+        int dispatchTarget = 1000;
+        __block int completionCount = 0;
+        for(int i=0; i<dispatchTarget; i++) {
+            NSString *nonStaticNonTaggedPointerString = [NSString stringWithFormat:@"%@", [NSDate dateWithTimeIntervalSince1970:i]];
+            dispatch_queue_t queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0ul);
+            dispatch_async(queue, ^{
+                
+                [self.requestSerializer setValue:nonStaticNonTaggedPointerString forHTTPHeaderField:@"FrequentlyUpdatedHeaderField"];
+                
+                dispatch_sync(dispatch_get_main_queue(), ^{
+                    completionCount++;
+                });
+            });
+        }
+        while (completionCount < dispatchTarget) {
+            [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
+        }
+    } // Test succeeds if it does not EXC_BAD_ACCESS when cleaning up the @autoreleasepool
+}
+
 #pragma mark - Helper Methods
 
 - (void)testQueryStringFromParameters {

--- a/Tests/Tests/AFJSONSerializationTests.m
+++ b/Tests/Tests/AFJSONSerializationTests.m
@@ -66,28 +66,6 @@ static NSData * AFJSONTestData() {
     XCTAssertTrue([@"[{\"key\":\"value\"}]" isEqualToString:body], @"Parameters were not encoded correctly");
 }
 
-- (void)testThatJSONRequestSerializationHandlesHeaderValueSetToReferenceCountedStringFromMultipleThreads {
-    @autoreleasepool {
-        int dispatchTarget = 1000;
-        __block int completionCount = 0;
-        for(int i=0; i<dispatchTarget; i++) {
-            NSString *nonStaticNonTaggedPointerString = [NSString stringWithFormat:@"%@", [NSDate dateWithTimeIntervalSince1970:i]];
-            dispatch_queue_t queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0ul);
-            dispatch_async(queue, ^{
-                
-                [self.requestSerializer setValue:nonStaticNonTaggedPointerString forHTTPHeaderField:@"FrequentlyUpdatedHeaderField"];
-                
-                dispatch_sync(dispatch_get_main_queue(), ^{
-                    completionCount++;
-                });
-            });
-        }
-        while (completionCount < dispatchTarget) {
-            [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
-        }
-    } // Test succeeds if it does not EXC_BAD_ACCESS when cleaning up the @autoreleasepool
-}
-
 @end
 
 #pragma mark -

--- a/Tests/Tests/AFJSONSerializationTests.m
+++ b/Tests/Tests/AFJSONSerializationTests.m
@@ -66,6 +66,28 @@ static NSData * AFJSONTestData() {
     XCTAssertTrue([@"[{\"key\":\"value\"}]" isEqualToString:body], @"Parameters were not encoded correctly");
 }
 
+- (void)testThatJSONRequestSerializationHandlesHeaderValueSetToReferenceCountedStringFromMultipleThreads {
+    @autoreleasepool {
+        int dispatchTarget = 1000;
+        __block int completionCount = 0;
+        for(int i=0; i<dispatchTarget; i++) {
+            NSString *nonStaticNonTaggedPointerString = [NSString stringWithFormat:@"%@", [NSDate dateWithTimeIntervalSince1970:i]];
+            dispatch_queue_t queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0ul);
+            dispatch_async(queue, ^{
+                
+                [self.requestSerializer setValue:nonStaticNonTaggedPointerString forHTTPHeaderField:@"FrequentlyUpdatedHeaderField"];
+                
+                dispatch_sync(dispatch_get_main_queue(), ^{
+                    completionCount++;
+                });
+            });
+        }
+        while (completionCount < dispatchTarget) {
+            [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
+        }
+    } // Test succeeds if it does not EXC_BAD_ACCESS when cleaning up the @autoreleasepool
+}
+
 @end
 
 #pragma mark -


### PR DESCRIPTION
This is a fix for an intermittent crash bug which is likely to occur in any app which sets header values with dynamic values over around six characters long. These strings are reference counted, but the counting goes wrong because the owner, the headers dictionary, is not a thread-safe collection, but will be used from multiple threads in normal use of the AFNetworking library. The frequency of crashes increases greatly if you have a header which needs to be updated constantly. The crashes appear in areas of the app which are almost always completely unrelated, but often have deallocation in the stack trace.

This fix has been included in a shipping app with ~400k daily launches since the end of February, and has reduced our crash rate to almost nil.

I have included a unit test which reproduces the issue, but more as a courtesy than as a proper unit test.  There is nothing to positively test for, the test succeeds if it doesn't EXC_BAD_ACCESS when cleaning up the @autoreleasepool at the end.