### PR TITLE
Task created in a session that has been invalidate

### DIFF
--- a/AFNetworking/AFURLSessionManager.h
+++ b/AFNetworking/AFURLSessionManager.h
@@ -95,6 +95,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readonly, nonatomic, strong) NSURLSession *session;
 
 /**
+ Invalidate session
+ */
+@property (nonatomic, strong) NSURLSession *invalidatedSession;
+
+/**
  The operation queue on which delegate callbacks are run.
  */
 @property (readonly, nonatomic, strong) NSOperationQueue *operationQueue;

--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -719,7 +719,14 @@ static NSString * const AFNSURLSessionTaskDidSuspendNotification = @"com.alamofi
 
     __block NSURLSessionDataTask *dataTask = nil;
     url_session_manager_create_task_safely(^{
-        dataTask = [self.session dataTaskWithRequest:request];
+//        dataTask = [self.session dataTaskWithRequest:request];
+        /** vinhsteven: fixed crash when lose connection suddenly.
+         the invalidatedSession was assigned when session is invalidated in - (void)URLSession:(NSURLSession *)session
+         didBecomeInvalidWithError:(NSError *)error
+         */
+        if (self.session != self.invalidatedSession) {
+            dataTask = [self.session dataTaskWithRequest:request];
+        }
     });
 
     [self addDelegateForDataTask:dataTask uploadProgress:uploadProgressBlock downloadProgress:downloadProgressBlock completionHandler:completionHandler];
@@ -914,6 +921,9 @@ static NSString * const AFNSURLSessionTaskDidSuspendNotification = @"com.alamofi
 - (void)URLSession:(NSURLSession *)session
 didBecomeInvalidWithError:(NSError *)error
 {
+    /** vinhsteven: fixed crash when lose connection suddenly. */
+    self.invalidatedSession = session;
+    
     if (self.sessionDidBecomeInvalid) {
         self.sessionDidBecomeInvalid(session, error);
     }


### PR DESCRIPTION
The application will be crashed when it loses internet connection suddenly. We'll see the log in console something like this: 

`Attempted to create a task in a session that has been invalidated
2016-07-02 16:52:57.354 FlydeApp[19981:191244] *** Terminating app due to uncaught exception 'NSGenericException', reason: 'Task created in a session that has been invalidate`

My solution is define another variable: invalidateSession and this value will be referenced from current session whenever the session in AFURLSessionManager is invalidated. Then, before create a data task, I will compare the current session with the invalidateSession variables to make sure no data task is created in invalidated session. I tested this solution on my own project, and it works perfectly. Hope it will release a lot of headache for others as well. 