### PR TITLE
fix space used in Objective-C method (coding style)

### DIFF
--- a/Tests/Tests/AFURLSessionManagerTests.m
+++ b/Tests/Tests/AFURLSessionManagerTests.m
@@ -459,7 +459,7 @@
     return [NSURLRequest requestWithURL:self.delayURL];
 }
 
-- (IMP)_implementationForTask:(NSURLSessionTask  *)task selector:(SEL)selector {
+- (IMP)_implementationForTask:(NSURLSessionTask *)task selector:(SEL)selector {
     return [self _implementationForClass:[task class] selector:selector];
 }
 

--- a/UIKit+AFNetworking/AFAutoPurgingImageCache.m
+++ b/UIKit+AFNetworking/AFAutoPurgingImageCache.m
@@ -37,7 +37,7 @@
 
 @implementation AFCachedImage
 
--(instancetype)initWithImage:(UIImage *)image identifier:(NSString *)identifier {
+- (instancetype)initWithImage:(UIImage *)image identifier:(NSString *)identifier {
     if (self = [self init]) {
         self.image = image;
         self.identifier = identifier;

--- a/UIKit+AFNetworking/AFAutoPurgingImageCache.m
+++ b/UIKit+AFNetworking/AFAutoPurgingImageCache.m
@@ -51,7 +51,7 @@
     return self;
 }
 
-- (UIImage*)accessImage {
+- (UIImage *)accessImage {
     self.lastAccessDate = [NSDate date];
     return self.image;
 }

--- a/UIKit+AFNetworking/AFImageDownloader.m
+++ b/UIKit+AFNetworking/AFImageDownloader.m
@@ -28,8 +28,8 @@
 
 @interface AFImageDownloaderResponseHandler : NSObject
 @property (nonatomic, strong) NSUUID *uuid;
-@property (nonatomic, copy) void (^successBlock)(NSURLRequest*, NSHTTPURLResponse*, UIImage*);
-@property (nonatomic, copy) void (^failureBlock)(NSURLRequest*, NSHTTPURLResponse*, NSError*);
+@property (nonatomic, copy) void (^successBlock)(NSURLRequest *, NSHTTPURLResponse *, UIImage *);
+@property (nonatomic, copy) void (^failureBlock)(NSURLRequest *, NSHTTPURLResponse *, NSError *);
 @end
 
 @implementation AFImageDownloaderResponseHandler
@@ -71,11 +71,11 @@
     return self;
 }
 
-- (void)addResponseHandler:(AFImageDownloaderResponseHandler*)handler {
+- (void)addResponseHandler:(AFImageDownloaderResponseHandler *)handler {
     [self.responseHandlers addObject:handler];
 }
 
-- (void)removeResponseHandler:(AFImageDownloaderResponseHandler*)handler {
+- (void)removeResponseHandler:(AFImageDownloaderResponseHandler *)handler {
     [self.responseHandlers removeObject:handler];
 }
 
@@ -257,7 +257,7 @@
                                        for (AFImageDownloaderResponseHandler *handler in mergedTask.responseHandlers) {
                                            if (handler.failureBlock) {
                                                dispatch_async(dispatch_get_main_queue(), ^{
-                                                   handler.failureBlock(request, (NSHTTPURLResponse*)response, error);
+                                                   handler.failureBlock(request, (NSHTTPURLResponse *)response, error);
                                                });
                                            }
                                        }
@@ -267,7 +267,7 @@
                                        for (AFImageDownloaderResponseHandler *handler in mergedTask.responseHandlers) {
                                            if (handler.successBlock) {
                                                dispatch_async(dispatch_get_main_queue(), ^{
-                                                   handler.successBlock(request, (NSHTTPURLResponse*)response, responseObject);
+                                                   handler.successBlock(request, (NSHTTPURLResponse *)response, responseObject);
                                                });
                                            }
                                        }
@@ -334,7 +334,7 @@
     });
 }
 
-- (AFImageDownloaderMergedTask*)safelyRemoveMergedTaskWithURLIdentifier:(NSString *)URLIdentifier {
+- (AFImageDownloaderMergedTask *)safelyRemoveMergedTaskWithURLIdentifier:(NSString *)URLIdentifier {
     __block AFImageDownloaderMergedTask *mergedTask = nil;
     dispatch_sync(self.synchronizationQueue, ^{
         mergedTask = [self removeMergedTaskWithURLIdentifier:URLIdentifier];

--- a/UIKit+AFNetworking/UIImage+AFNetworking.h
+++ b/UIKit+AFNetworking/UIImage+AFNetworking.h
@@ -28,7 +28,7 @@
 
 @interface UIImage (AFNetworking)
 
-+ (UIImage*) safeImageWithData:(NSData*)data;
++ (UIImage *)safeImageWithData:(NSData *)data;
 
 @end
 

--- a/UIKit+AFNetworking/UIWebView+AFNetworking.m
+++ b/UIKit+AFNetworking/UIWebView+AFNetworking.m
@@ -49,7 +49,7 @@
 
 @implementation UIWebView (AFNetworking)
 
-- (AFHTTPSessionManager  *)sessionManager {
+- (AFHTTPSessionManager *)sessionManager {
     static AFHTTPSessionManager *_af_defaultHTTPSessionManager = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{


### PR DESCRIPTION
1. apple documented coding guidelines, which uses (space after -)
2. fix asterisk location in method declaration
 
https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/CodingGuidelines/Articles/NamingBasics.html#//apple_ref/doc/uid/20001281-BBCHBFAH