### PR TITLE
Fixed a warning when linking from an app extension

### DIFF
--- a/AFNetworking.xcodeproj/project.pbxproj
+++ b/AFNetworking.xcodeproj/project.pbxproj
@@ -1370,6 +1370,7 @@
 		299522421BBF104D00859F49 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				BITCODE_GENERATION_MODE = marker;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -1392,6 +1393,7 @@
 		299522431BBF104D00859F49 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				BITCODE_GENERATION_MODE = bitcode;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";


### PR DESCRIPTION
When an app extension was using the framework built by `carthage` there
was a warning "linking against a dylib which is not safe for use in
application extensions".

This build setting makes linker much happier and mitigates the warning.

Fixes #3398 on iOS