### PR TITLE
Add test method to wait for common timeout without handler

### DIFF
--- a/Tests/Tests/AFHTTPSessionManagerTests.m
+++ b/Tests/Tests/AFHTTPSessionManagerTests.m
@@ -239,7 +239,7 @@
      }
      success:nil
      failure:nil];
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 - (void)testUploadProgressIsReportedForPOST {
@@ -260,7 +260,7 @@
      }
      success:nil
      failure:nil];
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 - (void)testUploadProgressIsReportedForStreamingPost {
@@ -284,7 +284,7 @@
      }
      success:nil
      failure:nil];
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 # pragma mark - HTTP Status Codes
@@ -299,7 +299,7 @@
          [expectation fulfill];
      }
      failure:nil];
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 - (void)testThatFailureBlockIsCalledFor404 {
@@ -312,7 +312,7 @@
      failure:^(NSURLSessionDataTask * _Nullable task, NSError * _Nullable error) {
          [expectation fulfill];
      }];
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 - (void)testThatResponseObjectIsEmptyFor204 {
@@ -327,7 +327,7 @@
          [expectation fulfill];
      }
      failure:nil];
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
     XCTAssertNil(urlResponseObject);
 }
 
@@ -344,7 +344,7 @@
          [expectation fulfill];
      }
      failure:nil];
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 - (void)testHEAD {
@@ -357,7 +357,7 @@
          [expectation fulfill];
      }
      failure:nil];
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 - (void)testPOST {
@@ -371,7 +371,7 @@
          [expectation fulfill];
      }
      failure:nil];
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 - (void)testPOSTWithConstructingBody {
@@ -392,7 +392,7 @@
          [expectation fulfill];
      }
      failure:nil];
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 - (void)testPUT {
@@ -405,7 +405,7 @@
          [expectation fulfill];
      }
      failure:nil];
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 - (void)testDELETE {
@@ -418,7 +418,7 @@
          [expectation fulfill];
      }
      failure:nil];
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 - (void)testPATCH {
@@ -432,7 +432,7 @@
      }
      failure:nil];
 
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 #pragma mark - Deprecated Rest Interface
@@ -450,7 +450,7 @@
      }
      failure:nil];
 #pragma clang diagnostic pop
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 - (void)testDeprecatedPOST {
@@ -466,7 +466,7 @@
      }
      failure:nil];
 #pragma clang diagnostic pop
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 - (void)testDeprecatedPOSTWithConstructingBody {
@@ -489,7 +489,7 @@
      }
      failure:nil];
 #pragma clang diagnostic pop    
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 #pragma mark - Auth
@@ -507,7 +507,7 @@
          XCTFail(@"Request should succeed");
          [expectation fulfill];
      }];
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 # pragma mark - Security Policy
@@ -582,7 +582,7 @@
          XCTAssertEqual(error.code, NSURLErrorCancelled);
          [expectation fulfill];
      }];
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
     [manager invalidateSessionCancelingTasks:YES];
 }
 
@@ -606,7 +606,7 @@
          XCTAssertEqual(error.code, NSURLErrorCancelled);
          [expectation fulfill];
      }];
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
     [manager invalidateSessionCancelingTasks:YES];
 }
 

--- a/Tests/Tests/AFImageDownloaderTests.m
+++ b/Tests/Tests/AFImageDownloaderTests.m
@@ -80,7 +80,7 @@
                                                    XCTAssertTrue(error.code == NSURLErrorBadURL);
                                                    [expectation fulfill];
                                                }];
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
     XCTAssertNil(downloadReceipt, @"downloadReceipt should be nil");
 }
 
@@ -99,7 +99,7 @@
      }
      failure:nil];
 
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 
     XCTAssertNotNil(urlResponse, @"HTTPURLResponse should not be nil");
     XCTAssertNotNil(responseImage, @"Response image should not be nil");
@@ -132,7 +132,7 @@
      }
      failure:nil];
 
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 
     XCTAssertNotNil(urlResponse1, @"HTTPURLResponse should not be nil");
     XCTAssertNotNil(responseImage1, @"Respone image should not be nil");
@@ -168,7 +168,7 @@
      }
      failure:nil];
 
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 
     XCTAssertEqual(urlResponse1, urlResponse2, @"responses should be equal");
     XCTAssertEqual(responseImage2, responseImage2, @"responses should be equal");
@@ -190,7 +190,7 @@
          [expectation fulfill];
      }
      failure:nil];
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
     XCTAssertNotNil(urlResponse);
     XCTAssertNotNil(responseImage);
 
@@ -211,7 +211,7 @@
      }
      failure:nil];
 
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 
     XCTestExpectation *expectation2 = [self expectationWithDescription:@"image 2 download should succeed"];
     __block NSHTTPURLResponse *urlResponse2 = nil;
@@ -226,7 +226,7 @@
      }
      failure:nil];
 
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 
     XCTAssertNotNil(urlResponse1);
     XCTAssertNotNil(responseImage1);
@@ -244,7 +244,7 @@
                 }
                 failure:nil];
 
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 
     XCTestExpectation *expectation2 = [self expectationWithDescription:@"image 2 download should succeed"];
 
@@ -256,7 +256,7 @@
                 }
                 failure:nil];
 
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 
     XCTAssertNotNil(receipt1);
     XCTAssertNil(receipt2);
@@ -277,7 +277,7 @@
                 }
                 failure:nil];
 
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 
     XCTestExpectation *expectation2 = [self expectationWithDescription:@"image 2 download should succeed"];
     NSMutableURLRequest *alteredRequest = [self.pngRequest mutableCopy];
@@ -295,7 +295,7 @@
                 }
                 failure:nil];
 
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 
     XCTAssertNotNil(receipt1);
     XCTAssertNotNil(receipt2);
@@ -324,7 +324,7 @@
                    [expectation fulfill];
                }];
     [self.downloader cancelTaskForImageDownloadReceipt:receipt];
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 
     XCTAssertTrue(responseError.code == NSURLErrorCancelled);
     XCTAssertTrue([responseError.domain isEqualToString:NSURLErrorDomain]);
@@ -355,7 +355,7 @@
                    [expectation2 fulfill];
                }];
     [self.downloader cancelTaskForImageDownloadReceipt:receipt];
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 
     XCTAssertTrue(responseError.code == NSURLErrorCancelled);
     XCTAssertTrue([responseError.domain isEqualToString:NSURLErrorDomain]);
@@ -398,7 +398,7 @@
          }];
     }
 
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 #pragma mark - Threading
@@ -412,7 +412,7 @@
          [expectation fulfill];
      }
      failure:nil];
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
     XCTAssertTrue(successIsOnMainThread);
 }
 
@@ -427,7 +427,7 @@
          failureIsOnMainThread = [[NSThread currentThread] isMainThread];
          [expectation fulfill];
      }];
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
     XCTAssertTrue(failureIsOnMainThread);
 }
 

--- a/Tests/Tests/AFNetworkActivityManagerTests.m
+++ b/Tests/Tests/AFNetworkActivityManagerTests.m
@@ -74,7 +74,7 @@
          [requestExpectation fulfill];
      }
      failure:nil];
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 - (void)testThatNetworkActivityIndicatorTurnsOnAndOffIndicatorWhenRequestFails {
@@ -100,7 +100,7 @@
      failure:^(NSURLSessionDataTask * _Nullable task, NSError * _Nonnull error) {
          [requestExpectation fulfill];
      }];
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 - (void)testThatVisibilityDelaysAreApplied {
@@ -134,7 +134,7 @@
          [requestExpectation fulfill];
      }
      failure:nil];
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
     XCTAssertTrue((indicatorVisbleTime - requestStartTime) > self.networkActivityIndicatorManager.activationDelay);
     XCTAssertTrue((indicatorHiddenTime - requestEndTime) > self.networkActivityIndicatorManager.completionDelay);
 }
@@ -174,7 +174,7 @@
      }
      failure:nil];
 
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 
 }
 

--- a/Tests/Tests/AFNetworkReachabilityManagerTests.m
+++ b/Tests/Tests/AFNetworkReachabilityManagerTests.m
@@ -79,7 +79,7 @@
 
     [manager startMonitoring];
 
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 - (void)testAddressReachabilityNotification {
@@ -108,7 +108,7 @@
 
     [manager startMonitoring];
 
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
     [manager setReachabilityStatusChangeBlock:nil];
     
 }

--- a/Tests/Tests/AFTestCase.h
+++ b/Tests/Tests/AFTestCase.h
@@ -33,6 +33,7 @@ extern NSString * const AFNetworkingTestsBaseURLString;
 
 @property (nonatomic, assign) NSTimeInterval networkTimeout;
 
+- (void)waitForExpectationsWithCommonTimeout;
 - (void)waitForExpectationsWithCommonTimeoutUsingHandler:(XCWaitCompletionHandler)handler;
 
 @end

--- a/Tests/Tests/AFTestCase.m
+++ b/Tests/Tests/AFTestCase.m
@@ -56,6 +56,10 @@ NSString * const AFNetworkingTestsBaseURLString = @"https://httpbin.org/";
     return [self.baseURL URLByAppendingPathComponent:[NSString stringWithFormat:@"status/%@", @(statusCode)]];
 }
 
+- (void)waitForExpectationsWithCommonTimeout {
+    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+}
+
 - (void)waitForExpectationsWithCommonTimeoutUsingHandler:(XCWaitCompletionHandler)handler {
     [self waitForExpectationsWithTimeout:self.networkTimeout handler:handler];
 }

--- a/Tests/Tests/AFUIActivityIndicatorViewTests.m
+++ b/Tests/Tests/AFUIActivityIndicatorViewTests.m
@@ -59,7 +59,7 @@
     self.activityIndicatorView = nil;
     
     [task resume];
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
     [task cancel];
 }
 
@@ -84,7 +84,7 @@
     self.activityIndicatorView = nil;
     
     [task resume];
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
     [task cancel];
 }
 
@@ -110,7 +110,7 @@
     [task resume];
     [task suspend];
     [task resume];
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
     [task cancel];
 }
 

--- a/Tests/Tests/AFUIButtonTests.m
+++ b/Tests/Tests/AFUIButtonTests.m
@@ -66,7 +66,7 @@
               evaluatedWithObject:self.button
                           handler:nil];
     
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 - (void)testThatForegroundImageCanBeCancelledAndDownloadedImmediately {
@@ -84,7 +84,7 @@
          [expectation fulfill];
      }
      failure:nil];
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
     XCTAssertNotNil(responseImage);
 }
 
@@ -103,7 +103,7 @@
          [expectation fulfill];
      }
      failure:nil];
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
     XCTAssertNotNil(responseImage);
 }
 

--- a/Tests/Tests/AFUIImageViewTests.m
+++ b/Tests/Tests/AFUIImageViewTests.m
@@ -61,7 +61,7 @@
     [self expectationForPredicate:[NSPredicate predicateWithFormat:@"image != nil"]
               evaluatedWithObject:self.imageView
                           handler:nil];
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 - (void)testThatImageDownloadSucceedsWhenDuplicateRequestIsSentToImageView {
@@ -71,7 +71,7 @@
     [self expectationForPredicate:[NSPredicate predicateWithFormat:@"image != nil"]
               evaluatedWithObject:self.imageView
                           handler:nil];
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 - (void)testThatPlaceholderImageIsSetIfRequestFails {
@@ -84,7 +84,7 @@
                                    failure:^(NSURLRequest * _Nonnull request, NSHTTPURLResponse * _Nullable response, NSError * _Nonnull error) {
                                        [expectation fulfill];
                                    }];
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
     XCTAssertEqual(self.imageView.image, placeholder);
 }
 
@@ -99,7 +99,7 @@
          [cacheExpectation fulfill];
      }
      failure:nil];
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 
     __block UIImage *cachedImage = nil;
     __block NSHTTPURLResponse *urlResponse;
@@ -113,7 +113,7 @@
          [expectation fulfill];
      }
      failure:nil];
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
     XCTAssertNil(urlResponse);
     XCTAssertNotNil(cachedImage);
     XCTAssertEqual(cachedImage, downloadImage);
@@ -133,7 +133,7 @@
          [expectation fulfill];
      }
      failure:nil];
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
     XCTAssertNotNil(responseImage);
 }
 

--- a/Tests/Tests/AFUIRefreshControlTests.m
+++ b/Tests/Tests/AFUIRefreshControlTests.m
@@ -59,7 +59,7 @@
     self.refreshControl = nil;
     
     [task resume];
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
     [task cancel];
 }
 
@@ -83,7 +83,7 @@
     self.refreshControl = nil;
     
     [task resume];
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
     [task cancel];
 }
 
@@ -109,7 +109,7 @@
     [task resume];
     [task suspend];
     [task resume];
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
     [task cancel];
 }
 

--- a/Tests/Tests/AFUIWebViewTests.m
+++ b/Tests/Tests/AFUIWebViewTests.m
@@ -48,7 +48,7 @@
          return HTML;
      }
      failure:nil];
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 - (void)testNULLProgressDoesNotCauseCrash {
@@ -61,7 +61,7 @@
          return HTML;
      }
      failure:nil];
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 - (void)testProgressIsSet {
@@ -78,7 +78,7 @@
     [self keyValueObservingExpectationForObject:progress
                                         keyPath:@"fractionCompleted"
                                   expectedValue:@(1.0)];
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 - (void)testRequestWithCustomHeaders {
@@ -98,7 +98,7 @@
          return string;
      }
      failure:nil];
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 @end

--- a/Tests/Tests/AFURLSessionManagerTests.m
+++ b/Tests/Tests/AFURLSessionManagerTests.m
@@ -95,7 +95,7 @@
             completionHandler:nil];
     
     [task resume];
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 - (void)testDataTaskDownloadProgressCanBeKVOd {
@@ -115,7 +115,7 @@
                                                 return new == 1.0 && old != 0.0;
                                             }];
     [task resume];
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 - (void)testDownloadTaskDoesReportProgress {
@@ -131,7 +131,7 @@
             destination:nil
             completionHandler:nil];
     [task resume];
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 - (void)testUploadTaskDoesReportProgress {
@@ -158,7 +158,7 @@
             }
             completionHandler:nil];
     [task resume];
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 - (void)testUploadProgressCanBeKVOd {
@@ -182,7 +182,7 @@
     [self keyValueObservingExpectationForObject:uploadProgress keyPath:NSStringFromSelector(@selector(fractionCompleted)) expectedValue:@(1.0)];
 
     [task resume];
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 #pragma mark - rdar://17029580
@@ -210,7 +210,7 @@
             [expectation fulfill];
         });
     }
-    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 #pragma mark - Issue #2702 Tests


### PR DESCRIPTION
Since literally every call to `waitForExpectationsWithCommonTimeoutUsingHandler` is passing a `nil` parameter, I think there should be a convenient method for this. 

This simplify the waiting method when doing async test. I have a feeling that people would love this.