### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ To integrate AFNetworking into your Xcode project using CocoaPods, specify it in
 source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '8.0'
 
+target 'TargetName' do
 pod 'AFNetworking', '~> 3.0'
+end
 ```
 
 Then, run the following command:


### PR DESCRIPTION
Update the content of the section `Installation with CocoaPods` in `README.md`, since the older one could lead to the following error with the latest CocoaPods:
```
The dependency `AFNetworking (~> 3.0)` is not used in any concrete target.
```