### PR TITLE
Change the `requestHeaderModificationQueue` to do a serial dispatch q…

### DIFF
--- a/AFNetworking/AFURLRequestSerialization.m
+++ b/AFNetworking/AFURLRequestSerialization.m
@@ -206,7 +206,7 @@ static void *AFHTTPRequestSerializerObserverContext = &AFHTTPRequestSerializerOb
     self.stringEncoding = NSUTF8StringEncoding;
 
     self.mutableHTTPRequestHeaders = [NSMutableDictionary dictionary];
-    self.requestHeaderModificationQueue = dispatch_queue_create("requestHeaderModificationQueue", DISPATCH_QUEUE_CONCURRENT);
+    self.requestHeaderModificationQueue = dispatch_queue_create("requestHeaderModificationQueue", DISPATCH_QUEUE_SERIAL);
 
     // Accept-Language HTTP Header; see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.4
     NSMutableArray *acceptLanguagesComponents = [NSMutableArray array];


### PR DESCRIPTION
…ueue to prevent concurrent access to the `mutableHTTPRequestHeaders` dictionary.

Follows on discussions here and here:

https://github.com/AFNetworking/AFNetworking/pull/3891#issuecomment-370477767
https://github.com/AFNetworking/AFNetworking/issues/3636