### PR TITLE
Add XMLParser/XMLDocument serializer tests

### DIFF
--- a/AFNetworking.xcodeproj/project.pbxproj
+++ b/AFNetworking.xcodeproj/project.pbxproj
@@ -173,6 +173,10 @@
 		29D96E991BCC406B00F571A5 /* UIImageView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 299522931BBF13C700859F49 /* UIImageView+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		29D96E9A1BCC406B00F571A5 /* UIProgressView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 299522961BBF13C700859F49 /* UIProgressView+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		29F5EF031C47E64F008B976A /* AFUIWebViewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 29F5EF021C47E64F008B976A /* AFUIWebViewTests.m */; };
+		2D4563901DB1179D00AE4812 /* AFXMLParserResponseSerializerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D45638F1DB1179D00AE4812 /* AFXMLParserResponseSerializerTests.m */; };
+		2D4563911DB117A200AE4812 /* AFXMLParserResponseSerializerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D45638F1DB1179D00AE4812 /* AFXMLParserResponseSerializerTests.m */; };
+		2D4563921DB117A200AE4812 /* AFXMLParserResponseSerializerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D45638F1DB1179D00AE4812 /* AFXMLParserResponseSerializerTests.m */; };
+		2D4563941DB11DDB00AE4812 /* AFXMLDocumentResponseSerializerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D4563931DB11DDB00AE4812 /* AFXMLDocumentResponseSerializerTests.m */; };
 		5F4323BB1BF63741003B8749 /* Equifax_Secure_Certificate_Authority_Root.cer in Resources */ = {isa = PBXBuildFile; fileRef = 5F4323B31BF63741003B8749 /* Equifax_Secure_Certificate_Authority_Root.cer */; };
 		5F4323BC1BF63741003B8749 /* Equifax_Secure_Certificate_Authority_Root.cer in Resources */ = {isa = PBXBuildFile; fileRef = 5F4323B31BF63741003B8749 /* Equifax_Secure_Certificate_Authority_Root.cer */; };
 		5F4323BD1BF63741003B8749 /* Equifax_Secure_Certificate_Authority_Root.cer in Resources */ = {isa = PBXBuildFile; fileRef = 5F4323B31BF63741003B8749 /* Equifax_Secure_Certificate_Authority_Root.cer */; };
@@ -297,6 +301,8 @@
 		2995229B1BBF13C700859F49 /* UIWebView+AFNetworking.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIWebView+AFNetworking.m"; sourceTree = "<group>"; };
 		29D3413E1C20D46400A7D266 /* AFCompoundResponseSerializerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFCompoundResponseSerializerTests.m; sourceTree = "<group>"; };
 		29F5EF021C47E64F008B976A /* AFUIWebViewTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFUIWebViewTests.m; sourceTree = "<group>"; };
+		2D45638F1DB1179D00AE4812 /* AFXMLParserResponseSerializerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFXMLParserResponseSerializerTests.m; sourceTree = "<group>"; };
+		2D4563931DB11DDB00AE4812 /* AFXMLDocumentResponseSerializerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFXMLDocumentResponseSerializerTests.m; sourceTree = "<group>"; };
 		5F4323B31BF63741003B8749 /* Equifax_Secure_Certificate_Authority_Root.cer */ = {isa = PBXFileReference; lastKnownFileType = file; path = Equifax_Secure_Certificate_Authority_Root.cer; sourceTree = "<group>"; };
 		5F4323B41BF63741003B8749 /* GeoTrust_Global_CA-cross.cer */ = {isa = PBXFileReference; lastKnownFileType = file; path = "GeoTrust_Global_CA-cross.cer"; sourceTree = "<group>"; };
 		5F4323B51BF63741003B8749 /* google.com.cer */ = {isa = PBXFileReference; lastKnownFileType = file; path = google.com.cer; sourceTree = "<group>"; };
@@ -434,6 +440,8 @@
 				298D7C821BC2C88F00FD3B3E /* AFHTTPResponseSerializationTests.m */,
 				298D7C831BC2C88F00FD3B3E /* AFHTTPSessionManagerTests.m */,
 				298D7C851BC2C88F00FD3B3E /* AFJSONSerializationTests.m */,
+				2D45638F1DB1179D00AE4812 /* AFXMLParserResponseSerializerTests.m */,
+				2D4563931DB11DDB00AE4812 /* AFXMLDocumentResponseSerializerTests.m */,
 				298D7C881BC2C88F00FD3B3E /* AFPropertyListResponseSerializerTests.m */,
 				E91164641DA6A7AE00DFFF56 /* AFPropertyListRequestSerializerTests.m */,
 				29D3413E1C20D46400A7D266 /* AFCompoundResponseSerializerTests.m */,
@@ -967,6 +975,7 @@
 				2987B0CF1BC40A7600179A4C /* AFPropertyListResponseSerializerTests.m in Sources */,
 				2987B0D21BC40AD800179A4C /* AFTestCase.m in Sources */,
 				2987B0CD1BC40A7600179A4C /* AFJSONSerializationTests.m in Sources */,
+				2D4563921DB117A200AE4812 /* AFXMLParserResponseSerializerTests.m in Sources */,
 				E91164671DA6A7AE00DFFF56 /* AFPropertyListRequestSerializerTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -992,6 +1001,7 @@
 				298D7C981BC2CA2500FD3B3E /* AFURLSessionManagerTests.m in Sources */,
 				297824AC1BC2DB450041C395 /* AFImageDownloaderTests.m in Sources */,
 				29F5EF031C47E64F008B976A /* AFUIWebViewTests.m in Sources */,
+				2D4563901DB1179D00AE4812 /* AFXMLParserResponseSerializerTests.m in Sources */,
 				298D7CD51BC2CAEC00FD3B3E /* AFHTTPSessionManagerTests.m in Sources */,
 				298D7CD71BC2CAEF00FD3B3E /* AFJSONSerializationTests.m in Sources */,
 				298D7CDB1BC2CAF500FD3B3E /* AFPropertyListResponseSerializerTests.m in Sources */,
@@ -1010,8 +1020,10 @@
 				1BF9F9611C87843200F1F35A /* AFImageResponseSerializerTests.m in Sources */,
 				298D7C971BC2C94500FD3B3E /* AFTestCase.m in Sources */,
 				298D7CD81BC2CAF000FD3B3E /* AFJSONSerializationTests.m in Sources */,
+				2D4563941DB11DDB00AE4812 /* AFXMLDocumentResponseSerializerTests.m in Sources */,
 				298D7CDC1BC2CAF500FD3B3E /* AFPropertyListResponseSerializerTests.m in Sources */,
 				298D7CD61BC2CAED00FD3B3E /* AFHTTPSessionManagerTests.m in Sources */,
+				2D4563911DB117A200AE4812 /* AFXMLParserResponseSerializerTests.m in Sources */,
 				298D7CDA1BC2CAF300FD3B3E /* AFNetworkReachabilityManagerTests.m in Sources */,
 				298D7C991BC2CA2600FD3B3E /* AFURLSessionManagerTests.m in Sources */,
 			);

--- a/AFNetworking/AFURLResponseSerialization.h
+++ b/AFNetworking/AFURLResponseSerialization.h
@@ -163,7 +163,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 
 /**
- Input and output options specifically intended for `NSXMLDocument` objects. For possible values, see the `NSJSONSerialization` documentation section "NSJSONReadingOptions". `0` by default.
+ Input and output options specifically intended for `NSXMLDocument` objects. For possible values, see the `NSXMLDocument` documentation section "Input and Output Options". `0` by default.
  */
 @property (nonatomic, assign) NSUInteger options;
 

--- a/Tests/Tests/AFXMLDocumentResponseSerializerTests.m
+++ b/Tests/Tests/AFXMLDocumentResponseSerializerTests.m
@@ -45,7 +45,7 @@ static NSData * AFXMLTestData() {
     self.responseSerializer = [AFXMLDocumentResponseSerializer serializer];
 }
 
-- (void)testThatXMLDocumentResponseSerializerAccpetsApplicationXMLMimeType {
+- (void)testThatXMLDocumentResponseSerializerAcceptsApplicationXMLMimeType {
     NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:self.baseURL statusCode:200 HTTPVersion:@"1.1" headerFields:@{@"Content-Type": @"application/xml"}];
     NSError *error = nil;
     [self.responseSerializer validateResponse:response data:AFXMLTestData() error:&error];
@@ -53,7 +53,7 @@ static NSData * AFXMLTestData() {
     XCTAssertNil(error, @"Error handling application/xml");
 }
 
-- (void)testThatXMLDocumentResponseSerializerAccpetsTextXMLMimeType {
+- (void)testThatXMLDocumentResponseSerializerAcceptsTextXMLMimeType {
     NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:self.baseURL statusCode:200 HTTPVersion:@"1.1" headerFields:@{@"Content-Type": @"text/xml"}];
     NSError *error = nil;
     [self.responseSerializer validateResponse:response data:AFXMLTestData() error:&error];
@@ -61,7 +61,7 @@ static NSData * AFXMLTestData() {
     XCTAssertNil(error, @"Error handling text/xml");
 }
 
-- (void)testThatXMLDocumentResponseSerializerDoesNotAcceptNonStandardXMLMimeType {
+- (void)testThatXMLDocumentResponseSerializerDoesNotAcceptsNonStandardXMLMimeType {
     NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:self.baseURL statusCode:200 HTTPVersion:@"1.1" headerFields:@{@"Content-Type": @"nonstandard/xml"}];
     NSError *error = nil;
     [self.responseSerializer validateResponse:response data:AFXMLTestData() error:&error];

--- a/Tests/Tests/AFXMLDocumentResponseSerializerTests.m
+++ b/Tests/Tests/AFXMLDocumentResponseSerializerTests.m
@@ -1,0 +1,101 @@
+// AFXMLDocumentResponseSerializerTests.m
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "AFTestCase.h"
+
+#import "AFURLRequestSerialization.h"
+#import "AFURLResponseSerialization.h"
+
+#import <XCTest/XCTest.h>
+
+static NSData * AFXMLTestData() {
+    return [@"<?xml version=\"1.0\" encoding=\"UTF-8\"?><foo attr1=\"1\" attr2=\"2\"><bar>someValue</bar></foo>" dataUsingEncoding:NSUTF8StringEncoding];
+}
+
+#pragma mark -
+
+@interface AFXMLDocumentResponseSerializerTests : AFTestCase
+@property (nonatomic, strong) AFXMLDocumentResponseSerializer *responseSerializer;
+@end
+
+#pragma mark -
+
+@implementation AFXMLDocumentResponseSerializerTests
+
+- (void)setUp {
+    [super setUp];
+    self.responseSerializer = [AFXMLDocumentResponseSerializer serializer];
+}
+
+- (void)testThatXMLDocumentResponseSerializerAccpetsApplicationXMLMimeType {
+    NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:self.baseURL statusCode:200 HTTPVersion:@"1.1" headerFields:@{@"Content-Type": @"application/xml"}];
+    NSError *error = nil;
+    [self.responseSerializer validateResponse:response data:AFXMLTestData() error:&error];
+
+    XCTAssertNil(error, @"Error handling application/xml");
+}
+
+- (void)testThatXMLDocumentResponseSerializerAccpetsTextXMLMimeType {
+    NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:self.baseURL statusCode:200 HTTPVersion:@"1.1" headerFields:@{@"Content-Type": @"text/xml"}];
+    NSError *error = nil;
+    [self.responseSerializer validateResponse:response data:AFXMLTestData() error:&error];
+
+    XCTAssertNil(error, @"Error handling text/xml");
+}
+
+- (void)testThatXMLDocumentResponseSerializerDoesNotAcceptNonStandardXMLMimeType {
+    NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:self.baseURL statusCode:200 HTTPVersion:@"1.1" headerFields:@{@"Content-Type": @"nonstandard/xml"}];
+    NSError *error = nil;
+    [self.responseSerializer validateResponse:response data:AFXMLTestData() error:&error];
+
+    XCTAssertNotNil(error, @"Error should have been thrown for nonstandard/xml");
+}
+
+- (void)testThatXMLDocumentResponseSerializerReturnsNSXMLDocumentObjectForValidXML {
+    NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:self.baseURL statusCode:200 HTTPVersion:@"1.1" headerFields:@{@"Content-Type": @"application/xml"}];
+    NSError *error = nil;
+    id responseObject = [self.responseSerializer responseObjectForResponse:response data:AFXMLTestData() error:&error];
+
+    XCTAssertNil(error, @"Serialization error should be nil");
+    XCTAssert([responseObject isKindOfClass:[NSXMLDocument class]], @"Expected response to be a NSXMLDocument");
+}
+
+- (void)testThatXMLDocumentResponseSerializerReturnsErrorForInvalidXML {
+    NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:self.baseURL statusCode:200 HTTPVersion:@"1.1" headerFields:@{@"Content-Type": @"application/xml"}];
+    NSError *error = nil;
+    [self.responseSerializer responseObjectForResponse:response data:[@"<foo" dataUsingEncoding:NSUTF8StringEncoding] error:&error];
+
+    XCTAssertNotNil(error, @"Serialization error should be nil");
+}
+
+- (void)testThatXMLDocumentResponseSerializerCanBeCopied {
+    [self.responseSerializer setAcceptableStatusCodes:[NSIndexSet indexSetWithIndex:100]];
+    [self.responseSerializer setAcceptableContentTypes:[NSSet setWithObject:@"test/type"]];
+
+    [self.responseSerializer setOptions:1];
+    AFXMLDocumentResponseSerializer *copiedSerializer = [self.responseSerializer copy];
+    XCTAssertNotEqual(copiedSerializer, self.responseSerializer);
+    XCTAssertEqual(copiedSerializer.acceptableStatusCodes, self.responseSerializer.acceptableStatusCodes);
+    XCTAssertEqual(copiedSerializer.acceptableContentTypes, self.responseSerializer.acceptableContentTypes);
+    XCTAssertEqual(copiedSerializer.options, self.responseSerializer.options);
+}
+
+@end

--- a/Tests/Tests/AFXMLDocumentResponseSerializerTests.m
+++ b/Tests/Tests/AFXMLDocumentResponseSerializerTests.m
@@ -83,7 +83,7 @@ static NSData * AFXMLTestData() {
     NSError *error = nil;
     [self.responseSerializer responseObjectForResponse:response data:[@"<foo" dataUsingEncoding:NSUTF8StringEncoding] error:&error];
 
-    XCTAssertNotNil(error, @"Serialization error should be nil");
+    XCTAssertNotNil(error, @"Serialization error should not be nil");
 }
 
 - (void)testThatXMLDocumentResponseSerializerCanBeCopied {

--- a/Tests/Tests/AFXMLParserResponseSerializerTests.m
+++ b/Tests/Tests/AFXMLParserResponseSerializerTests.m
@@ -1,0 +1,89 @@
+// AFXMLParserResponseSerializerTests.m
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "AFTestCase.h"
+
+#import "AFURLRequestSerialization.h"
+#import "AFURLResponseSerialization.h"
+
+static NSData * AFXMLTestData() {
+    return [@"<?xml version=\"1.0\" encoding=\"UTF-8\"?><foo attr1=\"1\" attr2=\"2\"><bar>someValue</bar></foo>" dataUsingEncoding:NSUTF8StringEncoding];
+}
+
+#pragma mark -
+
+@interface AFXMLParserResponseSerializerTests : AFTestCase
+@property (nonatomic, strong) AFXMLParserResponseSerializer *responseSerializer;
+@end
+
+#pragma mark -
+
+@implementation AFXMLParserResponseSerializerTests
+
+- (void)setUp {
+    [super setUp];
+    self.responseSerializer = [AFXMLParserResponseSerializer serializer];
+}
+
+- (void)testThatXMLParserResponseSerializerAccpetsApplicationXMLMimeType {
+    NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:self.baseURL statusCode:200 HTTPVersion:@"1.1" headerFields:@{@"Content-Type": @"application/xml"}];
+    NSError *error = nil;
+    [self.responseSerializer validateResponse:response data:AFXMLTestData() error:&error];
+
+    XCTAssertNil(error, @"Error handling application/xml");
+}
+
+- (void)testThatXMLParserResponseSerializerAccpetsTextXMLMimeType {
+    NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:self.baseURL statusCode:200 HTTPVersion:@"1.1" headerFields:@{@"Content-Type": @"text/xml"}];
+    NSError *error = nil;
+    [self.responseSerializer validateResponse:response data:AFXMLTestData() error:&error];
+
+    XCTAssertNil(error, @"Error handling text/xml");
+}
+
+- (void)testThatXMLParserResponseSerializerDoesNotAcceptNonStandardXMLMimeType {
+    NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:self.baseURL statusCode:200 HTTPVersion:@"1.1" headerFields:@{@"Content-Type": @"nonstandard/xml"}];
+    NSError *error = nil;
+    [self.responseSerializer validateResponse:response data:AFXMLTestData() error:&error];
+
+    XCTAssertNotNil(error, @"Error should have been thrown for nonstandard/xml");
+}
+
+- (void)testThatXMLParserResponseSerializerReturnsNSXMLParserObjectForValidXML {
+    NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:self.baseURL statusCode:200 HTTPVersion:@"1.1" headerFields:@{@"Content-Type": @"application/xml"}];
+    NSError *error = nil;
+    id responseObject = [self.responseSerializer responseObjectForResponse:response data:AFXMLTestData() error:&error];
+
+    XCTAssertNil(error, @"Serialization error should be nil");
+    XCTAssert([responseObject isKindOfClass:[NSXMLParser class]], @"Expected response to be a NSXMLParser");
+}
+
+- (void)testThatXMLParserResponseSerializerCanBeCopied {
+    [self.responseSerializer setAcceptableStatusCodes:[NSIndexSet indexSetWithIndex:100]];
+    [self.responseSerializer setAcceptableContentTypes:[NSSet setWithObject:@"test/type"]];
+
+    AFXMLParserResponseSerializer *copiedSerializer = [self.responseSerializer copy];
+    XCTAssertNotEqual(copiedSerializer, self.responseSerializer);
+    XCTAssertEqual(copiedSerializer.acceptableStatusCodes, self.responseSerializer.acceptableStatusCodes);
+    XCTAssertEqual(copiedSerializer.acceptableContentTypes, self.responseSerializer.acceptableContentTypes);
+}
+
+@end

--- a/Tests/Tests/AFXMLParserResponseSerializerTests.m
+++ b/Tests/Tests/AFXMLParserResponseSerializerTests.m
@@ -43,7 +43,7 @@ static NSData * AFXMLTestData() {
     self.responseSerializer = [AFXMLParserResponseSerializer serializer];
 }
 
-- (void)testThatXMLParserResponseSerializerAccpetsApplicationXMLMimeType {
+- (void)testThatXMLParserResponseSerializerAcceptsApplicationXMLMimeType {
     NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:self.baseURL statusCode:200 HTTPVersion:@"1.1" headerFields:@{@"Content-Type": @"application/xml"}];
     NSError *error = nil;
     [self.responseSerializer validateResponse:response data:AFXMLTestData() error:&error];
@@ -51,7 +51,7 @@ static NSData * AFXMLTestData() {
     XCTAssertNil(error, @"Error handling application/xml");
 }
 
-- (void)testThatXMLParserResponseSerializerAccpetsTextXMLMimeType {
+- (void)testThatXMLParserResponseSerializerAcceptsTextXMLMimeType {
     NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:self.baseURL statusCode:200 HTTPVersion:@"1.1" headerFields:@{@"Content-Type": @"text/xml"}];
     NSError *error = nil;
     [self.responseSerializer validateResponse:response data:AFXMLTestData() error:&error];
@@ -59,7 +59,7 @@ static NSData * AFXMLTestData() {
     XCTAssertNil(error, @"Error handling text/xml");
 }
 
-- (void)testThatXMLParserResponseSerializerDoesNotAcceptNonStandardXMLMimeType {
+- (void)testThatXMLParserResponseSerializerDoesNotAcceptsNonStandardXMLMimeType {
     NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:self.baseURL statusCode:200 HTTPVersion:@"1.1" headerFields:@{@"Content-Type": @"nonstandard/xml"}];
     NSError *error = nil;
     [self.responseSerializer validateResponse:response data:AFXMLTestData() error:&error];


### PR DESCRIPTION
Inspired by 290ec35a4a9101322253f05d2c1e1319e9b4b248, this adds tests for `AFXMLParserResponseSerializer` and `AFXMLDocumentResponseSerializer`. This also fixes an error in `AFXMLDocumentResponseSerializer` documentation.
