### PR TITLE
fix the bug of isReachable method is ineffective

### DIFF
--- a/AFNetworking/AFNetworkReachabilityManager.m
+++ b/AFNetworking/AFNetworkReachabilityManager.m
@@ -165,7 +165,7 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {
     }
 
     _networkReachability = CFRetain(reachability);
-    self.networkReachabilityStatus = AFNetworkReachabilityStatusUnknown;
+    self.networkReachabilityStatus =  [self checkNetworkReachabilityStatus];
 
     return self;
 }
@@ -183,6 +183,13 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {
     }
 }
 
+#pragma mark - fix the bug of isReachableXXX method is ineffective, by x5.
+- (AFNetworkReachabilityStatus)checkNetworkReachabilityStatus
+{
+    SCNetworkReachabilityFlags flags;
+    return SCNetworkReachabilityGetFlags(_networkReachability, &flags) ? AFNetworkReachabilityStatusForFlags(flags) : AFNetworkReachabilityStatusNotReachable;
+}
+
 #pragma mark -
 
 - (BOOL)isReachable {
@@ -190,11 +197,11 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {
 }
 
 - (BOOL)isReachableViaWWAN {
-    return self.networkReachabilityStatus == AFNetworkReachabilityStatusReachableViaWWAN;
+    return self.networkReachabilityStatus = [self checkNetworkReachabilityStatus] == AFNetworkReachabilityStatusReachableViaWWAN;
 }
 
 - (BOOL)isReachableViaWiFi {
-    return self.networkReachabilityStatus == AFNetworkReachabilityStatusReachableViaWiFi;
+    return self.networkReachabilityStatus = [self checkNetworkReachabilityStatus] == AFNetworkReachabilityStatusReachableViaWiFi;
 }
 
 #pragma mark -

--- a/AFNetworking/AFNetworkReachabilityManager.m
+++ b/AFNetworking/AFNetworkReachabilityManager.m
@@ -165,12 +165,7 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {
     }
 
     _networkReachability = CFRetain(reachability);
-<<<<<<< HEAD
-    self.networkReachabilityStatus =  [self checkNetworkReachabilityStatus];
-=======
     self.networkReachabilityStatus = [self checkNetworkReachabilityStatus];
->>>>>>> 3.1.1
-
     return self;
 }
 
@@ -187,11 +182,8 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {
     }
 }
 
-<<<<<<< HEAD
-#pragma mark - fix the bug of isReachableXXX method is ineffective, by x5.
-=======
-#pragma mark - fix the bug of isReachable method is ineffective, by x5.
->>>>>>> 3.1.1
+#pragma mark - fix the bug of isReachable method is ineffective, by x5. for master
+
 - (AFNetworkReachabilityStatus)checkNetworkReachabilityStatus
 {
     SCNetworkReachabilityFlags flags;


### PR DESCRIPTION
In the absence of calling stopMonitoring method, the methods of isReachableXXX is ineffective.