### PR TITLE
Fix objects array serialization

### DIFF
--- a/AFNetworking/AFURLRequestSerialization.m
+++ b/AFNetworking/AFURLRequestSerialization.m
@@ -145,7 +145,7 @@ NSArray * AFQueryStringPairsFromKeyAndValue(NSString *key, id value) {
         }
     } else if ([value isKindOfClass:[NSArray class]]) {
         NSArray *array = value;
-	NSUInteger i = 0
+	NSUInteger i = 0;
         for (id nestedValue in array) {
             [mutableQueryStringComponents addObjectsFromArray:AFQueryStringPairsFromKeyAndValue([NSString stringWithFormat:@"%@[%d]", key, i++], nestedValue)];
         }

--- a/AFNetworking/AFURLRequestSerialization.m
+++ b/AFNetworking/AFURLRequestSerialization.m
@@ -147,7 +147,7 @@ NSArray * AFQueryStringPairsFromKeyAndValue(NSString *key, id value) {
         NSArray *array = value;
 	NSUInteger i = 0;
         for (id nestedValue in array) {
-            [mutableQueryStringComponents addObjectsFromArray:AFQueryStringPairsFromKeyAndValue([NSString stringWithFormat:@"%@[%d]", key, (unsigned long)i++], nestedValue)];
+            [mutableQueryStringComponents addObjectsFromArray:AFQueryStringPairsFromKeyAndValue([NSString stringWithFormat:@"%@[%ld]", key, (unsigned long)i++], nestedValue)];
         }
     } else if ([value isKindOfClass:[NSSet class]]) {
         NSSet *set = value;

--- a/AFNetworking/AFURLRequestSerialization.m
+++ b/AFNetworking/AFURLRequestSerialization.m
@@ -145,8 +145,9 @@ NSArray * AFQueryStringPairsFromKeyAndValue(NSString *key, id value) {
         }
     } else if ([value isKindOfClass:[NSArray class]]) {
         NSArray *array = value;
+	NSUInteger i = 0
         for (id nestedValue in array) {
-            [mutableQueryStringComponents addObjectsFromArray:AFQueryStringPairsFromKeyAndValue([NSString stringWithFormat:@"%@[]", key], nestedValue)];
+            [mutableQueryStringComponents addObjectsFromArray:AFQueryStringPairsFromKeyAndValue([NSString stringWithFormat:@"%@[%d]", key, i++], nestedValue)];
         }
     } else if ([value isKindOfClass:[NSSet class]]) {
         NSSet *set = value;

--- a/AFNetworking/AFURLRequestSerialization.m
+++ b/AFNetworking/AFURLRequestSerialization.m
@@ -147,7 +147,7 @@ NSArray * AFQueryStringPairsFromKeyAndValue(NSString *key, id value) {
         NSArray *array = value;
 	NSUInteger i = 0;
         for (id nestedValue in array) {
-            [mutableQueryStringComponents addObjectsFromArray:AFQueryStringPairsFromKeyAndValue([NSString stringWithFormat:@"%@[%d]", key, i++], nestedValue)];
+            [mutableQueryStringComponents addObjectsFromArray:AFQueryStringPairsFromKeyAndValue([NSString stringWithFormat:@"%@[%d]", key, (unsigned long)i++], nestedValue)];
         }
     } else if ([value isKindOfClass:[NSSet class]]) {
         NSSet *set = value;


### PR DESCRIPTION
Assuming the following data structure :
{ "clients" : [ { "id" : "abc", "age" : 32, "name" : Bob } , { "id" : "def", "age" : 43, "name" : "Alice" } ] }

The serialized request was :

clients[][id]=abc
clients[][age]=32
clients[][name]=Bob
clients[][id]=def
clients[][age]=43
clients[][name]=Alice

After modification, it'll send :

clients[0][id]=abc
clients[0][age]=32
clients[0][name]=Bob
clients[1][id]=def
clients[1][age]=43
clients[1][name]=Alice