### PR TITLE
Fixed issue where UIWebView extension did not preserve all of the request information

### DIFF
--- a/Tests/Tests/AFUIWebViewTests.m
+++ b/Tests/Tests/AFUIWebViewTests.m
@@ -24,6 +24,7 @@
 #import "UIWebView+AFNetworking.h"
 
 @interface AFUIWebViewTests : AFTestCase
+
 @property (nonatomic, strong) UIWebView *webView;
 @property (nonatomic, strong) NSURLRequest *HTMLRequest;
 
@@ -80,6 +81,24 @@
     [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
 }
 
+- (void)testRequestWithCustomHeaders {
+    NSMutableURLRequest *customHeaderRequest = [NSMutableURLRequest requestWithURL:[self.baseURL URLByAppendingPathComponent:@"headers"]];
+    [customHeaderRequest setValue:@"Custom-Header-Value" forHTTPHeaderField:@"Custom-Header-Field"];
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Request should succeed"];
+    [self.webView
+     loadRequest:customHeaderRequest
+     progress:NULL
+     success:^NSString * _Nonnull(NSHTTPURLResponse * _Nonnull response, NSString * _Nonnull string) {
+         // Here string is actually JSON.
+         NSDictionary<NSString *, NSDictionary *> *responseObject = [NSJSONSerialization JSONObjectWithData:[string dataUsingEncoding:NSUTF8StringEncoding] options:(NSJSONReadingOptions)0 error:nil];
 
+         NSDictionary<NSString *, NSString *> *headers = responseObject[@"headers"];
+         XCTAssertTrue([headers[@"Custom-Header-Field"] isEqualToString:@"Custom-Header-Value"]);
+         [expectation fulfill];
+         return string;
+     }
+     failure:nil];
+    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+}
 
 @end

--- a/UIKit+AFNetworking/UIWebView+AFNetworking.m
+++ b/UIKit+AFNetworking/UIWebView+AFNetworking.m
@@ -119,27 +119,28 @@
     self.af_URLSessionTask = nil;
 
     __weak __typeof(self)weakSelf = self;
-    NSURLSessionDataTask *dataTask;
+    __block NSURLSessionDataTask *dataTask;
     dataTask = [self.sessionManager
-            GET:request.URL.absoluteString
-            parameters:nil
-            progress:nil
-            success:^(NSURLSessionDataTask * _Nonnull task, id  _Nonnull responseObject) {
-                __strong __typeof(weakSelf) strongSelf = weakSelf;
-                if (success) {
-                    success((NSHTTPURLResponse *)task.response, responseObject);
-                }
-                [strongSelf loadData:responseObject MIMEType:MIMEType textEncodingName:textEncodingName baseURL:[task.currentRequest URL]];
+                dataTaskWithRequest:request
+                uploadProgress:nil
+                downloadProgress:nil
+                completionHandler:^(NSURLResponse * _Nonnull response, id  _Nonnull responseObject, NSError * _Nullable error) {
+                    __strong __typeof(weakSelf) strongSelf = weakSelf;
+                    if (error) {
+                        if (failure) {
+                            failure(error);
+                        }
+                    } else {
+                        if (success) {
+                            success((NSHTTPURLResponse *)response, responseObject);
+                        }
+                        [strongSelf loadData:responseObject MIMEType:MIMEType textEncodingName:textEncodingName baseURL:[dataTask.currentRequest URL]];
 
-                if ([strongSelf.delegate respondsToSelector:@selector(webViewDidFinishLoad:)]) {
-                    [strongSelf.delegate webViewDidFinishLoad:strongSelf];
-                }
-            }
-            failure:^(NSURLSessionDataTask * _Nonnull task, NSError * _Nonnull error) {
-                if (failure) {
-                    failure(error);
-                }
-            }];
+                        if ([strongSelf.delegate respondsToSelector:@selector(webViewDidFinishLoad:)]) {
+                            [strongSelf.delegate webViewDidFinishLoad:strongSelf];
+                        }
+                    }
+                }];
     self.af_URLSessionTask = dataTask;
     if (progress != nil) {
         *progress = [self.sessionManager downloadProgressForTask:dataTask];


### PR DESCRIPTION
This should fix #3724 and any header-related issue in the future.

After this changes, the entire `request`, instead of only the `URL`, will be used to construct the `dataTask`.

Test case is added.