### PR TITLE
Enable custom httpbin URL with HTTPBIN_BASE_URL environment variable

### DIFF
--- a/AFNetworking.xcodeproj/xcshareddata/xcschemes/AFNetworking OS X.xcscheme
+++ b/AFNetworking.xcodeproj/xcshareddata/xcschemes/AFNetworking OS X.xcscheme
@@ -26,7 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldUseLaunchSchemeArgsEnv = "NO"
       codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
@@ -54,6 +54,13 @@
             ReferencedContainer = "container:AFNetworking.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "HTTPBIN_BASE_URL"
+            value = "http://127.0.0.1:5000"
+            isEnabled = "NO">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>

--- a/AFNetworking.xcodeproj/xcshareddata/xcschemes/AFNetworking iOS.xcscheme
+++ b/AFNetworking.xcodeproj/xcshareddata/xcschemes/AFNetworking iOS.xcscheme
@@ -40,7 +40,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldUseLaunchSchemeArgsEnv = "NO"
       codeCoverageEnabled = "YES"
       enableAddressSanitizer = "YES">
       <Testables>
@@ -69,6 +69,18 @@
             ReferencedContainer = "container:AFNetworking.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "OS_ACTIVITY_MODE"
+            value = "disable"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "HTTPBIN_BASE_URL"
+            value = "http://127.0.0.1:5000"
+            isEnabled = "NO">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>

--- a/AFNetworking.xcodeproj/xcshareddata/xcschemes/AFNetworking tvOS.xcscheme
+++ b/AFNetworking.xcodeproj/xcshareddata/xcschemes/AFNetworking tvOS.xcscheme
@@ -26,7 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldUseLaunchSchemeArgsEnv = "NO"
       enableAddressSanitizer = "YES">
       <Testables>
          <TestableReference
@@ -54,6 +54,18 @@
             ReferencedContainer = "container:AFNetworking.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "OS_ACTIVITY_MODE"
+            value = "disable"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "HTTPBIN_BASE_URL"
+            value = "http://127.0.0.1:5000"
+            isEnabled = "NO">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <AdditionalOptions>
          <AdditionalOption
             key = "NSZombieEnabled"

--- a/Tests/Tests/AFJSONSerializationTests.m
+++ b/Tests/Tests/AFJSONSerializationTests.m
@@ -45,7 +45,7 @@ static NSData * AFJSONTestData() {
 - (void)testThatJSONRequestSerializationHandlesParametersDictionary {
     NSDictionary *parameters = @{@"key":@"value"};
     NSError *error = nil;
-    NSMutableURLRequest *request = [self.requestSerializer requestWithMethod:@"POST" URLString:AFNetworkingTestsBaseURLString parameters:parameters error:&error];
+    NSMutableURLRequest *request = [self.requestSerializer requestWithMethod:@"POST" URLString:self.baseURL.absoluteString parameters:parameters error:&error];
 
     XCTAssertNil(error, @"Serialization error should be nil");
 
@@ -57,7 +57,7 @@ static NSData * AFJSONTestData() {
 - (void)testThatJSONRequestSerializationHandlesParametersArray {
     NSArray *parameters = @[@{@"key":@"value"}];
     NSError *error = nil;
-    NSMutableURLRequest *request = [self.requestSerializer requestWithMethod:@"POST" URLString:AFNetworkingTestsBaseURLString parameters:parameters error:&error];
+    NSMutableURLRequest *request = [self.requestSerializer requestWithMethod:@"POST" URLString:self.baseURL.absoluteString parameters:parameters error:&error];
 
     XCTAssertNil(error, @"Serialization error should be nil");
 
@@ -71,7 +71,7 @@ static NSData * AFJSONTestData() {
     
     NSDictionary *parameters = @{@"key":string};
     NSError *error = nil;
-    NSMutableURLRequest *request = [self.requestSerializer requestWithMethod:@"POST" URLString:AFNetworkingTestsBaseURLString parameters:parameters error:&error];
+    NSMutableURLRequest *request = [self.requestSerializer requestWithMethod:@"POST" URLString:self.baseURL.absoluteString parameters:parameters error:&error];
     
     XCTAssertNil(request, @"Expected nil request.");
     XCTAssertNotNil(error, @"Expected non-nil error.");
@@ -80,7 +80,7 @@ static NSData * AFJSONTestData() {
 - (void)testThatJSONRequestSerializationErrorsWithInvalidJSON {
     NSDictionary *parameters = @{@"key":[NSSet setWithObject:@"value"]};
     NSError *error = nil;
-    NSMutableURLRequest *request = [self.requestSerializer requestWithMethod:@"POST" URLString:AFNetworkingTestsBaseURLString parameters:parameters error:&error];
+    NSMutableURLRequest *request = [self.requestSerializer requestWithMethod:@"POST" URLString:self.baseURL.absoluteString parameters:parameters error:&error];
     
     XCTAssertNil(request, @"Request should be nil");
     XCTAssertNotNil(error, @"Serialization error should be not nil");

--- a/Tests/Tests/AFPropertyListRequestSerializerTests.m
+++ b/Tests/Tests/AFPropertyListRequestSerializerTests.m
@@ -39,7 +39,7 @@
 - (void)testThatPropertyListRequestSerializerAcceptsPlist {
     NSDictionary *parameters = @{@"key":@"value"};
     NSError *error = nil;
-    NSMutableURLRequest *request = [self.requestSerializer requestWithMethod:@"POST" URLString:AFNetworkingTestsBaseURLString parameters:parameters error:&error];
+    NSMutableURLRequest *request = [self.requestSerializer requestWithMethod:@"POST" URLString:self.baseURL.absoluteString parameters:parameters error:&error];
     
     XCTAssertNotNil(request, @"Expected non-nil request.");
 }
@@ -47,7 +47,7 @@
 - (void)testThatPropertyListRequestSerializerHandlesInvalidPlist {
     NSDictionary *parameters = @{@42:@"value"};
     NSError *error = nil;
-    NSMutableURLRequest *request = [self.requestSerializer requestWithMethod:@"POST" URLString:AFNetworkingTestsBaseURLString parameters:parameters error:&error];
+    NSMutableURLRequest *request = [self.requestSerializer requestWithMethod:@"POST" URLString:self.baseURL.absoluteString parameters:parameters error:&error];
     
     XCTAssertNil(request, @"Expected nil request.");
     XCTAssertNotNil(error, @"Expected non-nil error.");

--- a/Tests/Tests/AFTestCase.h
+++ b/Tests/Tests/AFTestCase.h
@@ -21,8 +21,6 @@
 
 #import <XCTest/XCTest.h>
 
-extern NSString * const AFNetworkingTestsBaseURLString;
-
 @interface AFTestCase : XCTestCase
 
 @property (nonatomic, strong, readonly) NSURL *baseURL;

--- a/Tests/Tests/AFTestCase.m
+++ b/Tests/Tests/AFTestCase.m
@@ -21,8 +21,6 @@
 
 #import "AFTestCase.h"
 
-NSString * const AFNetworkingTestsBaseURLString = @"https://httpbin.org/";
-
 @implementation AFTestCase
 
 - (void)setUp {
@@ -37,7 +35,8 @@ NSString * const AFNetworkingTestsBaseURLString = @"https://httpbin.org/";
 #pragma mark -
 
 - (NSURL *)baseURL {
-    return [NSURL URLWithString:AFNetworkingTestsBaseURLString];
+    NSDictionary *environment = [[NSProcessInfo processInfo] environment];
+    return [NSURL URLWithString:environment[@"HTTPBIN_BASE_URL"] ?: @"https://httpbin.org"];
 }
 
 - (NSURL *)pngURL {


### PR DESCRIPTION
Editing the scheme and checking the `HTTPBIN_BASE_URL` box enables running the test suites on a default local installation of httpbin.