### PR TITLE
Config AFImageDownloader NSURLCache and ask AFImageRequestCache implementer if an image should be cached

### DIFF
--- a/Tests/Tests/AFAutoPurgingImageCacheTests.m
+++ b/Tests/Tests/AFAutoPurgingImageCacheTests.m
@@ -230,4 +230,12 @@
     }
 }
 
+#pragma mark - Should Cache Image
+- (void)testThatShouldCacheIsYes {
+    NSURL *url = [NSURL URLWithString:@"http://test.com/image"];
+    NSString *identifier = @"filter";
+    NSURLRequest *request = [[NSURLRequest alloc] initWithURL:url];
+    BOOL result = [self.cache shouldCacheImage:self.testImage forRequest:request withAdditionalIdentifier:identifier];
+    XCTAssertTrue(result);
+}
 @end

--- a/Tests/Tests/AFImageDownloaderTests.m
+++ b/Tests/Tests/AFImageDownloaderTests.m
@@ -22,6 +22,11 @@
 #import "AFTestCase.h"
 #import "AFImageDownloader.h"
 
+@interface MockAFAutoPurgingImageCache : AFAutoPurgingImageCache
+@property (nonatomic, strong) BOOL(^shouldCache)(UIImage*, NSURLRequest*, NSString*);
+@property (nonatomic, strong) void(^addCache)(UIImage*, NSString*);
+@end
+
 @interface AFImageDownloaderTests : AFTestCase
 @property (nonatomic, strong) NSURLRequest *pngRequest;
 @property (nonatomic, strong) NSURLRequest *jpegRequest;
@@ -234,6 +239,114 @@
     XCTAssertEqual(responseImage1, responseImage2);
 }
 
+- (void)testThatImageCacheIsPromptedShouldCache {
+    XCTestExpectation *expectation3 = [self expectationWithDescription:@"image 1 shouldCache called"];
+    XCTestExpectation *expectation4 = [self expectationWithDescription:@"image 1 addCache called"];
+    
+    MockAFAutoPurgingImageCache *mock = [[MockAFAutoPurgingImageCache alloc] init];
+    mock.shouldCache = ^BOOL(UIImage *img, NSURLRequest *req, NSString *iden) {
+        [expectation3 fulfill];
+        return YES;
+    };
+    mock.addCache = ^(UIImage *img, NSString *ident) {
+        [expectation4 fulfill];
+    };
+    self.downloader.imageCache = mock;
+    
+    XCTestExpectation *expectation1 = [self expectationWithDescription:@"image 1 download should succeed"];
+    __block NSHTTPURLResponse *urlResponse1 = nil;
+    __block UIImage *responseImage1 = nil;
+    
+    [self.downloader
+     downloadImageForURLRequest:self.pngRequest
+     success:^(NSURLRequest * _Nonnull request, NSHTTPURLResponse * _Nullable response, UIImage * _Nonnull responseObject) {
+         urlResponse1 = response;
+         responseImage1 = responseObject;
+         [expectation1 fulfill];
+     }
+     failure:nil];
+    
+    [self waitForExpectationsWithCommonTimeout];
+    
+    XCTestExpectation *expectation2 = [self expectationWithDescription:@"image 2 download should succeed"];
+    __block NSHTTPURLResponse *urlResponse2 = nil;
+    __block UIImage *responseImage2 = nil;
+    
+    [self.downloader
+     downloadImageForURLRequest:self.pngRequest
+     success:^(NSURLRequest * _Nonnull request, NSHTTPURLResponse * _Nullable response, UIImage * _Nonnull responseObject) {
+         urlResponse2 = response;
+         responseImage2 = responseObject;
+         [expectation2 fulfill];
+     }
+     failure:nil];
+    
+    [self waitForExpectationsWithCommonTimeout];
+    
+    XCTAssertNotNil(urlResponse1);
+    XCTAssertNotNil(responseImage1);
+    XCTAssertNil(urlResponse2);
+    XCTAssertEqual(responseImage1, responseImage2);
+}
+
+- (void)testThatImageCacheIsPromptedShouldCacheNot {
+    XCTestExpectation *expectation3 = [self expectationWithDescription:@"image 1 shouldCache called"];
+    XCTestExpectation *expectation4 = [self expectationWithDescription:@"image 1 & 2 addCache NOT called"];
+    expectation4.inverted = YES;
+    
+    MockAFAutoPurgingImageCache *mock = [[MockAFAutoPurgingImageCache alloc] init];
+    mock.shouldCache = ^BOOL(UIImage *img, NSURLRequest *req, NSString *iden) {
+        [expectation3 fulfill];
+        return NO;
+    };
+    mock.addCache = ^(UIImage *img, NSString *ident) {
+        XCTFail(@"Not expected");
+    };
+    self.downloader.imageCache = mock;
+    
+    XCTestExpectation *expectation1 = [self expectationWithDescription:@"image 1 download should succeed"];
+    __block NSHTTPURLResponse *urlResponse1 = nil;
+    __block UIImage *responseImage1 = nil;
+    
+    [self.downloader
+     downloadImageForURLRequest:self.pngRequest
+     success:^(NSURLRequest * _Nonnull request, NSHTTPURLResponse * _Nullable response, UIImage * _Nonnull responseObject) {
+         urlResponse1 = response;
+         responseImage1 = responseObject;
+         [expectation1 fulfill];
+     }
+     failure:nil];
+    
+    [self waitForExpectationsWithCommonTimeout];
+    
+    XCTestExpectation *expectation2 = [self expectationWithDescription:@"image 2 download should succeed"];
+    __block NSHTTPURLResponse *urlResponse2 = nil;
+    __block UIImage *responseImage2 = nil;
+    
+    XCTestExpectation *expectation5 = [self expectationWithDescription:@"image 2 shouldCache called"];
+    
+    mock.shouldCache = ^BOOL(UIImage *img, NSURLRequest *req, NSString *iden) {
+        [expectation5 fulfill];
+        return NO;
+    };
+    
+    [self.downloader
+     downloadImageForURLRequest:self.pngRequest
+     success:^(NSURLRequest * _Nonnull request, NSHTTPURLResponse * _Nullable response, UIImage * _Nonnull responseObject) {
+         urlResponse2 = response;
+         responseImage2 = responseObject;
+         [expectation2 fulfill];
+     }
+     failure:nil];
+    
+    [self waitForExpectationsWithCommonTimeout];
+    
+    XCTAssertNotNil(urlResponse1);
+    XCTAssertNotNil(responseImage1);
+    XCTAssertNotNil(urlResponse2);
+    XCTAssertNotEqual(responseImage1, responseImage2);
+}
+
 - (void)testThatImageDownloadReceiptIsNilForCachedImage {
     XCTestExpectation *expectation1 = [self expectationWithDescription:@"image 1 download should succeed"];
     AFImageDownloadReceipt *receipt1;
@@ -444,4 +557,25 @@
     [self.downloader cancelTaskForImageDownloadReceipt:receipt];
 }
 
+@end
+
+#pragma mark -
+
+@implementation MockAFAutoPurgingImageCache
+
+-(BOOL)shouldCacheImage:(UIImage *)image forRequest:(NSURLRequest *)request withAdditionalIdentifier:(NSString *)identifier {
+    if (self.shouldCache) {
+        return self.shouldCache(image, request, identifier);
+    }
+    else {
+        return [super shouldCacheImage:image forRequest:request withAdditionalIdentifier:identifier];
+    }
+}
+
+-(void)addImage:(UIImage *)image withIdentifier:(NSString *)identifier{
+    [super addImage:image withIdentifier:identifier];
+    if (self.addCache) {
+        self.addCache(image, identifier);
+    }
+}
 @end

--- a/Tests/Tests/AFImageDownloaderTests.m
+++ b/Tests/Tests/AFImageDownloaderTests.m
@@ -291,8 +291,6 @@
 
 - (void)testThatImageCacheIsPromptedShouldCacheNot {
     XCTestExpectation *expectation3 = [self expectationWithDescription:@"image 1 shouldCache called"];
-    XCTestExpectation *expectation4 = [self expectationWithDescription:@"image 1 & 2 addCache NOT called"];
-    expectation4.inverted = YES;
     
     MockAFAutoPurgingImageCache *mock = [[MockAFAutoPurgingImageCache alloc] init];
     mock.shouldCache = ^BOOL(UIImage *img, NSURLRequest *req, NSString *iden) {

--- a/UIKit+AFNetworking/AFAutoPurgingImageCache.h
+++ b/UIKit+AFNetworking/AFAutoPurgingImageCache.h
@@ -73,6 +73,17 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol AFImageRequestCache <AFImageCache>
 
 /**
+ Asks if the image should be cached using an identifier created from the request and additional identifier.
+ 
+ @param image The image to be cached.
+ @param request The unique URL request identifing the image asset.
+ @param identifier The additional identifier to apply to the URL request to identify the image.
+ 
+ @return A BOOL indicating whether or not the image should be added to the cache. YES will cache, NO will prevent caching.
+ */
+- (BOOL)shouldCacheImage:(UIImage *)image forRequest:(NSURLRequest *)request withAdditionalIdentifier:(nullable NSString *)identifier;
+
+/**
  Adds the image to the cache using an identifier created from the request and additional identifier.
 
  @param image The image to cache.

--- a/UIKit+AFNetworking/AFAutoPurgingImageCache.m
+++ b/UIKit+AFNetworking/AFAutoPurgingImageCache.m
@@ -196,6 +196,10 @@
     return key;
 }
 
+- (BOOL)shouldCacheImage:(UIImage *)image forRequest:(NSURLRequest *)request withAdditionalIdentifier:(nullable NSString *)identifier {
+    return YES;
+}
+
 @end
 
 #endif

--- a/UIKit+AFNetworking/AFImageDownloader.h
+++ b/UIKit+AFNetworking/AFImageDownloader.h
@@ -82,6 +82,11 @@ typedef NS_ENUM(NSInteger, AFImageDownloadPrioritization) {
 + (NSURLCache *)defaultURLCache;
 
 /**
+ Sets the default `NSURLCache`
+ */
++ (void) setDefaultURLCache:(NSURLCache *)defaultCache;
+
+/**
  Default initializer
 
  @return An instance of `AFImageDownloader` initialized with default values.

--- a/UIKit+AFNetworking/AFImageDownloader.h
+++ b/UIKit+AFNetworking/AFImageDownloader.h
@@ -87,11 +87,25 @@ typedef NS_ENUM(NSInteger, AFImageDownloadPrioritization) {
 + (void) setDefaultURLCache:(NSURLCache *)defaultCache;
 
 /**
+ The default `NSURLSessionConfiguration` with common usage parameter values.
+ */
++ (NSURLSessionConfiguration *)defaultURLSessionConfiguration;
+
+/**
  Default initializer
 
  @return An instance of `AFImageDownloader` initialized with default values.
  */
 - (instancetype)init;
+
+/**
+ Initializer with specific `URLSessionConfiguration`
+ 
+ @param configuration The `NSURLSessionConfiguration` to be be used
+ 
+ @return An instance of `AFImageDownloader` initialized with default values and custom `NSURLSessionConfiguration`
+ */
+- (instancetype)initWithSessionConfiguration:(NSURLSessionConfiguration *)configuration;
 
 /**
  Initializes the `AFImageDownloader` instance with the given session manager, download prioritization, maximum active download count and image cache.

--- a/UIKit+AFNetworking/AFImageDownloader.h
+++ b/UIKit+AFNetworking/AFImageDownloader.h
@@ -82,11 +82,6 @@ typedef NS_ENUM(NSInteger, AFImageDownloadPrioritization) {
 + (NSURLCache *)defaultURLCache;
 
 /**
- Sets the default `NSURLCache`
- */
-+ (void) setDefaultURLCache:(NSURLCache *)defaultCache;
-
-/**
  The default `NSURLSessionConfiguration` with common usage parameter values.
  */
 + (NSURLSessionConfiguration *)defaultURLSessionConfiguration;

--- a/UIKit+AFNetworking/AFImageDownloader.m
+++ b/UIKit+AFNetworking/AFImageDownloader.m
@@ -254,7 +254,7 @@
                        completionHandler:^(NSURLResponse * _Nonnull response, id  _Nullable responseObject, NSError * _Nullable error) {
                            dispatch_async(self.responseQueue, ^{
                                __strong __typeof__(weakSelf) strongSelf = weakSelf;
-                               AFImageDownloaderMergedTask *mergedTask = self.mergedTasks[URLIdentifier];
+                               AFImageDownloaderMergedTask *mergedTask = strongSelf.mergedTasks[URLIdentifier];
                                if ([mergedTask.identifier isEqual:mergedTaskIdentifier]) {
                                    mergedTask = [strongSelf safelyRemoveMergedTaskWithURLIdentifier:URLIdentifier];
                                    if (error) {

--- a/UIKit+AFNetworking/AFImageDownloader.m
+++ b/UIKit+AFNetworking/AFImageDownloader.m
@@ -154,7 +154,11 @@ static NSURLCache* _defaultURLCache = nil;
 
 - (instancetype)init {
     NSURLSessionConfiguration *defaultConfiguration = [self.class defaultURLSessionConfiguration];
-    AFHTTPSessionManager *sessionManager = [[AFHTTPSessionManager alloc] initWithSessionConfiguration:defaultConfiguration];
+    return [self initWithSessionConfiguration:defaultConfiguration];
+}
+
+- (instancetype)initWithSessionConfiguration:(NSURLSessionConfiguration *)configuration {
+    AFHTTPSessionManager *sessionManager = [[AFHTTPSessionManager alloc] initWithSessionConfiguration:configuration];
     sessionManager.responseSerializer = [AFImageResponseSerializer serializer];
 
     return [self initWithSessionManager:sessionManager

--- a/UIKit+AFNetworking/AFImageDownloader.m
+++ b/UIKit+AFNetworking/AFImageDownloader.m
@@ -266,7 +266,9 @@
                                            }
                                        }
                                    } else {
-                                       [strongSelf.imageCache addImage:responseObject forRequest:request withAdditionalIdentifier:nil];
+                                       if ([strongSelf.imageCache shouldCacheImage:responseObject forRequest:request withAdditionalIdentifier:nil]) {
+                                           [strongSelf.imageCache addImage:responseObject forRequest:request withAdditionalIdentifier:nil];
+                                       }
 
                                        for (AFImageDownloaderResponseHandler *handler in mergedTask.responseHandlers) {
                                            if (handler.successBlock) {

--- a/UIKit+AFNetworking/AFImageDownloader.m
+++ b/UIKit+AFNetworking/AFImageDownloader.m
@@ -106,10 +106,16 @@
 
 @end
 
+static NSURLCache* _defaultURLCache = nil;
 
 @implementation AFImageDownloader
 
 + (NSURLCache *)defaultURLCache {
+    
+    if (_defaultURLCache) {
+        return _defaultURLCache;
+    }
+    
     // It's been discovered that a crash will occur on certain versions
     // of iOS if you customize the cache.
     //
@@ -123,6 +129,11 @@
     return [[NSURLCache alloc] initWithMemoryCapacity:20 * 1024 * 1024
                                          diskCapacity:150 * 1024 * 1024
                                              diskPath:@"com.alamofire.imagedownloader"];
+}
+
++ (void)setDefaultURLCache:(NSURLCache *)defaultCache {
+    
+    _defaultURLCache = defaultCache;
 }
 
 + (NSURLSessionConfiguration *)defaultURLSessionConfiguration {

--- a/UIKit+AFNetworking/AFImageDownloader.m
+++ b/UIKit+AFNetworking/AFImageDownloader.m
@@ -106,15 +106,9 @@
 
 @end
 
-static NSURLCache* _defaultURLCache = nil;
-
 @implementation AFImageDownloader
 
 + (NSURLCache *)defaultURLCache {
-    
-    if (_defaultURLCache) {
-        return _defaultURLCache;
-    }
     
     // It's been discovered that a crash will occur on certain versions
     // of iOS if you customize the cache.
@@ -129,11 +123,6 @@ static NSURLCache* _defaultURLCache = nil;
     return [[NSURLCache alloc] initWithMemoryCapacity:20 * 1024 * 1024
                                          diskCapacity:150 * 1024 * 1024
                                              diskPath:@"com.alamofire.imagedownloader"];
-}
-
-+ (void)setDefaultURLCache:(NSURLCache *)defaultCache {
-    
-    _defaultURLCache = defaultCache;
 }
 
 + (NSURLSessionConfiguration *)defaultURLSessionConfiguration {


### PR DESCRIPTION
### The new feature consists of 2 parts:

- Allow user to config `AFImageDownloader +defaultURLCache`. Currently, the values are hardcoded 20Mb mem, 150Mb disk.

- Provide a hook in `AFAutoPurgingImageCache` so `UIImages` can be filtered before cached. Ideally, one could filter out `UIImage` that exceeds certain *raster* size.

### Use case for this new two features:

A `UICollectionView` shows thumbnails of JPGs. Tapping any `UICollectionViewCell` opens a full size `UIImageView` that displays the full size JPG.

Under thew current implementation, large JPGs boot out thumbnails.
Hence JPGs and thumbnails are downloaded almost always as both caches keep getting recycled.

### References

SO: https://stackoverflow.com/questions/41939774/how-to-limit-size-of-image-disk-cache-using-afnetworking/45329948#45329948

See AFNetworking/issues/4009
