### PR TITLE
Update iOS Example

### DIFF
--- a/Example/iOS Example/AppDelegate.m
+++ b/Example/iOS Example/AppDelegate.m
@@ -38,7 +38,7 @@
     self.navigationController = [[UINavigationController alloc] initWithRootViewController:viewController];
     self.navigationController.navigationBar.tintColor = [UIColor darkGrayColor];
     
-    self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
+    self.window = [[UIWindow alloc] init];
     self.window.backgroundColor = [UIColor whiteColor];
     self.window.rootViewController = self.navigationController;
     [self.window makeKeyAndVisible];

--- a/Example/iOS Example/Controllers/GlobalTimelineViewController.m
+++ b/Example/iOS Example/Controllers/GlobalTimelineViewController.m
@@ -35,8 +35,6 @@
 @implementation GlobalTimelineViewController
 
 - (void)reload:(__unused id)sender {
-    self.navigationItem.rightBarButtonItem.enabled = NO;
-
     NSURLSessionTask *task = [Post globalTimelinePostsWithBlock:^(NSArray *posts, NSError *error) {
         if (!error) {
             self.posts = posts;
@@ -54,9 +52,8 @@
     
     self.title = NSLocalizedString(@"AFNetworking", nil);
 
-    self.refreshControl = [[UIRefreshControl alloc] initWithFrame:CGRectMake(0.0f, 0.0f, self.tableView.frame.size.width, 100.0f)];
+    self.refreshControl = [[UIRefreshControl alloc] init];
     [self.refreshControl addTarget:self action:@selector(reload:) forControlEvents:UIControlEventValueChanged];
-    [self.tableView.tableHeaderView addSubview:self.refreshControl];
 
     self.tableView.rowHeight = 70.0f;
     

--- a/Example/iOS Example/Views/PostTableViewCell.m
+++ b/Example/iOS Example/Views/PostTableViewCell.m
@@ -77,6 +77,11 @@
     CGFloat calculatedHeight = [[self class] detailTextHeight:self.post.text];
     detailTextLabelFrame.size.height = calculatedHeight;
     self.detailTextLabel.frame = detailTextLabelFrame;
+    
+    CGRect separatorViewFrame = self.subviews[1].frame;
+    separatorViewFrame.origin.x = 70.0f;
+    separatorViewFrame.size.width = [UIScreen mainScreen].bounds.size.width;
+    self.subviews[1].frame = separatorViewFrame;
 }
 
 @end


### PR DESCRIPTION
Fix post cell’s separator’s wrong position and width bug. And delete some unnecessary code.