### PR TITLE
Fix imageRequestCancel bug.

### DIFF
--- a/AFNetworking/AFURLResponseSerialization.h
+++ b/AFNetworking/AFURLResponseSerialization.h
@@ -239,7 +239,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) CGFloat imageScale;
 
 /**
- Whether to automatically inflate response image data for compressed formats (such as PNG or JPEG or GIFs). Enabling this can significantly improve drawing performance on iOS when used with `setCompletionBlockWithSuccess:failure:`, as it allows a bitmap representation to be constructed in the background rather than on the main thread. `YES` by default.
+ Whether to automatically inflate response image data for compressed formats (such as PNG, JPEG or GIF). Enabling this can significantly improve drawing performance on iOS when used with `setCompletionBlockWithSuccess:failure:`, as it allows a bitmap representation to be constructed in the background rather than on the main thread. `YES` by default.
  */
 @property (nonatomic, assign) BOOL automaticallyInflatesResponseImage;
 #endif

--- a/AFNetworking/AFURLResponseSerialization.h
+++ b/AFNetworking/AFURLResponseSerialization.h
@@ -239,7 +239,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) CGFloat imageScale;
 
 /**
- Whether to automatically inflate response image data for compressed formats (such as PNG or JPEG). Enabling this can significantly improve drawing performance on iOS when used with `setCompletionBlockWithSuccess:failure:`, as it allows a bitmap representation to be constructed in the background rather than on the main thread. `YES` by default.
+ Whether to automatically inflate response image data for compressed formats (such as PNG or JPEG or GIFs). Enabling this can significantly improve drawing performance on iOS when used with `setCompletionBlockWithSuccess:failure:`, as it allows a bitmap representation to be constructed in the background rather than on the main thread. `YES` by default.
  */
 @property (nonatomic, assign) BOOL automaticallyInflatesResponseImage;
 #endif

--- a/AFNetworking/AFURLResponseSerialization.m
+++ b/AFNetworking/AFURLResponseSerialization.m
@@ -615,26 +615,17 @@ static UIImage * AFInflatedImageFromResponseWithDataAtScale(NSHTTPURLResponse *r
         CGDataProviderRelease(dataProvider);
     } else if ([response.MIMEType isEqualToString:@"image/gif"]) {
         CGImageSourceRef source = CGImageSourceCreateWithData((__bridge CFDataRef)data, NULL);
-        
         size_t count = CGImageSourceGetCount(source);
-        
         UIImage *gifImage;
         
-        if (count <= 1) {
-            gifImage = [[UIImage alloc] initWithData:data];
-        }else{
+        if (count > 1) {
             NSMutableArray *images = [NSMutableArray array];
-            
             NSTimeInterval duration = 0.0f;
             
             for (size_t i = 0; i < count; i++) {
                 CGImageRef image = CGImageSourceCreateImageAtIndex(source, i, NULL);
-                
                 duration += AFFrameDurationFromSourceAtIndex(source, i);
-                
-                
                 [images addObject:[UIImage imageWithCGImage:image scale:scale orientation:UIImageOrientationUp]];
-                
                 CGImageRelease(image);
             }
             
@@ -646,8 +637,9 @@ static UIImage * AFInflatedImageFromResponseWithDataAtScale(NSHTTPURLResponse *r
         }
         
         CFRelease(source);
-        
-        return gifImage;
+        if (gifImage) {
+            return gifImage;
+        }
     }
 
 

--- a/AFNetworking/AFURLResponseSerialization.m
+++ b/AFNetworking/AFURLResponseSerialization.m
@@ -721,7 +721,12 @@ static UIImage * AFInflatedImageFromResponseWithDataAtScale(NSHTTPURLResponse *r
                 return nil;
             }
         }
+        
         inflatedImage = AFInflatedImageFromImageRefAndOrientationAtScale(imageRef, defaultImage.imageOrientation, scale);
+        
+        if (inflatedImage == nil) {
+            inflatedImage = defaultImage;
+        }
     }
     
     if (imageRef) {

--- a/AFNetworking/AFURLResponseSerialization.m
+++ b/AFNetworking/AFURLResponseSerialization.m
@@ -521,6 +521,7 @@ static id AFJSONObjectByRemovingKeysWithNullValues(id JSONObject, NSJSONReadingO
 
 #if TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_WATCH
 #import <CoreGraphics/CoreGraphics.h>
+#import <ImageIO/ImageIO.h>
 #import <UIKit/UIKit.h>
 
 @interface UIImage (AFNetworkingSafeImageLoading)
@@ -555,17 +556,50 @@ static UIImage * AFImageWithDataAtScale(NSData *data, CGFloat scale) {
     return [[UIImage alloc] initWithCGImage:[image CGImage] scale:scale orientation:image.imageOrientation];
 }
 
+static float AFFrameDurationFromSourceAtIndex(CGImageSourceRef source, NSUInteger index){
+    float frameDuration = 0.1f;
+    CFDictionaryRef cfFrameProperties = CGImageSourceCopyPropertiesAtIndex(source, index, nil);
+    NSDictionary *frameProperties = (__bridge NSDictionary *)cfFrameProperties;
+    NSDictionary *gifProperties = frameProperties[(NSString *)kCGImagePropertyGIFDictionary];
+    
+    NSNumber *delayTimeUnclampedProp = gifProperties[(NSString *)kCGImagePropertyGIFUnclampedDelayTime];
+    if (delayTimeUnclampedProp) {
+        frameDuration = [delayTimeUnclampedProp floatValue];
+    }
+    else {
+        
+        NSNumber *delayTimeProp = gifProperties[(NSString *)kCGImagePropertyGIFDelayTime];
+        if (delayTimeProp) {
+            frameDuration = [delayTimeProp floatValue];
+        }
+    }
+    
+    // Many annoying ads specify a 0 duration to make an image flash as quickly as possible.
+    // We follow Firefox's behavior and use a duration of 100 ms for any frames that specify
+    // a duration of <= 10 ms. See <rdar://problem/7689300> and <http://webkit.org/b/36082>
+    // for more information.
+    
+    if (frameDuration < 0.011f) {
+        frameDuration = 0.100f;
+    }
+    
+    CFRelease(cfFrameProperties);
+    return frameDuration;
+}
+
 static UIImage * AFInflatedImageFromResponseWithDataAtScale(NSHTTPURLResponse *response, NSData *data, CGFloat scale) {
     if (!data || [data length] == 0) {
         return nil;
     }
 
     CGImageRef imageRef = NULL;
-    CGDataProviderRef dataProvider = CGDataProviderCreateWithCFData((__bridge CFDataRef)data);
 
     if ([response.MIMEType isEqualToString:@"image/png"]) {
+        CGDataProviderRef dataProvider = CGDataProviderCreateWithCFData((__bridge CFDataRef)data);
         imageRef = CGImageCreateWithPNGDataProvider(dataProvider,  NULL, true, kCGRenderingIntentDefault);
+        CGDataProviderRelease(dataProvider);
     } else if ([response.MIMEType isEqualToString:@"image/jpeg"]) {
+        CGDataProviderRef dataProvider = CGDataProviderCreateWithCFData((__bridge CFDataRef)data);
         imageRef = CGImageCreateWithJPEGDataProvider(dataProvider, NULL, true, kCGRenderingIntentDefault);
 
         if (imageRef) {
@@ -578,9 +612,44 @@ static UIImage * AFInflatedImageFromResponseWithDataAtScale(NSHTTPURLResponse *r
                 imageRef = NULL;
             }
         }
+        CGDataProviderRelease(dataProvider);
+    } else if ([response.MIMEType isEqualToString:@"image/gif"]) {
+        CGImageSourceRef source = CGImageSourceCreateWithData((__bridge CFDataRef)data, NULL);
+        
+        size_t count = CGImageSourceGetCount(source);
+        
+        UIImage *gifImage;
+        
+        if (count <= 1) {
+            gifImage = [[UIImage alloc] initWithData:data];
+        }else{
+            NSMutableArray *images = [NSMutableArray array];
+            
+            NSTimeInterval duration = 0.0f;
+            
+            for (size_t i = 0; i < count; i++) {
+                CGImageRef image = CGImageSourceCreateImageAtIndex(source, i, NULL);
+                
+                duration += AFFrameDurationFromSourceAtIndex(source, i);
+                
+                
+                [images addObject:[UIImage imageWithCGImage:image scale:scale orientation:UIImageOrientationUp]];
+                
+                CGImageRelease(image);
+            }
+            
+            if (!duration) {
+                duration = (1.0f / 10.0f) * count;
+            }
+            
+            gifImage = [UIImage animatedImageWithImages:images duration:duration];
+        }
+        
+        CFRelease(source);
+        
+        return gifImage;
     }
 
-    CGDataProviderRelease(dataProvider);
 
     UIImage *image = AFImageWithDataAtScale(data, scale);
     if (!imageRef) {

--- a/Tests/Tests/AFImageDownloaderTests.m
+++ b/Tests/Tests/AFImageDownloaderTests.m
@@ -25,7 +25,7 @@
 @interface AFImageDownloaderTests : AFTestCase
 @property (nonatomic, strong) NSURLRequest *pngRequest;
 @property (nonatomic, strong) NSURLRequest *jpegRequest;
-@property (nonatomic, strong) NSURLRequest *gifsRequest;
+@property (nonatomic, strong) NSURLRequest *gifRequest;
 @property (nonatomic, strong) AFImageDownloader *downloader;
 @end
 
@@ -38,7 +38,7 @@
     [[[AFImageDownloader defaultInstance] imageCache] removeAllImages];
     self.pngRequest = [NSURLRequest requestWithURL:self.pngURL];
     self.jpegRequest = [NSURLRequest requestWithURL:self.jpegURL];
-    self.gifsRequest = [NSURLRequest requestWithURL:self.gifsURL];
+    self.gifRequest = [NSURLRequest requestWithURL:self.gifURL];
 }
 
 - (void)tearDown {
@@ -139,7 +139,7 @@
     __block UIImage *responseImage3 = nil;
     
     [self.downloader
-     downloadImageForURLRequest:self.gifsRequest
+     downloadImageForURLRequest:self.gifRequest
      success:^(NSURLRequest * _Nonnull request, NSHTTPURLResponse * _Nullable response, UIImage * _Nonnull responseObject) {
          urlResponse3 = response;
          responseImage3 = responseObject;
@@ -191,7 +191,7 @@
     __block UIImage *responseImage3 = nil;
     
     [self.downloader
-     downloadImageForURLRequest:self.gifsRequest
+     downloadImageForURLRequest:self.gifRequest
      success:^(NSURLRequest * _Nonnull request, NSHTTPURLResponse * _Nullable response, UIImage * _Nonnull responseObject) {
          urlResponse3 = response;
          responseImage3 = responseObject;

--- a/Tests/Tests/AFImageDownloaderTests.m
+++ b/Tests/Tests/AFImageDownloaderTests.m
@@ -25,6 +25,7 @@
 @interface AFImageDownloaderTests : AFTestCase
 @property (nonatomic, strong) NSURLRequest *pngRequest;
 @property (nonatomic, strong) NSURLRequest *jpegRequest;
+@property (nonatomic, strong) NSURLRequest *gifsRequest;
 @property (nonatomic, strong) AFImageDownloader *downloader;
 @end
 
@@ -37,6 +38,7 @@
     [[[AFImageDownloader defaultInstance] imageCache] removeAllImages];
     self.pngRequest = [NSURLRequest requestWithURL:self.pngURL];
     self.jpegRequest = [NSURLRequest requestWithURL:self.jpegURL];
+    self.gifsRequest = [NSURLRequest requestWithURL:self.gifsURL];
 }
 
 - (void)tearDown {
@@ -131,6 +133,19 @@
          [expectation2 fulfill];
      }
      failure:nil];
+    
+    XCTestExpectation *expectation3 = [self expectationWithDescription:@"image 3 download should succeed"];
+    __block NSHTTPURLResponse *urlResponse3 = nil;
+    __block UIImage *responseImage3 = nil;
+    
+    [self.downloader
+     downloadImageForURLRequest:self.gifsRequest
+     success:^(NSURLRequest * _Nonnull request, NSHTTPURLResponse * _Nullable response, UIImage * _Nonnull responseObject) {
+         urlResponse3 = response;
+         responseImage3 = responseObject;
+         [expectation3 fulfill];
+     }
+     failure:nil];
 
     [self waitForExpectationsWithCommonTimeout];
 
@@ -139,6 +154,9 @@
 
     XCTAssertNotNil(urlResponse2, @"HTTPURLResponse should not be nil");
     XCTAssertNotNil(responseImage2, @"Respone image should not be nil");
+    
+    XCTAssertNotNil(urlResponse3, @"HTTPURLResponse should not be nil");
+    XCTAssertNotNil(responseImage3, @"Respone image should not be nil");
 }
 
 - (void)testThatSimultaneouslyRequestsForTheSameAssetReceiveSameResponse {
@@ -167,11 +185,25 @@
          [expectation2 fulfill];
      }
      failure:nil];
+    
+    XCTestExpectation *expectation3 = [self expectationWithDescription:@"image 2 download should succeed"];
+    __block NSHTTPURLResponse *urlResponse3 = nil;
+    __block UIImage *responseImage3 = nil;
+    
+    [self.downloader
+     downloadImageForURLRequest:self.gifsRequest
+     success:^(NSURLRequest * _Nonnull request, NSHTTPURLResponse * _Nullable response, UIImage * _Nonnull responseObject) {
+         urlResponse3 = response;
+         responseImage3 = responseObject;
+         [expectation3 fulfill];
+     }
+     failure:nil];
 
     [self waitForExpectationsWithCommonTimeout];
 
     XCTAssertEqual(urlResponse1, urlResponse2, @"responses should be equal");
     XCTAssertEqual(responseImage2, responseImage2, @"responses should be equal");
+    XCTAssertEqual(responseImage3, responseImage3, @"responses should be equal");
 }
 
 - (void)testThatImageBehindRedirectCanBeDownloaded {

--- a/Tests/Tests/AFTestCase.h
+++ b/Tests/Tests/AFTestCase.h
@@ -26,7 +26,7 @@
 @property (nonatomic, strong, readonly) NSURL *baseURL;
 @property (nonatomic, strong, readonly) NSURL *pngURL;
 @property (nonatomic, strong, readonly) NSURL *jpegURL;
-@property (nonatomic, strong, readonly) NSURL *gifsURL;
+@property (nonatomic, strong, readonly) NSURL *gifURL;
 @property (nonatomic, strong, readonly) NSURL *delayURL;
 - (NSURL *)URLWithStatusCode:(NSInteger)statusCode;
 

--- a/Tests/Tests/AFTestCase.h
+++ b/Tests/Tests/AFTestCase.h
@@ -26,6 +26,7 @@
 @property (nonatomic, strong, readonly) NSURL *baseURL;
 @property (nonatomic, strong, readonly) NSURL *pngURL;
 @property (nonatomic, strong, readonly) NSURL *jpegURL;
+@property (nonatomic, strong, readonly) NSURL *gifsURL;
 @property (nonatomic, strong, readonly) NSURL *delayURL;
 - (NSURL *)URLWithStatusCode:(NSInteger)statusCode;
 

--- a/Tests/Tests/AFTestCase.m
+++ b/Tests/Tests/AFTestCase.m
@@ -47,6 +47,10 @@
     return [self.baseURL URLByAppendingPathComponent:@"image/jpeg"];
 }
 
+- (NSURL *)gifsURL {
+    return [NSURL URLWithString:@"http://www.801390.com.cn/imgall/o53xolrtm5uwm4zomnxw2/s/0/1o/01obw.gif"];
+}
+
 - (NSURL *)delayURL {
     return [self.baseURL URLByAppendingPathComponent:@"delay/1"];
 }

--- a/Tests/Tests/AFTestCase.m
+++ b/Tests/Tests/AFTestCase.m
@@ -48,7 +48,7 @@
 }
 
 - (NSURL *)gifsURL {
-    return [NSURL URLWithString:@"http://www.801390.com.cn/imgall/o53xolrtm5uwm4zomnxw2/s/0/1o/01obw.gif"];
+    return [NSURL URLWithString:@"http://67.media.tumblr.com/tumblr_m9cmp8nu1n1qfc8cw.gif"];
 }
 
 - (NSURL *)delayURL {

--- a/Tests/Tests/AFTestCase.m
+++ b/Tests/Tests/AFTestCase.m
@@ -47,7 +47,7 @@
     return [self.baseURL URLByAppendingPathComponent:@"image/jpeg"];
 }
 
-- (NSURL *)gifsURL {
+- (NSURL *)gifURL {
     return [NSURL URLWithString:@"http://67.media.tumblr.com/tumblr_m9cmp8nu1n1qfc8cw.gif"];
 }
 

--- a/Tests/Tests/AFUIImageViewTests.m
+++ b/Tests/Tests/AFUIImageViewTests.m
@@ -137,7 +137,7 @@
     XCTAssertNotNil(responseImage);
 }
 
-- (void)testGifsImageImageCanBeCancelledAndDownloadedImmediately {
+- (void)testGifsImageCanBeCancelledAndDownloadedImmediately {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Request should succeed"];
     [self.imageView setImageWithURL:self.gifsURL];
     [self.imageView cancelImageDownloadTask];

--- a/Tests/Tests/AFUIImageViewTests.m
+++ b/Tests/Tests/AFUIImageViewTests.m
@@ -156,6 +156,19 @@
     XCTAssertNotNil(gifsImage);
     
 }
+
+- (void)testCancelImageRequest {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Request should canceled"];
+    [self.imageView setImageWithURLRequest:self.jpegURLRequest
+                          placeholderImage:nil
+                                   success:nil
+                                   failure:^(NSURLRequest * _Nonnull request, NSHTTPURLResponse * _Nullable response, NSError * _Nonnull error) {
+                                       [expectation fulfill];
+                                   }];
+    [self.imageView cancelImageDownloadTask];
+    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+}
+
 - (void)testThatNilURLDoesntCrash {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnonnull"

--- a/Tests/Tests/AFUIImageViewTests.m
+++ b/Tests/Tests/AFUIImageViewTests.m
@@ -139,11 +139,11 @@
 
 - (void)testGifsImageCanBeCancelledAndDownloadedImmediately {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Request should succeed"];
-    [self.imageView setImageWithURL:self.gifsURL];
+    [self.imageView setImageWithURL:self.gifURL];
     [self.imageView cancelImageDownloadTask];
     __block UIImage *gifsImage;
     [self.imageView
-     setImageWithURLRequest:[NSURLRequest requestWithURL:self.gifsURL]
+     setImageWithURLRequest:[NSURLRequest requestWithURL:self.gifURL]
      placeholderImage:nil
      success:^(NSURLRequest * _Nonnull request, NSHTTPURLResponse * _Nullable response, UIImage * _Nonnull image) {
          if (image.images.count > 1) {

--- a/Tests/Tests/AFUIImageViewTests.m
+++ b/Tests/Tests/AFUIImageViewTests.m
@@ -137,6 +137,25 @@
     XCTAssertNotNil(responseImage);
 }
 
+- (void)testGifsImageImageCanBeCancelledAndDownloadedImmediately {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Request should succeed"];
+    [self.imageView setImageWithURL:self.gifsURL];
+    [self.imageView cancelImageDownloadTask];
+    __block UIImage *gifsImage;
+    [self.imageView
+     setImageWithURLRequest:[NSURLRequest requestWithURL:self.gifsURL]
+     placeholderImage:nil
+     success:^(NSURLRequest * _Nonnull request, NSHTTPURLResponse * _Nullable response, UIImage * _Nonnull image) {
+         if (image.images.count > 1) {
+             gifsImage = image;
+         }
+         [expectation fulfill];
+     }
+     failure:nil];
+    [self waitForExpectationsWithCommonTimeout];
+    XCTAssertNotNil(gifsImage);
+    
+}
 - (void)testThatNilURLDoesntCrash {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnonnull"

--- a/UIKit+AFNetworking/UIImageView+AFNetworking.m
+++ b/UIKit+AFNetworking/UIImageView+AFNetworking.m
@@ -154,7 +154,6 @@
 - (void)cancelImageDownloadTask {
     if (self.af_activeImageDownloadReceipt != nil) {
         [[self.class sharedImageDownloader] cancelTaskForImageDownloadReceipt:self.af_activeImageDownloadReceipt];
-        [self clearActiveDownloadInformation];
      }
 }
 

--- a/UIKit+AFNetworking/UIImageView+AFNetworking.m
+++ b/UIKit+AFNetworking/UIImageView+AFNetworking.m
@@ -98,6 +98,13 @@
             success(urlRequest, nil, cachedImage);
         } else {
             self.image = cachedImage;
+            if (self.animationImages.count > 1) {
+                self.animationImages = cachedImage.images;
+                self.animationDuration = cachedImage.duration;
+                [self startAnimating];
+            }else{
+                [self stopAnimating];
+            }
         }
         [self clearActiveDownloadInformation];
     } else {
@@ -118,6 +125,13 @@
                                success(request, response, responseObject);
                            } else if(responseObject) {
                                strongSelf.image = responseObject;
+                               if (self.animationImages.count > 1) {
+                                   self.animationImages = cachedImage.images;
+                                   self.animationDuration = cachedImage.duration;
+                                   [self startAnimating];
+                               }else{
+                                   [self stopAnimating];
+                               }
                            }
                            [strongSelf clearActiveDownloadInformation];
                        }


### PR DESCRIPTION
About UIImageView+AFNetworking will cancelImageDownloadTask.
cancelTaskForImageDownloadReceipt is working on GCD, when we cancel the request at main thread. The first work at  "self.af_activeImageDownloadReceipt = nil;" , when CANCEL Block , if ([strongSelf.af_activeImageDownloadReceipt.receiptID isEqual:downloadID]) alway is false.