### PR TITLE
Add - Custom HTTPHeaderField remove method.

### DIFF
--- a/AFNetworking/AFURLRequestSerialization.h
+++ b/AFNetworking/AFURLRequestSerialization.h
@@ -180,6 +180,13 @@ forHTTPHeaderField:(NSString *)field;
 - (nullable NSString *)valueForHTTPHeaderField:(NSString *)field;
 
 /**
+ Removes the key for the HTTP headers set in the request serializer.
+ 
+ @param field The HTTP header field to remove
+ */
+- (void)removeHTTPHeaderField:(NSString *)field;
+
+/**
  Sets the "Authorization" HTTP header set in request objects made by the HTTP client to a basic authentication value with Base64-encoded username and password. This overwrites any existing value for this header.
 
  @param username The HTTP basic auth username

--- a/AFNetworking/AFURLRequestSerialization.m
+++ b/AFNetworking/AFURLRequestSerialization.m
@@ -325,6 +325,14 @@ forHTTPHeaderField:(NSString *)field
     return value;
 }
 
+- (void)removeHTTPHeaderField:(NSString *)field {
+    dispatch_barrier_async(self.requestHeaderModificationQueue, ^{
+        if ([self.mutableHTTPRequestHeaders objectForKey:field]) {
+            [self.mutableHTTPRequestHeaders removeObjectForKey:field];
+        }
+    });
+}
+
 - (void)setAuthorizationHeaderFieldWithUsername:(NSString *)username
                                        password:(NSString *)password
 {


### PR DESCRIPTION
* Add - Removes the key for the HTTP headers set in the request serializer.

It is a confusing implementation to add an HTTPHeaderField to the AFHTTPResponseSerializer and remove the value by putting nil.
So I added a function that removes the HTTPHeaderField itself.