### PR TITLE
Search for default pinned certificates in the main bundle

### DIFF
--- a/AFNetworking/AFSecurityPolicy.h
+++ b/AFNetworking/AFSecurityPolicy.h
@@ -45,10 +45,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  The certificates used to evaluate server trust according to the SSL pinning mode. 
-
-  By default, this property is set to any (`.cer`) certificates included in the target compiling AFNetworking. Note that if you are using AFNetworking as embedded framework, no certificates will be pinned by default. Use `certificatesInBundle` to load certificates from your target, and then create a new policy by calling `policyWithPinningMode:withPinnedCertificates`.
  
  Note that if pinning is enabled, `evaluateServerTrust:forDomain:` will return true if any pinned certificate matches.
+
+ @see policyWithPinningMode:withPinnedCertificates:
  */
 @property (nonatomic, strong, nullable) NSSet <NSData *> *pinnedCertificates;
 
@@ -90,10 +90,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Creates and returns a security policy with the specified pinning mode.
+ 
+ Certificates with the `.cer` extension found in the main bundle will be pinned. If you want more control over which certificates are pinned, please use `policyWithPinningMode:withPinnedCertificates:` instead.
 
  @param pinningMode The SSL pinning mode.
 
  @return A new security policy.
+
+ @see -policyWithPinningMode:withPinnedCertificates:
  */
 + (instancetype)policyWithPinningMode:(AFSSLPinningMode)pinningMode;
 
@@ -104,7 +108,10 @@ NS_ASSUME_NONNULL_BEGIN
  @param pinnedCertificates The certificates to pin against.
 
  @return A new security policy.
- */
+
+ @see +certificatesInBundle:
+ @see -pinnedCertificates
+*/
 + (instancetype)policyWithPinningMode:(AFSSLPinningMode)pinningMode withPinnedCertificates:(NSSet <NSData *> *)pinnedCertificates;
 
 ///------------------------------

--- a/AFNetworking/AFSecurityPolicy.m
+++ b/AFNetworking/AFSecurityPolicy.m
@@ -158,17 +158,6 @@ static NSArray * AFPublicKeyTrustChainForServerTrust(SecTrustRef serverTrust) {
     return [NSSet setWithSet:certificates];
 }
 
-+ (NSSet *)defaultPinnedCertificates {
-    static NSSet *_defaultPinnedCertificates = nil;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        NSBundle *bundle = [NSBundle bundleForClass:[self class]];
-        _defaultPinnedCertificates = [self certificatesInBundle:bundle];
-    });
-
-    return _defaultPinnedCertificates;
-}
-
 + (instancetype)defaultPolicy {
     AFSecurityPolicy *securityPolicy = [[self alloc] init];
     securityPolicy.SSLPinningMode = AFSSLPinningModeNone;
@@ -177,7 +166,8 @@ static NSArray * AFPublicKeyTrustChainForServerTrust(SecTrustRef serverTrust) {
 }
 
 + (instancetype)policyWithPinningMode:(AFSSLPinningMode)pinningMode {
-    return [self policyWithPinningMode:pinningMode withPinnedCertificates:[self defaultPinnedCertificates]];
+    NSSet <NSData *> *defaultPinnedCertificates = [self certificatesInBundle:[NSBundle mainBundle]];
+    return [self policyWithPinningMode:pinningMode withPinnedCertificates:defaultPinnedCertificates];
 }
 
 + (instancetype)policyWithPinningMode:(AFSSLPinningMode)pinningMode withPinnedCertificates:(NSSet *)pinnedCertificates {


### PR DESCRIPTION
Using `[NSBundle bundleForClass:[self class]]` is dangerous because the code will behave differently depending on how AFNetworking is integrated.
- If it is integrated as a static library (for example using CocoaPods), certificates will be searched in the main bundle.
- If it is integrated as a framework (for example using Carthage), certificates will be searched in the AFNetworking framework.

Even though this behavior is documented, this is dangerous. Using the main bundle makes the behavior deterministic.

Fixes #3575
