### PR TITLE
Extract common URLs into AFTestCase

### DIFF
--- a/Tests/Tests/AFImageDownloaderTests.m
+++ b/Tests/Tests/AFImageDownloaderTests.m
@@ -35,10 +35,8 @@
     self.downloader = [[AFImageDownloader alloc] init];
     [[AFImageDownloader defaultURLCache] removeAllCachedResponses];
     [[[AFImageDownloader defaultInstance] imageCache] removeAllImages];
-    NSURL *pngURL = [NSURL URLWithString:@"https://httpbin.org/image/png"];
-    self.pngRequest = [NSURLRequest requestWithURL:pngURL];
-    NSURL *jpegURL = [NSURL URLWithString:@"https://httpbin.org/image/jpeg"];
-    self.jpegRequest = [NSURLRequest requestWithURL:jpegURL];
+    self.pngRequest = [NSURLRequest requestWithURL:self.pngURL];
+    self.jpegRequest = [NSURLRequest requestWithURL:self.jpegURL];
 }
 
 - (void)tearDown {
@@ -66,8 +64,7 @@
 
 - (void)testThatImageDownloaderReturnsNilWithInvalidURL
 {
-    NSURL *pngURL = [NSURL URLWithString:@"https://httpbin.org/image/png"];
-    NSMutableURLRequest *mutableURLRequest = [NSMutableURLRequest requestWithURL:pngURL];
+    NSMutableURLRequest *mutableURLRequest = [NSMutableURLRequest requestWithURL:self.pngURL];
     [mutableURLRequest setURL:nil];
     /** NSURLRequest nor NSMutableURLRequest can be initialized with a nil URL, 
      *  but NSMutableURLRequest can have its URL set to nil 
@@ -420,8 +417,7 @@
 }
 
 - (void)testThatItAlwaysCallsTheFailureHandlerOnTheMainQueue {
-    NSURL *url = [NSURL URLWithString:@"https://httpbin.org/status/404"];
-    NSURLRequest *notFoundRequest = [NSURLRequest requestWithURL:url];
+    NSURLRequest *notFoundRequest = [NSURLRequest requestWithURL:[self URLWithStatusCode:404]];
     XCTestExpectation *expectation = [self expectationWithDescription:@"image download should fail"];
     __block BOOL failureIsOnMainThread = false;
     [self.downloader

--- a/Tests/Tests/AFTestCase.h
+++ b/Tests/Tests/AFTestCase.h
@@ -26,6 +26,11 @@ extern NSString * const AFNetworkingTestsBaseURLString;
 @interface AFTestCase : XCTestCase
 
 @property (nonatomic, strong, readonly) NSURL *baseURL;
+@property (nonatomic, strong, readonly) NSURL *pngURL;
+@property (nonatomic, strong, readonly) NSURL *jpegURL;
+@property (nonatomic, strong, readonly) NSURL *delayURL;
+- (NSURL *)URLWithStatusCode:(NSInteger)statusCode;
+
 @property (nonatomic, assign) NSTimeInterval networkTimeout;
 
 - (void)waitForExpectationsWithCommonTimeoutUsingHandler:(XCWaitCompletionHandler)handler;

--- a/Tests/Tests/AFTestCase.m
+++ b/Tests/Tests/AFTestCase.m
@@ -40,6 +40,22 @@ NSString * const AFNetworkingTestsBaseURLString = @"https://httpbin.org/";
     return [NSURL URLWithString:AFNetworkingTestsBaseURLString];
 }
 
+- (NSURL *)pngURL {
+    return [self.baseURL URLByAppendingPathComponent:@"image/png"];
+}
+
+- (NSURL *)jpegURL {
+    return [self.baseURL URLByAppendingPathComponent:@"image/jpeg"];
+}
+
+- (NSURL *)delayURL {
+    return [self.baseURL URLByAppendingPathComponent:@"delay/1"];
+}
+
+- (NSURL *)URLWithStatusCode:(NSInteger)statusCode {
+    return [self.baseURL URLByAppendingPathComponent:[NSString stringWithFormat:@"status/%@", @(statusCode)]];
+}
+
 - (void)waitForExpectationsWithCommonTimeoutUsingHandler:(XCWaitCompletionHandler)handler {
     [self waitForExpectationsWithTimeout:self.networkTimeout handler:handler];
 }

--- a/Tests/Tests/AFUIActivityIndicatorViewTests.m
+++ b/Tests/Tests/AFUIActivityIndicatorViewTests.m
@@ -34,7 +34,7 @@
 - (void)setUp {
     [super setUp];
     self.activityIndicatorView = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleWhite];
-    self.request = [NSURLRequest requestWithURL:[self.baseURL URLByAppendingPathComponent:@"delay/1"]];
+    self.request = [NSURLRequest requestWithURL:self.delayURL];
     self.sessionManager = [[AFURLSessionManager alloc] initWithSessionConfiguration:nil];
 }
 

--- a/Tests/Tests/AFUIButtonTests.m
+++ b/Tests/Tests/AFUIButtonTests.m
@@ -29,10 +29,8 @@
 @property (nonatomic, strong) NSURLRequest *cachedImageRequest;
 @property (nonatomic, strong) UIButton *button;
 
-@property (nonatomic, strong) NSURL *error404URL;
 @property (nonatomic, strong) NSURLRequest *error404URLRequest;
 
-@property (nonatomic, strong) NSURL *jpegURL;
 @property (nonatomic, strong) NSURLRequest *jpegURLRequest;
 @end
 
@@ -46,12 +44,9 @@
 
     self.button = [UIButton new];
 
-    self.jpegURL = [NSURL URLWithString:@"https://httpbin.org/image/jpeg"];
     self.jpegURLRequest = [NSURLRequest requestWithURL:self.jpegURL];
 
-    self.error404URL = [NSURL URLWithString:@"https://httpbin.org/status/404"];
-    self.error404URLRequest = [NSURLRequest requestWithURL:self.error404URL];
-
+    self.error404URLRequest = [NSURLRequest requestWithURL:[self URLWithStatusCode:404]];
 }
 
 - (void)tearDown {

--- a/Tests/Tests/AFUIImageViewTests.m
+++ b/Tests/Tests/AFUIImageViewTests.m
@@ -28,10 +28,8 @@
 @property (nonatomic, strong) NSURLRequest *cachedImageRequest;
 @property (nonatomic, strong) UIImageView *imageView;
 
-@property (nonatomic, strong) NSURL *error404URL;
 @property (nonatomic, strong) NSURLRequest *error404URLRequest;
 
-@property (nonatomic, strong) NSURL *jpegURL;
 @property (nonatomic, strong) NSURLRequest *jpegURLRequest;
 
 @end
@@ -46,12 +44,9 @@
 
     self.imageView = [UIImageView new];
 
-    self.jpegURL = [NSURL URLWithString:@"https://httpbin.org/image/jpeg"];
     self.jpegURLRequest = [NSURLRequest requestWithURL:self.jpegURL];
 
-    self.error404URL = [NSURL URLWithString:@"https://httpbin.org/status/404"];
-    self.error404URLRequest = [NSURLRequest requestWithURL:self.error404URL];
-
+    self.error404URLRequest = [NSURLRequest requestWithURL:[self URLWithStatusCode:404]];
 }
 
 - (void)tearDown {

--- a/Tests/Tests/AFUIRefreshControlTests.m
+++ b/Tests/Tests/AFUIRefreshControlTests.m
@@ -34,7 +34,7 @@
 - (void)setUp {
     [super setUp];
     self.refreshControl = [[UIRefreshControl alloc] init];
-    self.request = [NSURLRequest requestWithURL:[self.baseURL URLByAppendingPathComponent:@"delay/1"]];
+    self.request = [NSURLRequest requestWithURL:self.delayURL];
     self.sessionManager = [[AFURLSessionManager alloc] initWithSessionConfiguration:nil];
 }
 

--- a/Tests/Tests/AFUIWebViewTests.m
+++ b/Tests/Tests/AFUIWebViewTests.m
@@ -34,7 +34,7 @@
 - (void)setUp {
     [super setUp];
     self.webView = [UIWebView new];
-    self.HTMLRequest = [NSURLRequest requestWithURL:[NSURL URLWithString:@"https://httpbin.org/html"]];
+    self.HTMLRequest = [NSURLRequest requestWithURL:[self.baseURL URLByAppendingPathComponent:@"html"]];
 }
 
 - (void)testNilProgressDoesNotCauseCrash {

--- a/Tests/Tests/AFURLSessionManagerTests.m
+++ b/Tests/Tests/AFURLSessionManagerTests.m
@@ -441,7 +441,7 @@
 }
 
 - (NSURLRequest *)_delayURLRequest {
-    return [NSURLRequest requestWithURL:[self.baseURL URLByAppendingPathComponent:@"delay/1"]];
+    return [NSURLRequest requestWithURL:self.delayURL];
 }
 
 - (IMP)_implementationForTask:(NSURLSessionTask  *)task selector:(SEL)selector {


### PR DESCRIPTION
There was some repetition in URL creation for unit tests. Extracting the common URLs (png, jpeg, delay, status code) makes it easier run the test suites on a local copy of httpbin with the `python -m httpbin.core` command.