### PR TITLE
Deprecate the unused stringEncoding property of AFHTTPResponseSerializer

### DIFF
--- a/AFNetworking/AFURLResponseSerialization.h
+++ b/AFNetworking/AFURLResponseSerialization.h
@@ -57,10 +57,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init;
 
-/**
- The string encoding used to serialize data received from the server, when no string encoding is specified by the response. `NSUTF8StringEncoding` by default.
- */
-@property (nonatomic, assign) NSStringEncoding stringEncoding;
+@property (nonatomic, assign) NSStringEncoding stringEncoding DEPRECATED_MSG_ATTRIBUTE("The string encoding is never used. AFHTTPResponseSerializer only validates status codes and content types but does not try to decode the received data in any way.");
 
 /**
  Creates and returns a serializer with default configuration.

--- a/AFNetworking/AFURLResponseSerialization.m
+++ b/AFNetworking/AFURLResponseSerialization.m
@@ -97,8 +97,6 @@ static id AFJSONObjectByRemovingKeysWithNullValues(id JSONObject, NSJSONReadingO
         return nil;
     }
 
-    self.stringEncoding = NSUTF8StringEncoding;
-
     self.acceptableStatusCodes = [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(200, 100)];
     self.acceptableContentTypes = nil;
 


### PR DESCRIPTION
The `stringEncoding` property is never used. It was probably inroduced by error in 9a40c0dc0f27e9a547fb173a0b1b5a06072e91f9. It was probably a copy/paste error as the same property also exists on `AFHTTPRequestSerializer` where it’s actually used.