### PR TITLE
Fix progress handlers called with fractionCompleted == 1 several times

### DIFF
--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -285,8 +285,8 @@ didCompleteWithError:(NSError *)error
           dataTask:(__unused NSURLSessionDataTask *)dataTask
     didReceiveData:(NSData *)data
 {
-    self.downloadProgress.completedUnitCount = dataTask.countOfBytesReceived;
     self.downloadProgress.totalUnitCount = dataTask.countOfBytesExpectedToReceive;
+    self.downloadProgress.completedUnitCount = dataTask.countOfBytesReceived;
 
     [self.mutableData appendData:data];
 }
@@ -296,8 +296,8 @@ didCompleteWithError:(NSError *)error
     totalBytesSent:(int64_t)totalBytesSent
 totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend{
     
-    self.uploadProgress.completedUnitCount = task.countOfBytesSent;
     self.uploadProgress.totalUnitCount = task.countOfBytesExpectedToSend;
+    self.uploadProgress.completedUnitCount = task.countOfBytesSent;
 }
 
 #pragma mark - NSURLSessionDownloadDelegate

--- a/Tests/Tests/AFHTTPSessionManagerTests.m
+++ b/Tests/Tests/AFHTTPSessionManagerTests.m
@@ -228,7 +228,7 @@
 #pragma mark - Progress
 
 - (void)testDownloadProgressIsReportedForGET {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Progress Should equal 1.0"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"Progress Should equal 1.0"];
     [self.manager
      GET:@"image"
      parameters:nil
@@ -248,7 +248,7 @@
         [payload appendString:@"AFNetworking"];
     }
 
-    __weak __block XCTestExpectation *expectation = [self expectationWithDescription:@"Progress Should equal 1.0"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"Progress Should equal 1.0"];
 
     [self.manager
      POST:@"post"
@@ -256,7 +256,6 @@
      progress:^(NSProgress * _Nonnull uploadProgress) {
          if (uploadProgress.fractionCompleted == 1.0) {
              [expectation fulfill];
-             expectation = nil;
          }
      }
      success:nil
@@ -270,7 +269,7 @@
         [payload appendString:@"AFNetworking"];
     }
 
-    __block __weak XCTestExpectation *expectation = [self expectationWithDescription:@"Progress Should equal 1.0"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"Progress Should equal 1.0"];
 
     [self.manager
      POST:@"post"
@@ -281,7 +280,6 @@
      progress:^(NSProgress * _Nonnull uploadProgress) {
          if (uploadProgress.fractionCompleted == 1.0) {
              [expectation fulfill];
-             expectation = nil;
          }
      }
      success:nil

--- a/Tests/Tests/AFURLSessionManagerTests.m
+++ b/Tests/Tests/AFURLSessionManagerTests.m
@@ -140,7 +140,7 @@
             fromData:[payload dataUsingEncoding:NSUTF8StringEncoding]
             progress:^(NSProgress * _Nonnull uploadProgress) {
                 NSLog(@"%@", uploadProgress.localizedDescription);
-                if ([uploadProgress fractionCompleted] == 1.0) {
+                if (uploadProgress.fractionCompleted == 1.0) {
                     [expectation fulfill];
                 }
             }


### PR DESCRIPTION
Setting the expectation to nil after it is fulfilled in order to avoid `*** Assertion failure in -[XCTestExpectation fulfill]` was just hiding the real issue.