### PR TITLE
Fix crash around customizing NSURLCache size.

### DIFF
--- a/UIKit+AFNetworking/AFImageDownloader.m
+++ b/UIKit+AFNetworking/AFImageDownloader.m
@@ -110,6 +110,9 @@
 @implementation AFImageDownloader
 
 + (NSURLCache *)defaultURLCache {
+    if ([[[UIDevice currentDevice] systemVersion] compare:@"8.2" options:NSNumericSearch] == NSOrderedAscending) {
+        return [NSURLCache sharedURLCache];
+    }
     return [[NSURLCache alloc] initWithMemoryCapacity:20 * 1024 * 1024
                                          diskCapacity:150 * 1024 * 1024
                                              diskPath:@"com.alamofire.imagedownloader"];


### PR DESCRIPTION
In our app, we're experiencing a crash due to use of custom size for NSURLCache, which gets fixed as soon as we stop customizing the cache size. This crash only happens on devices below iOS 8.2, which is small portion but it'd still be nice to see this gets fixed in the API.

Discussion around this bug can be found here: http://stackoverflow.com/questions/27233448/ios-crasher-cfnetwork-httpreadfilterdoplainreadstreamreader-unsigned-char/28464227#28464227

Below is the stack trace.
```
Thread 4 Crashed:
0   libsystem_platform.dylib             0x3568fb7a _platform_memmove + 186
1   CFNetwork                            0x26f862c7 HTTPReadFilter::doPlainRead(StreamReader*, unsigned char*, long, CFStreamError*, unsigned char*) + 176
2   CFNetwork                            0x26f8611b HTTPReadFilter::_streamImpl_Read(unsigned char*, long, CFStreamError*, unsigned char*) + 392
3   CFNetwork                            0x26f6dd73 CoreStreamBase::_streamInterface_Read(unsigned char*, long) + 96
4   CFNetwork                            0x26ff13a3 HTTPNetStreamInfo::_streamImpl_Read(__CFReadStream*, unsigned char*, long, CFStreamError*, unsigned char*) + 304
5   CFNetwork                            0x2705fc3d CFNetworkReadStream::httpStreamRead(__CFReadStream*, unsigned char*, long, CFStreamError*, unsigned char*, void*) + 42
6   CoreFoundation                       0x274521a9 CFReadStreamRead + 326
7   CFNetwork                            0x26ff1ee9 HTTPNetStreamInfo::_readStreamClientCallBack(__CFReadStream*, unsigned long) + 126
8   CFNetwork                            0x2705fd57 CFNetworkReadStream::_readStreamClientCallBackCallBack(__CFReadStream*, unsigned long, void*) + 36
9   CoreFoundation                       0x274916d7 _signalEventSync + 144
10  CoreFoundation                       0x27491633 _cfstream_shared_signalEventSync + 340
11  CoreFoundation                       0x274e0d57 __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 12
12  CoreFoundation                       0x274e01f9 __CFRunLoopDoSources0 + 362
13  CoreFoundation                       0x274de7cd __CFRunLoopRun + 770
14  CoreFoundation                       0x2742c3c1 CFRunLoopRunSpecific + 474
15  CoreFoundation                       0x2742c1d3 CFRunLoopRunInMode + 104
16  CFNetwork                            0x26fe1957 +[NSURLConnection(Loader) _resourceLoadLoop:] + 484
17  Foundation                           0x2822ab5b __NSThread__main__ + 1116
18  libsystem_pthread.dylib              0x35695e93 _pthread_body + 136
19  libsystem_pthread.dylib              0x35695e07 _pthread_start + 116
20  libsystem_pthread.dylib              0x35693b90 thread_start + 6
```