### PR TITLE
Update Fastlane Configuration

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,4 +1,4 @@
 import_from_git(
   url: 'https://github.com/AFNetworking/fastlane.git', 
-  branch: '0.0.6'
+  branch: '0.0.8'
 )


### PR DESCRIPTION
After [this PR](https://github.com/AFNetworking/fastlane/pull/10), we should not be seeing the same CI errors we are currently seeing—we were using a deprecated logging method.