### PR TITLE
Fix AFURLSessionManager security weakness

### DIFF
--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -39,13 +39,18 @@ static dispatch_queue_t url_session_manager_creation_queue() {
 }
 
 static void url_session_manager_create_task_safely(dispatch_block_t block) {
-    if (NSFoundationVersionNumber < NSFoundationVersionNumber_With_Fixed_5871104061079552_bug) {
-        // Fix of bug
-        // Open Radar:http://openradar.appspot.com/radar?id=5871104061079552 (status: Fixed in iOS8)
-        // Issue about:https://github.com/AFNetworking/AFNetworking/issues/2093
-        dispatch_sync(url_session_manager_creation_queue(), block);
+    
+    if(block != nil) {
+        if (NSFoundationVersionNumber < NSFoundationVersionNumber_With_Fixed_5871104061079552_bug) {
+            // Fix of bug
+            // Open Radar:http://openradar.appspot.com/radar?id=5871104061079552 (status: Fixed in iOS8)
+            // Issue about:https://github.com/AFNetworking/AFNetworking/issues/2093
+            dispatch_sync(url_session_manager_creation_queue(), block);
+        } else {
+            block();
+        }
     } else {
-        block();
+        return;
     }
 }
 


### PR DESCRIPTION
crashes when calling to a released block pointer

A security weakness was detected as a result of detection by Facebook's infer.
You can trigger a crash by sending nil to the url_session_manager_create_task_safely function as a debugger.