### PR TITLE
Clarify documentation for supported encodings in AFJSONResponseSerializer

### DIFF
--- a/AFNetworking/AFURLResponseSerialization.h
+++ b/AFNetworking/AFURLResponseSerialization.h
@@ -109,7 +109,7 @@ NS_ASSUME_NONNULL_BEGIN
  - `text/json`
  - `text/javascript`
 
- In RFC 7159 - Section 8.1, it states that JSON text is required to be encoded in UTF-8, UTF-16, or UTF-32, and the default encoding is UTF-8. NSJSONSerialization provides support for all the encodings listed in the specification, and recommends UTF-8 for efficiency. Using unsupported encoding will result in serialization error. See the `NSJSONSerialization` documentation for more details.
+ In RFC 7159 - Section 8.1, it states that JSON text is required to be encoded in UTF-8, UTF-16, or UTF-32, and the default encoding is UTF-8. NSJSONSerialization provides support for all the encodings listed in the specification, and recommends UTF-8 for efficiency. Using an unsupported encoding will result in serialization error. See the `NSJSONSerialization` documentation for more details.
  */
 @interface AFJSONResponseSerializer : AFHTTPResponseSerializer
 

--- a/AFNetworking/AFURLResponseSerialization.h
+++ b/AFNetworking/AFURLResponseSerialization.h
@@ -109,7 +109,7 @@ NS_ASSUME_NONNULL_BEGIN
  - `text/json`
  - `text/javascript`
 
- According to RFC 4627, JSON text should be encoded in Unicode and the default encoding is UTF-8. NSJSONSerialization also recommends using UTF-8 for efficiency, even though it actually supports more encodings. Using unsupported encoding will result in serialization error. See the `NSJSONSerialization` documentation for more details.
+ In RFC 7159 - Section 8.1, it states that JSON text is required to be encoded in UTF-8, UTF-16, or UTF-32, and the default encoding is UTF-8. NSJSONSerialization provides support for all the encodings listed in the specification, and recommends UTF-8 for efficiency. Using unsupported encoding will result in serialization error. See the `NSJSONSerialization` documentation for more details.
  */
 @interface AFJSONResponseSerializer : AFHTTPResponseSerializer
 

--- a/AFNetworking/AFURLResponseSerialization.h
+++ b/AFNetworking/AFURLResponseSerialization.h
@@ -108,6 +108,8 @@ NS_ASSUME_NONNULL_BEGIN
  - `application/json`
  - `text/json`
  - `text/javascript`
+
+ According to RFC 4627, JSON text should be encoded in Unicode and the default encoding is UTF-8. NSJSONSerialization also recommends using UTF-8 for efficiency, even though it actually supports more encodings. Using unsupported encoding will result in serialization error. See the `NSJSONSerialization` documentation for more details.
  */
 @interface AFJSONResponseSerializer : AFHTTPResponseSerializer
 


### PR DESCRIPTION
This clarify the data encoding needed for `AFJSONResponseSerializer` to successfully parsing the response as JSON object. 
