### PR TITLE
AFURLRequestSerialization: use dispatch_barrier_sync for header changes

### DIFF
--- a/AFNetworking/AFURLRequestSerialization.m
+++ b/AFNetworking/AFURLRequestSerialization.m
@@ -312,7 +312,7 @@ static void *AFHTTPRequestSerializerObserverContext = &AFHTTPRequestSerializerOb
 - (void)setValue:(NSString *)value
 forHTTPHeaderField:(NSString *)field
 {
-    dispatch_barrier_async(self.requestHeaderModificationQueue, ^{
+    dispatch_barrier_sync(self.requestHeaderModificationQueue, ^{
         [self.mutableHTTPRequestHeaders setValue:value forKey:field];
     });
 }


### PR DESCRIPTION
This fixes a rare crash in the async block, which I believe occurs when the block was invoked async _after_ the object had already been deallocated.

fixes #3636

cc #3526 @aopod @alexbird 