### PR TITLE
AFJSONObjectByRemovingKeysWithNullValues use less memory

### DIFF
--- a/AFNetworking/AFURLResponseSerialization.m
+++ b/AFNetworking/AFURLResponseSerialization.m
@@ -69,7 +69,7 @@ static id AFJSONObjectByRemovingKeysWithNullValues(id JSONObject, NSJSONReadingO
 
         return (readingOptions & NSJSONReadingMutableContainers) ? mutableArray : [NSArray arrayWithArray:mutableArray];
     } else if ([JSONObject isKindOfClass:[NSDictionary class]]) {
-        NSMutableDictionary *mutableDictionary = [NSMutableDictionary dictionaryWithDictionary:JSONObject];
+        NSMutableDictionary *mutableDictionary = (readingOptions & NSJSONReadingMutableContainers) == NSJSONReadingMutableContainers ? JSONObject : [NSMutableDictionary dictionaryWithDictionary:JSONObject];
         for (id <NSCopying> key in [(NSDictionary *)JSONObject allKeys]) {
             id value = (NSDictionary *)JSONObject[key];
             if (!value || [value isEqual:[NSNull null]]) {


### PR DESCRIPTION
There's no need to create a mutable dictionary if it is already. 
This saves a lot of memory especially with big responses.