### PR TITLE
Remove conflicting nullable specifier on init

### DIFF
--- a/AFNetworking/AFNetworkReachabilityManager.h
+++ b/AFNetworking/AFNetworkReachabilityManager.h
@@ -108,11 +108,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithReachability:(SCNetworkReachabilityRef)reachability NS_DESIGNATED_INITIALIZER;
 
 /**
- *  Initializes an instance of a network reachability manager
- *
- *  @return nil as this method is unavailable
+ *  Unavailable initialiser
  */
-- (nullable instancetype)init NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
 
 ///--------------------------------------------------
 /// @name Starting & Stopping Reachability Monitoring

--- a/AFNetworking/AFNetworkReachabilityManager.h
+++ b/AFNetworking/AFNetworkReachabilityManager.h
@@ -108,7 +108,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithReachability:(SCNetworkReachabilityRef)reachability NS_DESIGNATED_INITIALIZER;
 
 /**
- *  Unavailable initialiser
+ *  Unavailable initializer
+ */
++ (instancetype)new NS_UNAVAILABLE;
+
+/**
+ *  Unavailable initializer
  */
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/AFNetworking/AFNetworkReachabilityManager.m
+++ b/AFNetworking/AFNetworkReachabilityManager.m
@@ -170,8 +170,9 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {
     return self;
 }
 
-- (instancetype)init NS_UNAVAILABLE
+- (instancetype)init
 {
+    @throw [NSException exceptionWithName:NSGenericException reason:@"`-init` unavailable. Use `-initWithReachability:` instead" userInfo:nil];
     return nil;
 }
 

--- a/AFNetworking/AFNetworkReachabilityManager.m
+++ b/AFNetworking/AFNetworkReachabilityManager.m
@@ -172,7 +172,9 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {
 
 - (instancetype)init
 {
-    @throw [NSException exceptionWithName:NSGenericException reason:@"`-init` unavailable. Use `-initWithReachability:` instead" userInfo:nil];
+    @throw [NSException exceptionWithName:NSGenericException
+                                   reason:@"`-init` unavailable. Use `-initWithReachability:` instead"
+                                 userInfo:nil];
     return nil;
 }
 

--- a/Tests/Tests/AFNetworkReachabilityManagerTests.m
+++ b/Tests/Tests/AFNetworkReachabilityManagerTests.m
@@ -23,6 +23,7 @@
 
 #import "AFNetworkReachabilityManager.h"
 #import <netinet/in.h>
+#import <objc/message.h>
 
 @interface AFNetworkReachabilityManagerTests : AFTestCase
 @property (nonatomic, strong) AFNetworkReachabilityManager *addressReachability;
@@ -45,6 +46,23 @@
     [self.domainReachability stopMonitoring];
 
     [super tearDown];
+}
+
+- (void)testInitializerThrowsExceptionWhenCalled {
+    XCTAssertThrows(^{
+        AFNetworkReachabilityManager *manager = [AFNetworkReachabilityManager alloc];
+        id (*custom_msgSend)(id, SEL) = (id(*)(id, SEL))objc_msgSend;
+        
+        manager = custom_msgSend(manager, @selector(init));
+    }());
+}
+
+- (void)testNewThrowsExceptionWhenCalled {
+    XCTAssertThrows(^{
+        id (*custom_msgSend)(id, SEL) = (id(*)(id, SEL))objc_msgSend;
+
+        __unused AFNetworkReachabilityManager *manager = custom_msgSend([AFNetworkReachabilityManager class], @selector(new));
+    }());
 }
 
 - (void)testAddressReachabilityStartsInUnknownState {

--- a/Tests/Tests/AFNetworkReachabilityManagerTests.m
+++ b/Tests/Tests/AFNetworkReachabilityManagerTests.m
@@ -49,20 +49,17 @@
 }
 
 - (void)testInitializerThrowsExceptionWhenCalled {
-    XCTAssertThrows(^{
-        AFNetworkReachabilityManager *manager = [AFNetworkReachabilityManager alloc];
-        id (*custom_msgSend)(id, SEL) = (id(*)(id, SEL))objc_msgSend;
-        
-        manager = custom_msgSend(manager, @selector(init));
-    }());
+    AFNetworkReachabilityManager *manager = [AFNetworkReachabilityManager alloc];
+    id (*custom_msgSend)(id, SEL) = (id(*)(id, SEL))objc_msgSend;
+
+    XCTAssertThrows(custom_msgSend(manager, @selector(init)));
 }
 
 - (void)testNewThrowsExceptionWhenCalled {
-    XCTAssertThrows(^{
-        id (*custom_msgSend)(id, SEL) = (id(*)(id, SEL))objc_msgSend;
+    id (*custom_msgSend)(id, SEL) = (id(*)(id, SEL))objc_msgSend;
 
-        __unused AFNetworkReachabilityManager *manager = custom_msgSend([AFNetworkReachabilityManager class], @selector(new));
-    }());
+    XCTAssertThrows(custom_msgSend([AFNetworkReachabilityManager class],
+                                   @selector(new)));
 }
 
 - (void)testAddressReachabilityStartsInUnknownState {


### PR DESCRIPTION
See #4154—this is just cherry-picking it onto `master`. Closes #4163. Closes #4154.