### PR TITLE
Remove conflicting nullable specifier on init

### DIFF
--- a/AFNetworking/AFNetworkReachabilityManager.h
+++ b/AFNetworking/AFNetworkReachabilityManager.h
@@ -108,11 +108,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithReachability:(SCNetworkReachabilityRef)reachability NS_DESIGNATED_INITIALIZER;
 
 /**
- *  Initializes an instance of a network reachability manager
- *
- *  @return nil as this method is unavailable
+ *  Unavailable initialiser
  */
-- (nullable instancetype)init NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
 
 ///--------------------------------------------------
 /// @name Starting & Stopping Reachability Monitoring

--- a/AFNetworking/AFNetworkReachabilityManager.m
+++ b/AFNetworking/AFNetworkReachabilityManager.m
@@ -170,8 +170,9 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {
     return self;
 }
 
-- (instancetype)init NS_UNAVAILABLE
+- (instancetype)init
 {
+    @throw [NSException exceptionWithName:NSGenericException reason:@"`-init` unavailable. Use `-initWithReachability:` instead" userInfo:nil];
     return nil;
 }
 


### PR DESCRIPTION
The nullable specifier on init conflicts with the nonnull specifier on NSObject which generates a warning. This change removes it and throws an exception if init is used.