### PR TITLE
Fix build error for Xcode 9.3 for macOS target

### DIFF
--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -1132,6 +1132,7 @@ didBecomeDownloadTask:(NSURLSessionDownloadTask *)downloadTask
     }
 }
 
+#if !TARGET_OS_MAC
 - (void)URLSessionDidFinishEventsForBackgroundURLSession:(NSURLSession *)session {
     if (self.didFinishEventsForBackgroundURLSession) {
         dispatch_async(dispatch_get_main_queue(), ^{
@@ -1139,6 +1140,7 @@ didBecomeDownloadTask:(NSURLSessionDownloadTask *)downloadTask
         });
     }
 }
+#endif
 
 #pragma mark - NSURLSessionDownloadDelegate
 


### PR DESCRIPTION
## Overview

Updated today and noticed this error when I was trying to build from Carthage:
```
/Users/jmanik/Documents/AFNetworking/AFNetworking/AFURLSessionManager.m:1135:1: error: implementing unavailable method [-Werror,-Wdeprecated-implementations]
- (void)URLSessionDidFinishEventsForBackgroundURLSession:(NSURLSession *)session {
^
In module 'Foundation' imported from /Users/jmanik/Documents/AFNetworking/AFNetworking/AFURLSessionManager.h:23:
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Foundation.framework/Headers/NSURLSession.h:710:1: note: method 'URLSessionDidFinishEventsForBackgroundURLSession:' declared here
- (void)URLSessionDidFinishEventsForBackgroundURLSession:(NSURLSession *)session API_AVAILABLE(ios(7.0), watchos(2.0), tvos(9.0)) API_UNAVAILABLE(macos);
^
1 error generated.
```

It looks like they flagged this function as unavailable for macOS:
https://developer.apple.com/documentation/foundation/nsurlsessiondelegate/1617185-urlsessiondidfinisheventsforback

So I just added a static guard to prevent that function from being compiled with the macOS target.