### PR TITLE
Fix analyzer warning for upload task creation

### DIFF
--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -737,14 +737,14 @@ static NSString * const AFNSURLSessionTaskDidSuspendNotification = @"com.alamofi
     __block NSURLSessionUploadTask *uploadTask = nil;
     url_session_manager_create_task_safely(^{
         uploadTask = [self.session uploadTaskWithRequest:request fromFile:fileURL];
-    });
-
-    // uploadTask may be nil on iOS7 because uploadTaskWithRequest:fromFile: may return nil despite being documented as nonnull (https://devforums.apple.com/message/926113#926113)
-    if (!uploadTask && self.attemptsToRecreateUploadTasksForBackgroundSessions && self.session.configuration.identifier) {
-        for (NSUInteger attempts = 0; !uploadTask && attempts < AFMaximumNumberOfAttemptsToRecreateBackgroundSessionUploadTask; attempts++) {
-            uploadTask = [self.session uploadTaskWithRequest:request fromFile:fileURL];
+        
+        // uploadTask may be nil on iOS7 because uploadTaskWithRequest:fromFile: may return nil despite being documented as nonnull (https://devforums.apple.com/message/926113#926113)
+        if (!uploadTask && self.attemptsToRecreateUploadTasksForBackgroundSessions && self.session.configuration.identifier) {
+            for (NSUInteger attempts = 0; !uploadTask && attempts < AFMaximumNumberOfAttemptsToRecreateBackgroundSessionUploadTask; attempts++) {
+                uploadTask = [self.session uploadTaskWithRequest:request fromFile:fileURL];
+            }
         }
-    }
+    });
 
     [self addDelegateForUploadTask:uploadTask progress:uploadProgressBlock completionHandler:completionHandler];
 

--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -745,8 +745,12 @@ static NSString * const AFNSURLSessionTaskDidSuspendNotification = @"com.alamofi
             }
         }
     });
-
-    [self addDelegateForUploadTask:uploadTask progress:uploadProgressBlock completionHandler:completionHandler];
+    
+    if (uploadTask) {
+        [self addDelegateForUploadTask:uploadTask
+                              progress:uploadProgressBlock
+                     completionHandler:completionHandler];
+    }
 
     return uploadTask;
 }

--- a/Tests/Tests/AFURLSessionManagerTests.m
+++ b/Tests/Tests/AFURLSessionManagerTests.m
@@ -140,17 +140,12 @@
     
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wnonnull"
-    __block NSURLSessionUploadTask *task = nil;
-    void (^test)(void) = ^{
-        task = [self.localManager uploadTaskWithRequest:[NSURLRequest requestWithURL:self.baseURL]
-                                                     fromFile:nil
-                                                     progress:NULL
-                                      completionHandler:NULL];
-    };
+    XCTAssertNil([self.localManager uploadTaskWithRequest:[NSURLRequest requestWithURL:self.baseURL]
+                                                 fromFile:nil
+                                                 progress:NULL
+                                        completionHandler:NULL],
+                 @"Upload task should be nil.");
 #pragma GCC diagnostic pop
-    
-    XCTAssertNoThrowSpecificNamed(test, NSException, NSInternalInconsistencyException);
-    XCTAssertNil(task, @"Upload task should be nil.");
 }
 
 - (void)testUploadTaskDoesReportProgress {


### PR DESCRIPTION
This is the same as [@funnel20](https://github.com/funnel20)’s [PR](https://github.com/AFNetworking/AFNetworking/pull/4120), but made off of the latest `master` so hopefully the coverage bot will have fewer changes to look at.