### PR TITLE
Image Request cancel bug.

### DIFF
--- a/Tests/Tests/AFUIImageViewTests.m
+++ b/Tests/Tests/AFUIImageViewTests.m
@@ -137,6 +137,19 @@
     XCTAssertNotNil(responseImage);
 }
 
+- (void)testThatImageCanBeCancel{
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Request should canceled"];
+    [self.imageView
+     setImageWithURLRequest:self.jpegURLRequest
+     placeholderImage:nil
+     success:nil
+     failure:^(NSURLRequest * _Nonnull request, NSHTTPURLResponse * _Nullable response, NSError * _Nonnull error) {
+         [expectation fulfill];
+     }];
+    [self.imageView cancelImageDownloadTask];
+    [self waitForExpectationsWithCommonTimeout];
+}
+
 - (void)testThatNilURLDoesntCrash {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnonnull"

--- a/UIKit+AFNetworking/UIImageView+AFNetworking.m
+++ b/UIKit+AFNetworking/UIImageView+AFNetworking.m
@@ -140,7 +140,6 @@
 - (void)cancelImageDownloadTask {
     if (self.af_activeImageDownloadReceipt != nil) {
         [[self.class sharedImageDownloader] cancelTaskForImageDownloadReceipt:self.af_activeImageDownloadReceipt];
-        [self clearActiveDownloadInformation];
      }
 }
 


### PR DESCRIPTION
About UIImageView+AFNetworking will cancelImageDownloadTask.
cancelTaskForImageDownloadReceipt is working on GCD, when we cancel the request at main thread. The first work at  "self.af_activeImageDownloadReceipt = nil;" , when CANCEL Block , if ([strongSelf.af_activeImageDownloadReceipt.receiptID isEqual:downloadID]) alway is false.