### PR TITLE
Fixed an issue where registering a UIProgessView to a task that was a…

### DIFF
--- a/UIKit+AFNetworking/UIProgressView+AFNetworking.m
+++ b/UIKit+AFNetworking/UIProgressView+AFNetworking.m
@@ -55,6 +55,10 @@ static void * AFTaskCountOfBytesReceivedContext = &AFTaskCountOfBytesReceivedCon
 - (void)setProgressWithUploadProgressOfTask:(NSURLSessionUploadTask *)task
                                    animated:(BOOL)animated
 {
+    if (task.state == NSURLSessionTaskStateCompleted) {
+        return;
+    }
+    
     [task addObserver:self forKeyPath:@"state" options:(NSKeyValueObservingOptions)0 context:AFTaskCountOfBytesSentContext];
     [task addObserver:self forKeyPath:@"countOfBytesSent" options:(NSKeyValueObservingOptions)0 context:AFTaskCountOfBytesSentContext];
 
@@ -64,6 +68,10 @@ static void * AFTaskCountOfBytesReceivedContext = &AFTaskCountOfBytesReceivedCon
 - (void)setProgressWithDownloadProgressOfTask:(NSURLSessionDownloadTask *)task
                                      animated:(BOOL)animated
 {
+    if (task.state == NSURLSessionTaskStateCompleted) {
+        return;
+    }
+    
     [task addObserver:self forKeyPath:@"state" options:(NSKeyValueObservingOptions)0 context:AFTaskCountOfBytesReceivedContext];
     [task addObserver:self forKeyPath:@"countOfBytesReceived" options:(NSKeyValueObservingOptions)0 context:AFTaskCountOfBytesReceivedContext];
 


### PR DESCRIPTION
Noticed that when having a UIProgressView calling `setProgressWithUploadProgressOfTask:animated: `or `setProgressWithDownloadProgressOfTask:animated` of `UIProgressView+AFNetworking` with the task parameter object **having already completed** (status == NSURLSessionTaskStateCompleted), the app would crash when the task object is deallocated with the following error:

> CRASH: Fatal exception: An instance ***** of class ******* was deallocated while key value observers were still registered with it.