### PR TITLE
Fix CHANGELOG formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,7 +173,7 @@ For detailed information about migrating to AFNetworking 3.0.0, please reference
  * Implemented by Kevin Harwood in [#3034](https://github.com/AFNetworking/AFNetworking/pull/3034).
 
 
-##[2.6.3](https://github.com/AFNetworking/AFNetworking/releases/tag/2.6.3) (11/11/2015)
+## [2.6.3](https://github.com/AFNetworking/AFNetworking/releases/tag/2.6.3) (11/11/2015)
 Released on Wednesday, November 11, 2015. All issues associated with this milestone can be found using this [filter](https://github.com/AFNetworking/AFNetworking/issues?q=milestone%3A2.6.3+is%3Aclosed).
 
 #### Fixed
@@ -183,7 +183,7 @@ Released on Wednesday, November 11, 2015. All issues associated with this milest
  * Fixed by [jcayzac](https://github.com/jcayzac) in [#3139](https://github.com/AFNetworking/AFNetworking/pull/3139).
  
 
-##[2.6.2](https://github.com/AFNetworking/AFNetworking/releases/tag/2.6.2) (11/06/2015)
+## [2.6.2](https://github.com/AFNetworking/AFNetworking/releases/tag/2.6.2) (11/06/2015)
 Released on Friday, November 06, 2015. All issues associated with this milestone can be found using this [filter](https://github.com/AFNetworking/AFNetworking/issues?q=milestone%3A2.6.2+is%3Aclosed).
 
 ### Important Upgrade Note for Swift
@@ -225,10 +225,10 @@ Released on Friday, November 06, 2015. All issues associated with this milestone
 ## [2.6.1](https://github.com/AFNetworking/AFNetworking/releases/tag/2.6.1) (10-13-2015)
 Released on Tuesday, October 13th, 2015. All issues associated with this milestone can be found using this [filter](https://github.com/AFNetworking/AFNetworking/issues?q=milestone%3A2.6.1+is%3Aclosed).
 
-###Future Compatibility Note
+### Future Compatibility Note
 Note that AFNetworking 3.0 will soon be released, and will drop support for all `NSURLConnection` based API's (`AFHTTPRequestOperationManager`, `AFHTTPRequestOperation`, and `AFURLConnectionOperation`. If you have not already migrated to `NSURLSession` based API's, please do so soon. For more information, please see the [3.0 migration guide](https://github.com/AFNetworking/AFNetworking/wiki/AFNetworking-3.0-Migration-Guide).
 
-####Fixed
+#### Fixed
 * Fixed a bug that prevented empty x-www-form-urlencoded bodies.
 	* Fixed by [Julien Cayzac](https://github.com/jcayzac) in [#2868](https://github.com/AFNetworking/AFNetworking/pull/2868).
 * Fixed bug that prevented AFNetworking from being installed for watchOS via Cocoapods.
@@ -253,7 +253,7 @@ Note that AFNetworking 3.0 will soon be released, and will drop support for all 
 ## [2.6.0](https://github.com/AFNetworking/AFNetworking/releases/tag/2.6.0) (08-19-2015)
 Released on Wednesday, August 19th, 2015. All issues associated with this milestone can be found using this [filter](https://github.com/AFNetworking/AFNetworking/issues?q=milestone%3A2.6.0+is%3Aclosed).
 
-###Important Upgrade Notes
+### Important Upgrade Notes
 Please note the following API/project changes have been made:
 
 * iOS 6 and OS X 10.8 support has been dropped from the project to facilitate support for watchOS 2. The final release supporting iOS 6 and OS X 10.8 is 2.5.4.
@@ -280,7 +280,7 @@ Please note the following API/project changes have been made:
 
 **Note** that support for `NSURLConnection` based API's will be removed in a future update. If you have not already done so, it is recommended that you transition to the `NSURLSession` APIs in the very near future.
 
-####Added
+#### Added
 * Added watchOS 2.0 support. `AFNetworking` can now be added to watchOS targets using CocoaPods.
 	* Added by [Kevin Harwood](https://github.com/Kevin Harwood) in [#2837](https://github.com/AFNetworking/AFNetworking/issues/2837).
 * Added nullability annotations to all of the header files to improve Swift interoperability.
@@ -290,7 +290,7 @@ Please note the following API/project changes have been made:
 * Improved memory performance when download large objects.
 	* Fixed by [Gabe Zabrino](https://github.com/gfzabarino) and [Kevin Harwood](https://github.com/Kevin Harwood) in [#2672](https://github.com/AFNetworking/AFNetworking/pull/2672).
 
-####Fixed
+#### Fixed
 * Fixed a crash related for objects that observe notifications but don't properly unregister.
 	* Fixed by [Kevin Harwood](https://github.com/Kevin Harwood) and [bnickle](https://github.com/bnickel) in [#2741](https://github.com/AFNetworking/AFNetworking/pull/2741).
 * Fixed a race condition crash that occured with `AFImageResponseSerialization`.
@@ -306,7 +306,7 @@ Please note the following API/project changes have been made:
 * Fixed potential memory leak in `AFNetworkReachabilityManager`.
 	* Fixed by [Julien Cayzac](https://github.com/jcayzac) in [#2867](https://github.com/AFNetworking/AFNetworking/pull/2867).
 
-####Documentation Improvements
+#### Documentation Improvements
 * Clarified best practices for Reachability per Apple recommendations.
 	* Fixed by [Steven Fisher](https://github.com/tewha) in [#2704](https://github.com/AFNetworking/AFNetworking/pull/2704).
 * Added `startMonitoring` call to the Reachability section of the README
@@ -319,11 +319,11 @@ Please note the following API/project changes have been made:
 ## [2.5.4](https://github.com/AFNetworking/AFNetworking/releases/tag/2.5.4) (2015-05-14)
 Released on 2015-05-14. All issues associated with this milestone can be found using this [filter](https://github.com/AFNetworking/AFNetworking/issues?q=milestone%3A2.5.4+is%3Aclosed).
 
-####Updated
+#### Updated
 * Updated the CI test script to run iOS tests on all versions of iOS that are installed on the build machine.
 	* Updated by [Kevin Harwood](https://github.com/Kevin Harwood) in [#2716](https://github.com/AFNetworking/AFNetworking/pull/2716).
 	
-####Fixed
+#### Fixed
 
 * Fixed an issue where `AFNSURLSessionTaskDidResumeNotification` and `AFNSURLSessionTaskDidSuspendNotification` were not being properly called due to implementation differences in `NSURLSessionTask` in iOS 7 and iOS 8, which also affects the `AFNetworkActivityIndicatorManager`. 
 	* Fixed by [Kevin Harwood](https://github.com/Kevin Harwood) in [#2702](https://github.com/AFNetworking/AFNetworking/pull/2702).
@@ -1065,7 +1065,7 @@ calls (Mindaugas Vaičiūnas)
 
   * Update files to remove executable privilege (Kyle Fuller)
 
-## 2.0.1 (2013-10-10)
+## [2.0.1](https://github.com/AFNetworking/AFNetworking/releases/tag/2.0.1) (2013-10-10)
 
  * Fix iOS 6 compatibility (Matt Baker, Mattt Thompson)
 
@@ -1769,7 +1769,7 @@ Steven Fisher)
 renamed to `numberOfFinishedOperations` (Mattt Thompson)
 
 
-## 0.10.0 / 2012-06-26
+## [0.10.0](https://github.com/AFNetworking/AFNetworking/releases/tag/0.10.0) / 2012-06-26
 
  * Add Twitter Mac Example application (Mattt Thompson)
 
@@ -1834,7 +1834,7 @@ renamed to `numberOfFinishedOperations` (Mattt Thompson)
  * Fix AFHTTPClient to not add unnecessary data when constructing multipart form
  request with nil parameters (Taeho Kim)
 
-## 1.0RC1 / 2012-04-25
+## [1.0RC1](https://github.com/AFNetworking/AFNetworking/releases/tag/1.0RC1) / 2012-04-25
 
  * Add `AFHTTPRequestOperation +addAcceptableStatusCodes /
 +addAcceptableContentTypes` to dynamically add acceptable status codes and
@@ -1854,7 +1854,7 @@ Mattt Thompson)
 distinction between WWan and WiFi reachability (Kevin Harwood, Mattt Thompson)
 
 
-## 0.9.2 / 2012-04-25
+## [0.9.2](https://github.com/AFNetworking/AFNetworking/releases/tag/0.9.2) / 2012-04-25
 
  * Add thread safety to `AFNetworkActivityIndicator` (Peter Steinberger, Mattt
 Thompson)
@@ -1899,7 +1899,7 @@ Mattt Thompson)
  * Remove @try-@catch block wrapping network thread entry point (Charles T. Ahn)
 
 
-## 0.9.1 / 2012-03-19
+## [0.9.1](https://github.com/AFNetworking/AFNetworking/releases/tag/0.9.1) / 2012-03-19
 
  * Create Twitter example application (Mattt Thompson)
 
@@ -1957,7 +1957,7 @@ where % is used as a literal rather than as part of a percent escape code
 `AFImageRequestOperation` (Michael Schneider)
 
 
-## 0.9.0 / 2012-01-23
+## [0.9.0](https://github.com/AFNetworking/AFNetworking/releases/tag/0.9.0) / 2012-01-23
 
  * Add thread-safe behavior to `AFURLConnectionOperation` (Mattt Thompson)
 


### PR DESCRIPTION
* Fix header formatting (requires space between `#` and header text)
* Add missing links to release tags for some older versions