### PR TITLE
Add sender object when posting AFNetworkingReachabilityDidChangeNotification

### DIFF
--- a/AFNetworking/AFNetworkReachabilityManager.h
+++ b/AFNetworking/AFNetworkReachabilityManager.h
@@ -45,6 +45,11 @@ NS_ASSUME_NONNULL_BEGIN
 @interface AFNetworkReachabilityManager : NSObject
 
 /**
+ The underlying network reachability (can be used to listen for specific AFNetworkingReachabilityDidChangeNotification notifications)
+ */
+@property (readonly, nonatomic, assign) SCNetworkReachabilityRef networkReachability;
+
+/**
  The current network reachability status.
  */
 @property (readonly, nonatomic, assign) AFNetworkReachabilityStatus networkReachabilityStatus;


### PR DESCRIPTION
## Description
This PR attempts to fix issue #2970 

When an app handles several `AFReachabilityManager` and uses `AFNetworkingReachabilityDidChangeNotification` at the same time, it is not possible to identify what manager is posting the notifications.

With proposed changes, object that act as sender of notifications is the underlying `SCNetworkReachabilityRef` of each manager (I have chosen this object because of practical reasons, as it was already available from callers of method `AFPostReachabilityStatusChange`). This object has been exposed in header file as readonly so it can be used to listen for specific notifications.