### PR TITLE
UIImageView and UIButton setImageWithURL: internally uses requestSerializer

### DIFF
--- a/UIKit+AFNetworking/AFImageDownloader.m
+++ b/UIKit+AFNetworking/AFImageDownloader.m
@@ -145,6 +145,7 @@
     NSURLSessionConfiguration *defaultConfiguration = [self.class defaultURLSessionConfiguration];
     AFHTTPSessionManager *sessionManager = [[AFHTTPSessionManager alloc] initWithSessionConfiguration:defaultConfiguration];
     sessionManager.responseSerializer = [AFImageResponseSerializer serializer];
+    [sessionManager.requestSerializer setValue:@"image/*" forHTTPHeaderField:@"Accept"];
 
     return [self initWithSessionManager:sessionManager
                  downloadPrioritization:AFImageDownloadPrioritizationFIFO

--- a/UIKit+AFNetworking/UIButton+AFNetworking.m
+++ b/UIKit+AFNetworking/UIButton+AFNetworking.m
@@ -122,6 +122,11 @@ static const char * af_backgroundImageDownloadReceiptKeyForState(UIControlState 
                  withURL:(NSURL *)url
         placeholderImage:(UIImage *)placeholderImage
 {
+    if (!url) {
+        [self setImage:placeholderImage forState:state];
+        return;
+    }
+    
     AFHTTPRequestSerializer <AFURLRequestSerialization> * requestSerializer = [[self class] sharedImageDownloader].sessionManager.requestSerializer;
     NSURLRequest *request = [requestSerializer requestWithMethod:@"GET" URLString:url.absoluteString parameters:nil error:nil];
 

--- a/UIKit+AFNetworking/UIButton+AFNetworking.m
+++ b/UIKit+AFNetworking/UIButton+AFNetworking.m
@@ -122,8 +122,8 @@ static const char * af_backgroundImageDownloadReceiptKeyForState(UIControlState 
                  withURL:(NSURL *)url
         placeholderImage:(UIImage *)placeholderImage
 {
-    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
-    [request addValue:@"image/*" forHTTPHeaderField:@"Accept"];
+    AFHTTPRequestSerializer <AFURLRequestSerialization> * requestSerializer = [[self class] sharedImageDownloader].sessionManager.requestSerializer;
+    NSURLRequest *request = [requestSerializer requestWithMethod:@"GET" URLString:url.absoluteString parameters:nil error:nil];
 
     [self setImageForState:state withURLRequest:request placeholderImage:placeholderImage success:nil failure:nil];
 }

--- a/UIKit+AFNetworking/UIImageView+AFNetworking.m
+++ b/UIKit+AFNetworking/UIImageView+AFNetworking.m
@@ -64,8 +64,8 @@
 - (void)setImageWithURL:(NSURL *)url
        placeholderImage:(UIImage *)placeholderImage
 {
-    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
-    [request addValue:@"image/*" forHTTPHeaderField:@"Accept"];
+    AFHTTPRequestSerializer <AFURLRequestSerialization> * requestSerializer = [[self class] sharedImageDownloader].sessionManager.requestSerializer;
+    NSURLRequest *request = [requestSerializer requestWithMethod:@"GET" URLString:url.absoluteString parameters:nil error:nil];
 
     [self setImageWithURLRequest:request placeholderImage:placeholderImage success:nil failure:nil];
 }

--- a/UIKit+AFNetworking/UIImageView+AFNetworking.m
+++ b/UIKit+AFNetworking/UIImageView+AFNetworking.m
@@ -64,6 +64,11 @@
 - (void)setImageWithURL:(NSURL *)url
        placeholderImage:(UIImage *)placeholderImage
 {
+    if (!url) {
+        self.image = placeholderImage;
+        return;
+    }
+    
     AFHTTPRequestSerializer <AFURLRequestSerialization> * requestSerializer = [[self class] sharedImageDownloader].sessionManager.requestSerializer;
     NSURLRequest *request = [requestSerializer requestWithMethod:@"GET" URLString:url.absoluteString parameters:nil error:nil];
 


### PR DESCRIPTION
### Overview
`UIImageView` and `UIButton` both have categories with method `-setImageWithURL:placeholderImage:` (and shortcut `setImageWithURL:`).This method is building new `NSMutableURLRequest` and manually setting `Accept: image/*` header.

### Problems
1. It is impossible to customise HTTP headers and other request properties (e.g. cache policy etc.) globally for all images downloaded using the category
    - Only solution is to implement custom category always building custom request
2. All Image requests done using this convenience method have only basic `Accept: image/*`
3. Requests done using the method ignore even the `AFNetworking`'s basic default HTTP headers like `User-Agent`

### Suggestion / solution
IMHO the request done using the convenience method should be using request serializer of session manager used for this request (`[class sharedImageDownloader].sessionManager.requestSerializer`).
That way it is possible have global configuration for all image requests done using this method.

This change allows configuration like this:
```
AFHTTPRequestSerializer <AFURLRequestSerialization> * requestSerializer = [[UIImageView class] sharedImageDownloader].sessionManager.requestSerializer;
[requestSerializer setValue:customHeader forHTTPHeaderField:@"MyCustomValue"];
requestSerializer.cachePolicy = NSURLRequestReloadIgnoringCacheData;
```
(Please note that this is just an example. Turning off image cache completely might not very desirable 😃 )

### Compatibility
Without explicitly opting in by customising request serializer, the solution should work just as before the change. The same default `Accept` header is set, just on different place (removed duplication).

---

### Feedback welcome
Please note I opened this PR mainly as suggestion / base for discussion. I'd like to hear your opinion if my thinking about it is right.