### PR TITLE
change ipv6 condition in ReachabilityManager

### DIFF
--- a/AFNetworking/AFNetworkReachabilityManager.m
+++ b/AFNetworking/AFNetworkReachabilityManager.m
@@ -144,7 +144,7 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {
 
 + (instancetype)manager
 {
-#if (defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && __IPHONE_OS_VERSION_MIN_REQUIRED >= 90000) || (defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 101100)
+    #if (TARGET_OS_IPHONE && NSFoundationVersionNumber > 1240) || (TARGET_OS_MAC && NSFoundationVersionNumber >= 1252)
     struct sockaddr_in6 address;
     bzero(&address, sizeof(address));
     address.sin6_len = sizeof(address);


### PR DESCRIPTION
when run in more than iOS9 device, can not jump to the ipv6 branch in the master version. So I fix it use NSFoundationVersionNumber.
