### PR TITLE
Check Security Policy only if baseURL is set

### DIFF
--- a/AFNetworking/AFHTTPSessionManager.m
+++ b/AFNetworking/AFHTTPSessionManager.m
@@ -101,7 +101,7 @@
 @dynamic securityPolicy;
 
 - (void)setSecurityPolicy:(AFSecurityPolicy *)securityPolicy {
-    if (securityPolicy.SSLPinningMode != AFSSLPinningModeNone && ![self.baseURL.scheme isEqualToString:@"https"]) {
+    if (securityPolicy.SSLPinningMode != AFSSLPinningModeNone && self.baseURL && ![self.baseURL.scheme isEqualToString:@"https"]) {
         NSString *pinningMode = @"Unknown Pinning Mode";
         switch (securityPolicy.SSLPinningMode) {
             case AFSSLPinningModeNone:        pinningMode = @"AFSSLPinningModeNone"; break;

--- a/Tests/Tests/AFHTTPSessionManagerTests.m
+++ b/Tests/Tests/AFHTTPSessionManagerTests.m
@@ -550,6 +550,18 @@
     XCTAssertThrowsSpecificNamed(manager.securityPolicy = securityPolicy, NSException, @"Invalid Security Policy");
 }
 
+- (void)testValidCertificatePinningSecurityPolicyWithoutBaseURL {		
+     AFHTTPSessionManager *manager = [[AFHTTPSessionManager alloc] init];		
+     AFSecurityPolicy *securityPolicy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModeCertificate];		
+     XCTAssertNoThrow(manager.securityPolicy = securityPolicy);		
+ }		
+ 		
+ - (void)testValidPublicKeyPinningSecurityPolicyWithoutBaseURL {		
+     AFHTTPSessionManager *manager = [[AFHTTPSessionManager alloc] init];		
+     AFSecurityPolicy *securityPolicy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModePublicKey];		
+     XCTAssertNoThrow(manager.securityPolicy = securityPolicy);
+ }
+
 # pragma mark - Server Trust
 
 - (void)testInvalidServerTrustProducesCorrectErrorForCertificatePinning {

--- a/Tests/Tests/AFHTTPSessionManagerTests.m
+++ b/Tests/Tests/AFHTTPSessionManagerTests.m
@@ -550,18 +550,6 @@
     XCTAssertThrowsSpecificNamed(manager.securityPolicy = securityPolicy, NSException, @"Invalid Security Policy");
 }
 
-- (void)testInvalidCertificatePinningSecurityPolicyWithoutBaseURL {
-    AFHTTPSessionManager *manager = [[AFHTTPSessionManager alloc] init];
-    AFSecurityPolicy *securityPolicy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModeCertificate];
-    XCTAssertThrowsSpecificNamed(manager.securityPolicy = securityPolicy, NSException, @"Invalid Security Policy");
-}
-
-- (void)testInvalidPublicKeyPinningSecurityPolicyWithoutBaseURL {
-    AFHTTPSessionManager *manager = [[AFHTTPSessionManager alloc] init];
-    AFSecurityPolicy *securityPolicy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModePublicKey];
-    XCTAssertThrowsSpecificNamed(manager.securityPolicy = securityPolicy, NSException, @"Invalid Security Policy");
-}
-
 # pragma mark - Server Trust
 
 - (void)testInvalidServerTrustProducesCorrectErrorForCertificatePinning {


### PR DESCRIPTION
There is no reason to assert on security policy if there is no baseURL. Doing that will break existing code that are indeed using https, but baseURL is not being used