### PR TITLE
Redirect response should return nullable NSURLRequest

### DIFF
--- a/AFNetworking/AFURLConnectionOperation.h
+++ b/AFNetworking/AFURLConnectionOperation.h
@@ -306,7 +306,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param block A block object to be executed when the request URL was changed. The block returns an `NSURLRequest` object, the URL request to redirect, and takes three arguments: the URL connection object, the the proposed redirected request, and the URL response that caused the redirect.
  */
-- (void)setRedirectResponseBlock:(nullable NSURLRequest * (^)(NSURLConnection *connection, NSURLRequest *request, NSURLResponse *redirectResponse))block;
+- (void)setRedirectResponseBlock:(nullable NSURLRequest * _Nullable (^)(NSURLConnection *connection, NSURLRequest *request, NSURLResponse *redirectResponse))block;
 
 
 /**


### PR DESCRIPTION
Return value from `- (NSURLRequest *)connection:(NSURLConnection *)connection willSendRequest:(NSURLRequest *)request redirectResponse:(NSURLResponse *)response;` 
> The actual URL request to use in light of the redirection response. The delegate may return request unmodified to allow the redirect, return a new request, or *return nil to reject the redirect and continue processing the connection*.

So in the header you have `ASSUME_NONNULL` block which breaks that particular line, so I fixed it.