### PR TITLE
Safely get mergedTasks On responseQueue

### DIFF
--- a/UIKit+AFNetworking/AFImageDownloader.m
+++ b/UIKit+AFNetworking/AFImageDownloader.m
@@ -254,7 +254,7 @@
                        completionHandler:^(NSURLResponse * _Nonnull response, id  _Nullable responseObject, NSError * _Nullable error) {
                            dispatch_async(self.responseQueue, ^{
                                __strong __typeof__(weakSelf) strongSelf = weakSelf;
-                               AFImageDownloaderMergedTask *mergedTask = strongSelf.mergedTasks[URLIdentifier];
+                               AFImageDownloaderMergedTask *mergedTask = [strongSelf safelyGetMergedTask: URLIdentifier];
                                if ([mergedTask.identifier isEqual:mergedTaskIdentifier]) {
                                    mergedTask = [strongSelf safelyRemoveMergedTaskWithURLIdentifier:URLIdentifier];
                                    if (error) {
@@ -402,6 +402,14 @@
 
 - (BOOL)isActiveRequestCountBelowMaximumLimit {
     return self.activeRequestCount < self.maximumActiveDownloads;
+}
+
+- (AFImageDownloaderMergedTask *)safelyGetMergedTask:(NSString *)URLIdentifier {
+    __block AFImageDownloaderMergedTask *mergedTask;
+    dispatch_sync(self.synchronizationQueue, ^(){
+        mergedTask = self.mergedTasks[URLIdentifier];
+    });
+    return mergedTask;
 }
 
 @end

--- a/UIKit+AFNetworking/AFImageDownloader.m
+++ b/UIKit+AFNetworking/AFImageDownloader.m
@@ -254,7 +254,7 @@
                        completionHandler:^(NSURLResponse * _Nonnull response, id  _Nullable responseObject, NSError * _Nullable error) {
                            dispatch_async(self.responseQueue, ^{
                                __strong __typeof__(weakSelf) strongSelf = weakSelf;
-                               AFImageDownloaderMergedTask *mergedTask = [strongSelf safelyGetMergedTask: URLIdentifier];
+                               AFImageDownloaderMergedTask *mergedTask = [strongSelf safelyGetMergedTask:URLIdentifier];
                                if ([mergedTask.identifier isEqual:mergedTaskIdentifier]) {
                                    mergedTask = [strongSelf safelyRemoveMergedTaskWithURLIdentifier:URLIdentifier];
                                    if (error) {


### PR DESCRIPTION
There is a race condition in -[AFImageDownloader downloadImageForURLRequest:withReceiptID:success:failure:] that can cause a crash.
#3876

The race condition can be seen with the Xcode Thread Sanitizer on and the project downloading and cancelling images quickly. 
In particular I noticed this downloading images for UITableViewCells and scrolling through the tableView.
#3984 

I think the main issue here is that `mergedTasks` is always updated on `synchronizationQueue` and it is being accessed on `responseQueue`. So there could be a change to the dictionary on a different thread.