### PR TITLE
Use @available if available to silence a warning.

### DIFF
--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -149,7 +149,7 @@ typedef void (^AFURLSessionTaskCompletionHandler)(NSURLResponse *response, id re
             [weakTask suspend];
         };
 #if __has_warning("-Wunguarded-availability")
-        if (@available(iOS 9, macOS 10.11, tvOS 9, watchOS 2, *)) {
+        if (@available(iOS 9, macOS 10.11, *)) {
 #else
         if ([progress respondsToSelector:@selector(setResumingHandler:)]) {
 #endif

--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -148,7 +148,11 @@ typedef void (^AFURLSessionTaskCompletionHandler)(NSURLResponse *response, id re
         progress.pausingHandler = ^{
             [weakTask suspend];
         };
+#if __has_warning("-Wunguarded-availability")
+        if (@available(iOS 9, macOS 10.11, tvOS 9, watchOS 2, *)) {
+#else
         if ([progress respondsToSelector:@selector(setResumingHandler:)]) {
+#endif
             progress.resumingHandler = ^{
                 [weakTask resume];
             };

--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -148,7 +148,7 @@ typedef void (^AFURLSessionTaskCompletionHandler)(NSURLResponse *response, id re
         progress.pausingHandler = ^{
             [weakTask suspend];
         };
-#if __has_warning("-Wunguarded-availability")
+#if __has_warning("-Wunguarded-availability-new")
         if (@available(iOS 9, macOS 10.11, *)) {
 #else
         if ([progress respondsToSelector:@selector(setResumingHandler:)]) {


### PR DESCRIPTION
This PR fixes the last remaining issue encountered by running `pod lib lint`.