### PR TITLE
AFHTTPSessionManager now throws exception if SSL pinning mode is set for non https sessions

### DIFF
--- a/AFNetworking/AFHTTPSessionManager.h
+++ b/AFNetworking/AFHTTPSessionManager.h
@@ -94,6 +94,15 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, strong) AFHTTPResponseSerializer <AFURLResponseSerialization> * responseSerializer;
 
+///-------------------------------
+/// @name Managing Security Policy
+///-------------------------------
+
+/**
+ The security policy used by created session to evaluate server trust for secure connections. `AFURLSessionManager` uses the `defaultPolicy` unless otherwise specified. A security policy configured with `AFSSLPinningModePublicKey` or `AFSSLPinningModeCertificate` can only be applied on a session manager initialized with a secure base URL (i.e. https). Applying a security policy with pinning enabled on an insecure session manager throws an `Invalid Security Policy` exception.
+ */
+@property (nonatomic, strong) AFSecurityPolicy *securityPolicy;
+
 ///---------------------
 /// @name Initialization
 ///---------------------

--- a/AFNetworking/AFHTTPSessionManager.m
+++ b/AFNetworking/AFHTTPSessionManager.m
@@ -98,6 +98,23 @@
     [super setResponseSerializer:responseSerializer];
 }
 
+@dynamic securityPolicy;
+
+- (void)setSecurityPolicy:(AFSecurityPolicy *)securityPolicy {
+    if (securityPolicy.SSLPinningMode != AFSSLPinningModeNone && ![self.baseURL.scheme isEqualToString:@"https"]) {
+        NSString *pinningMode = @"Unknown Pinning Mode";
+        switch (securityPolicy.SSLPinningMode) {
+            case AFSSLPinningModeNone:        pinningMode = @"AFSSLPinningModeNone"; break;
+            case AFSSLPinningModeCertificate: pinningMode = @"AFSSLPinningModeCertificate"; break;
+            case AFSSLPinningModePublicKey:   pinningMode = @"AFSSLPinningModePublicKey"; break;
+        }
+        NSString *reason = [NSString stringWithFormat:@"A security policy configured with `%@` can only be applied on a manager with a secure base URL (i.e. https)", pinningMode];
+        @throw [NSException exceptionWithName:@"Invalid Security Policy" reason:reason userInfo:nil];
+    }
+
+    [super setSecurityPolicy:securityPolicy];
+}
+
 #pragma mark -
 
 - (NSURLSessionDataTask *)GET:(NSString *)URLString

--- a/Tests/Tests/AFHTTPSessionManagerTests.m
+++ b/Tests/Tests/AFHTTPSessionManagerTests.m
@@ -510,6 +510,56 @@
     [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
 }
 
+# pragma mark - Security Policy
+
+- (void)testValidSecureNoPinningSecurityPolicy {
+    AFHTTPSessionManager *manager = [[AFHTTPSessionManager alloc] initWithBaseURL:[NSURL URLWithString:@"https://example.com"]];
+    AFSecurityPolicy *securityPolicy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModeNone];
+    XCTAssertNoThrow(manager.securityPolicy = securityPolicy);
+}
+
+- (void)testValidInsecureNoPinningSecurityPolicy {
+    AFHTTPSessionManager *manager = [[AFHTTPSessionManager alloc] initWithBaseURL:[NSURL URLWithString:@"http://example.com"]];
+    AFSecurityPolicy *securityPolicy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModeNone];
+    XCTAssertNoThrow(manager.securityPolicy = securityPolicy);
+}
+
+- (void)testValidCertificatePinningSecurityPolicy {
+    AFHTTPSessionManager *manager = [[AFHTTPSessionManager alloc] initWithBaseURL:[NSURL URLWithString:@"https://example.com"]];
+    AFSecurityPolicy *securityPolicy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModeCertificate];
+    XCTAssertNoThrow(manager.securityPolicy = securityPolicy);
+}
+
+- (void)testInvalidCertificatePinningSecurityPolicy {
+    AFHTTPSessionManager *manager = [[AFHTTPSessionManager alloc] initWithBaseURL:[NSURL URLWithString:@"http://example.com"]];
+    AFSecurityPolicy *securityPolicy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModeCertificate];
+    XCTAssertThrowsSpecificNamed(manager.securityPolicy = securityPolicy, NSException, @"Invalid Security Policy");
+}
+
+- (void)testValidPublicKeyPinningSecurityPolicy {
+    AFHTTPSessionManager *manager = [[AFHTTPSessionManager alloc] initWithBaseURL:[NSURL URLWithString:@"https://example.com"]];
+    AFSecurityPolicy *securityPolicy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModePublicKey];
+    XCTAssertNoThrow(manager.securityPolicy = securityPolicy);
+}
+
+- (void)testInvalidPublicKeyPinningSecurityPolicy {
+    AFHTTPSessionManager *manager = [[AFHTTPSessionManager alloc] initWithBaseURL:[NSURL URLWithString:@"http://example.com"]];
+    AFSecurityPolicy *securityPolicy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModePublicKey];
+    XCTAssertThrowsSpecificNamed(manager.securityPolicy = securityPolicy, NSException, @"Invalid Security Policy");
+}
+
+- (void)testInvalidCertificatePinningSecurityPolicyWithoutBaseURL {
+    AFHTTPSessionManager *manager = [[AFHTTPSessionManager alloc] init];
+    AFSecurityPolicy *securityPolicy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModeCertificate];
+    XCTAssertThrowsSpecificNamed(manager.securityPolicy = securityPolicy, NSException, @"Invalid Security Policy");
+}
+
+- (void)testInvalidPublicKeyPinningSecurityPolicyWithoutBaseURL {
+    AFHTTPSessionManager *manager = [[AFHTTPSessionManager alloc] init];
+    AFSecurityPolicy *securityPolicy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModePublicKey];
+    XCTAssertThrowsSpecificNamed(manager.securityPolicy = securityPolicy, NSException, @"Invalid Security Policy");
+}
+
 # pragma mark - Server Trust
 
 - (void)testInvalidServerTrustProducesCorrectErrorForCertificatePinning {


### PR DESCRIPTION
### Before this commit
Setting a security policy configured with `AFSSLPinningModeCertificate` or `AFSSLPinningModePublicKey` on a AFHTTPSessionManager instance configured with an insecure `http` base URL was valid. Requests made with this manager would always succeed since the `-[AFURLSessionManager URLSession:didReceiveChallenge:completionHandler:]` would never be called and thus the security policy would never be evaluated.

### After this commit
Setting a security policy configured with `AFSSLPinningModeCertificate` or `AFSSLPinningModePublicKey` on a AFHTTPSessionManager instance configured with an insecure `http` base URL will throw an exception. This will force the manager to be configured with a secure `https` URL.

Note that properly configuring App Transport Security (ATS) would also solve this issue since insecure connections would fail anyway, but this is a *belt and suspenders* solution.