### PR TITLE
Added startRequestsImmediately to AFHTTPSessionManager

### DIFF
--- a/AFNetworking/AFHTTPSessionManager.h
+++ b/AFNetworking/AFHTTPSessionManager.h
@@ -103,6 +103,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, strong) AFSecurityPolicy *securityPolicy;
 
+/**
+ Whether to start requests immediately after being constructed. 'YES' by default.
+ */
+@property (nonatomic, assign) BOOL startRequestsImmediately;
+
 ///---------------------
 /// @name Initialization
 ///---------------------

--- a/AFNetworking/AFHTTPSessionManager.m
+++ b/AFNetworking/AFHTTPSessionManager.m
@@ -356,6 +356,7 @@
     if (decodedPolicy) {
         self.securityPolicy = decodedPolicy;
     }
+    self.startRequestsImmediately = [decoder decodeBoolForKey:NSStringFromSelector(@selector(startRequestsImmediately))];
 
     return self;
 }
@@ -372,6 +373,7 @@
     [coder encodeObject:self.requestSerializer forKey:NSStringFromSelector(@selector(requestSerializer))];
     [coder encodeObject:self.responseSerializer forKey:NSStringFromSelector(@selector(responseSerializer))];
     [coder encodeObject:self.securityPolicy forKey:NSStringFromSelector(@selector(securityPolicy))];
+    [coder encodeBool:self.startRequestsImmediately forKey:NSStringFromSelector(@selector(startRequestsImmediately))];
 }
 
 #pragma mark - NSCopying

--- a/AFNetworking/AFHTTPSessionManager.m
+++ b/AFNetworking/AFHTTPSessionManager.m
@@ -81,6 +81,8 @@
     self.requestSerializer = [AFHTTPRequestSerializer serializer];
     self.responseSerializer = [AFJSONResponseSerializer serializer];
 
+    self.startRequestsImmediately = YES;
+    
     return self;
 }
 
@@ -141,8 +143,10 @@
                                                           success:success
                                                           failure:failure];
 
-    [dataTask resume];
-
+    if (self.startRequestsImmediately) {
+        [dataTask resume];
+    }
+    
     return dataTask;
 }
 
@@ -157,8 +161,10 @@
         }
     } failure:failure];
 
-    [dataTask resume];
-
+    if (self.startRequestsImmediately) {
+        [dataTask resume];
+    }
+    
     return dataTask;
 }
 
@@ -178,8 +184,10 @@
 {
     NSURLSessionDataTask *dataTask = [self dataTaskWithHTTPMethod:@"POST" URLString:URLString parameters:parameters uploadProgress:uploadProgress downloadProgress:nil success:success failure:failure];
 
-    [dataTask resume];
-
+    if (self.startRequestsImmediately) {
+        [dataTask resume];
+    }
+    
     return dataTask;
 }
 
@@ -222,9 +230,11 @@
             }
         }
     }];
-
-    [task resume];
-
+    
+    if (self.startRequestsImmediately) {
+        [task resume];
+    }
+    
     return task;
 }
 
@@ -235,8 +245,10 @@
 {
     NSURLSessionDataTask *dataTask = [self dataTaskWithHTTPMethod:@"PUT" URLString:URLString parameters:parameters uploadProgress:nil downloadProgress:nil success:success failure:failure];
 
-    [dataTask resume];
-
+    if (self.startRequestsImmediately) {
+        [dataTask resume];
+    }
+    
     return dataTask;
 }
 
@@ -247,8 +259,10 @@
 {
     NSURLSessionDataTask *dataTask = [self dataTaskWithHTTPMethod:@"PATCH" URLString:URLString parameters:parameters uploadProgress:nil downloadProgress:nil success:success failure:failure];
 
-    [dataTask resume];
-
+    if (self.startRequestsImmediately) {
+        [dataTask resume];
+    }
+    
     return dataTask;
 }
 
@@ -259,8 +273,10 @@
 {
     NSURLSessionDataTask *dataTask = [self dataTaskWithHTTPMethod:@"DELETE" URLString:URLString parameters:parameters uploadProgress:nil downloadProgress:nil success:success failure:failure];
 
-    [dataTask resume];
-
+    if (self.startRequestsImmediately) {
+        [dataTask resume];
+    }
+    
     return dataTask;
 }
 

--- a/Tests/Tests/AFHTTPSessionManagerTests.m
+++ b/Tests/Tests/AFHTTPSessionManagerTests.m
@@ -196,6 +196,43 @@
     [self waitForExpectationsWithTimeout:10.0 handler:nil];
 }
 
+- (void)testStartRequestsImmediatelyDefaultResumesTaskForGET {
+    NSURLSessionDataTask *dataTask = [self.manager GET:@"get"
+                                            parameters:nil
+                                              progress:nil
+                                               success:nil
+                                               failure:nil];
+    XCTAssertEqual(dataTask.state, NSURLSessionTaskStateRunning);
+}
+
+- (void)testStartRequestsImmediatelyFalseDoesNotResumeTaskForGET {
+    self.manager.startRequestsImmediately = NO;
+    NSURLSessionDataTask *dataTask = [self.manager GET:@"get"
+                                            parameters:nil
+                                              progress:nil
+                                               success:nil
+                                               failure:nil];
+    XCTAssertEqual(dataTask.state, NSURLSessionTaskStateSuspended);
+}
+
+- (void)testStartRequestImmediatelyChangedForGET {
+    self.manager.startRequestsImmediately = YES;
+    NSURLSessionDataTask *resumedDataTask = [self.manager GET:@"get"
+                                                   parameters:nil
+                                                     progress:nil
+                                                      success:nil
+                                                      failure:nil];
+    XCTAssertEqual(resumedDataTask.state, NSURLSessionTaskStateRunning);
+    
+    self.manager.startRequestsImmediately = NO;
+    NSURLSessionDataTask *suspendedDataTask = [self.manager GET:@"get"
+                                                     parameters:nil
+                                                       progress:nil
+                                                        success:nil
+                                                        failure:nil];
+    XCTAssertEqual(suspendedDataTask.state, NSURLSessionTaskStateSuspended);
+}
+
 #pragma mark - NSCoding
 
 - (void)testSupportsSecureCoding {


### PR DESCRIPTION
Added `startRequestsImmediately` to give the option of not resuming the data tasks immediately for HTTP requests.

I tried to mirror the implementation in Alamofire.