### PR TITLE
Update AFNetworkReachabilityManager.m for IPv6

### DIFF
--- a/AFNetworking/AFNetworkReachabilityManager.m
+++ b/AFNetworking/AFNetworkReachabilityManager.m
@@ -144,17 +144,11 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {
 
 + (instancetype)manager
 {
-#if (defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && __IPHONE_OS_VERSION_MIN_REQUIRED >= 90000) || (defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 101100)
-    struct sockaddr_in6 address;
-    bzero(&address, sizeof(address));
-    address.sin6_len = sizeof(address);
-    address.sin6_family = AF_INET6;
-#else
     struct sockaddr_in address;
     bzero(&address, sizeof(address));
     address.sin_len = sizeof(address);
     address.sin_family = AF_INET;
-#endif
+
     return [self managerForAddress:&address];
 }
 


### PR DESCRIPTION
It's no needs to add sockaddr_in6 address.
If the build target is iOS9, in iOS8 device "setReachabilityStatusChangeBlock" not works in IPv4 network.
If the build target is lower than iOS9, in iOS8 device "setReachabilityStatusChangeBlock" not works in IPv6 network.
In iOS9 device "setReachabilityStatusChangeBlock" works good in both IPv4 & IPv6 network no mater which build target version is.
Base in Apple "Unofficial" review rules, they just test it in newest iOS version, so sockaddr_in is enough, add sockaddr_in6 leads to duplicated code, which is difficult to maintain.