### PR TITLE
Moved `[self didChangeValueForKey:@"currentState"]` into correct scope

### DIFF
--- a/UIKit+AFNetworking/AFNetworkActivityIndicatorManager.m
+++ b/UIKit+AFNetworking/AFNetworkActivityIndicatorManager.m
@@ -191,8 +191,9 @@ typedef void (^AFNetworkActivityActionBlock)(BOOL networkActivityIndicatorVisibl
                     [self startCompletionDelayTimer];
                     break;
             }
+            [self didChangeValueForKey:@"currentState"];
         }
-        [self didChangeValueForKey:@"currentState"];
+        
     }
 }
 


### PR DESCRIPTION
I found '[self didChangeValueForKey:@"currentState"];' is outsite of the if{} scope,that confused me, maybe it should be insite.