### PR TITLE
Move a brace to make Xcode happy.

### DIFF
--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -149,14 +149,16 @@ typedef void (^AFURLSessionTaskCompletionHandler)(NSURLResponse *response, id re
             [weakTask suspend];
         };
 #if __has_warning("-Wunguarded-availability-new")
-        if (@available(iOS 9, macOS 10.11, *)) {
+        if (@available(iOS 9, macOS 10.11, *))
 #else
-        if ([progress respondsToSelector:@selector(setResumingHandler:)]) {
+        if ([progress respondsToSelector:@selector(setResumingHandler:)])
 #endif
+        {
             progress.resumingHandler = ^{
                 [weakTask resume];
             };
         }
+        
         [progress addObserver:self
                    forKeyPath:NSStringFromSelector(@selector(fractionCompleted))
                       options:NSKeyValueObservingOptionNew


### PR DESCRIPTION
The trailing brace within the #ifdef was confusig Xcode parsing the structure of the file. Fixes #4162.