### PR TITLE
Fixed crash when passing invalid JSON to request serialization

### DIFF
--- a/AFNetworking/AFURLRequestSerialization.m
+++ b/AFNetworking/AFURLRequestSerialization.m
@@ -1254,6 +1254,14 @@ typedef enum {
             [mutableRequest setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
         }
 
+        if (![NSJSONSerialization isValidJSONObject:parameters]) {
+            if (error) {
+                NSDictionary *userInfo = @{NSLocalizedFailureReasonErrorKey: NSLocalizedStringFromTable(@"The `parameters` argument is not valid JSON.", @"AFNetworking", nil)};
+                *error = [[NSError alloc] initWithDomain:AFURLRequestSerializationErrorDomain code:NSURLErrorCannotDecodeContentData userInfo:userInfo];
+            }
+            return nil;
+        }
+
         NSData *jsonData = [NSJSONSerialization dataWithJSONObject:parameters options:self.writingOptions error:error];
         
         if (!jsonData) {

--- a/Tests/Tests/AFJSONSerializationTests.m
+++ b/Tests/Tests/AFJSONSerializationTests.m
@@ -77,6 +77,18 @@ static NSData * AFJSONTestData() {
     XCTAssertNotNil(error, @"Expected non-nil error.");
 }
 
+- (void)testThatJSONRequestSerializationErrorsWithInvalidJSON {
+    NSDictionary *parameters = @{@"key":[NSSet setWithObject:@"value"]};
+    NSError *error = nil;
+    NSMutableURLRequest *request = [self.requestSerializer requestWithMethod:@"POST" URLString:AFNetworkingTestsBaseURLString parameters:parameters error:&error];
+    
+    XCTAssertNil(request, @"Request should be nil");
+    XCTAssertNotNil(error, @"Serialization error should be not nil");
+    XCTAssertEqualObjects(error.domain, AFURLRequestSerializationErrorDomain);
+    XCTAssertEqual(error.code, NSURLErrorCannotDecodeContentData);
+    XCTAssertEqualObjects(error.localizedFailureReason, @"The `parameters` argument is not valid JSON.");
+}
+
 @end
 
 #pragma mark -


### PR DESCRIPTION
Fixes #3711

The `NSURLErrorCannotDecodeContentData` code is not ideal, but `AFURLRequestSerializationErrorDomain` should define its own error codes anyway.