### PR TITLE
Fixed issue where `NS_UNAVAILABLE` is not reported for `AFNetworkReachabilityManager`

### DIFF
--- a/AFNetworking/AFNetworkReachabilityManager.h
+++ b/AFNetworking/AFNetworkReachabilityManager.h
@@ -107,6 +107,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (instancetype)initWithReachability:(SCNetworkReachabilityRef)reachability NS_DESIGNATED_INITIALIZER;
 
+/**
+ *  Initializes an instance of a network reachability manager
+ *
+ *  @return nil as this method is unavailable
+ */
+- (nullable instancetype)init NS_UNAVAILABLE;
+
 ///--------------------------------------------------
 /// @name Starting & Stopping Reachability Monitoring
 ///--------------------------------------------------


### PR DESCRIPTION
Fixed issue where NS_UNAVAILABLE is not reported to calling code as it was previously just in the .m file - this allows the compiler to generate a build error when using the init method