### PR TITLE
Fix imageRequestCancel bug.

### DIFF
--- a/Tests/Tests/AFUIImageViewTests.m
+++ b/Tests/Tests/AFUIImageViewTests.m
@@ -137,6 +137,21 @@
     XCTAssertNotNil(responseImage);
 }
 
+- (void)testThatImageCanBeCancelled{
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Request should canceled success"];
+    [self.imageView setImageWithURL:self.jpegURL];
+    [self.imageView cancelImageDownloadTask];
+    [self.imageView
+     setImageWithURLRequest:self.jpegURLRequest
+     placeholderImage:nil
+     success:nil
+     failure:^(NSURLRequest * _Nonnull request, NSHTTPURLResponse * _Nullable response, NSError * _Nonnull error) {
+         [expectation fulfill];
+     }];
+    [self.imageView cancelImageDownloadTask];
+    [self waitForExpectationsWithCommonTimeout];
+}
+
 - (void)testThatNilURLDoesntCrash {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnonnull"

--- a/UIKit+AFNetworking/AFImageDownloader.m
+++ b/UIKit+AFNetworking/AFImageDownloader.m
@@ -321,9 +321,13 @@
             NSDictionary *userInfo = @{NSLocalizedFailureReasonErrorKey:failureReason};
             NSError *error = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorCancelled userInfo:userInfo];
             if (handler.failureBlock) {
-                dispatch_async(dispatch_get_main_queue(), ^{
+                if ([NSThread isMainThread]) {
                     handler.failureBlock(imageDownloadReceipt.task.originalRequest, nil, error);
-                });
+                }else{
+                    dispatch_async(dispatch_get_main_queue(), ^{
+                        handler.failureBlock(imageDownloadReceipt.task.originalRequest, nil, error);
+                    });
+                }
             }
         }
 


### PR DESCRIPTION
About UIImageView+AFNetworking will cancelImageDownloadTask.
cancelTaskForImageDownloadReceipt is working on GCD, when we cancel the
request at main thread. The first work at
"self.af_activeImageDownloadReceipt = nil;" , when CANCEL Block , if
([strongSelf.af_activeImageDownloadReceipt.receiptID
isEqual:downloadID]) alway is false.