### PR TITLE
Removing NULL objects within an Array

### DIFF
--- a/AFNetworking/AFURLResponseSerialization.m
+++ b/AFNetworking/AFURLResponseSerialization.m
@@ -64,7 +64,9 @@ static id AFJSONObjectByRemovingKeysWithNullValues(id JSONObject, NSJSONReadingO
     if ([JSONObject isKindOfClass:[NSArray class]]) {
         NSMutableArray *mutableArray = [NSMutableArray arrayWithCapacity:[(NSArray *)JSONObject count]];
         for (id value in (NSArray *)JSONObject) {
-            [mutableArray addObject:AFJSONObjectByRemovingKeysWithNullValues(value, readingOptions)];
+            if (value && ![value isEqual:[NSNull null]]) { // Check to see if the object is non NULL before adding to the array.
+                [mutableArray addObject:AFJSONObjectByRemovingKeysWithNullValues(value, readingOptions)];
+            }
         }
 
         return (readingOptions & NSJSONReadingMutableContainers) ? mutableArray : [NSArray arrayWithArray:mutableArray];


### PR DESCRIPTION
This method currently removes keys for NULL values only within a dictionary.
Proposing here to remove NULL objects from Array as well.

If this goes against the function name _AFJSONObjectByRemovingKeysWithNullValues_ and the flag _removesKeysWithNullValues_ would you recommend changing them (to _AFJSONObjectByRemovingNullValues_ and _removesNullValues_ respectively) or add another Flag?