### PR TITLE
Add an ability that notification-observer know which reachability it belongs

### DIFF
--- a/AFNetworking/AFNetworkReachabilityManager.h
+++ b/AFNetworking/AFNetworkReachabilityManager.h
@@ -151,6 +151,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)setReachabilityStatusChangeBlock:(nullable void (^)(AFNetworkReachabilityStatus status))block;
 
+/**
+ Returns the reachability of current networkReachabilityManager.
+ */
+- (SCNetworkReachabilityRef)currentNetworkReachability;
+
 @end
 
 ///----------------

--- a/AFNetworking/AFNetworkReachabilityManager.h
+++ b/AFNetworking/AFNetworkReachabilityManager.h
@@ -151,11 +151,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)setReachabilityStatusChangeBlock:(nullable void (^)(AFNetworkReachabilityStatus status))block;
 
-/**
- Returns the reachability of current networkReachabilityManager.
- */
-- (SCNetworkReachabilityRef)currentNetworkReachability;
-
 @end
 
 ///----------------

--- a/AFNetworking/AFNetworkReachabilityManager.m
+++ b/AFNetworking/AFNetworkReachabilityManager.m
@@ -32,6 +32,7 @@ NSString * const AFNetworkingReachabilityDidChangeNotification = @"com.alamofire
 NSString * const AFNetworkingReachabilityNotificationStatusItem = @"AFNetworkingReachabilityNotificationStatusItem";
 
 typedef void (^AFNetworkReachabilityStatusBlock)(AFNetworkReachabilityStatus status);
+typedef AFNetworkReachabilityManager * (^AFNetworkReachabilityStatusCallback)(AFNetworkReachabilityStatus status);
 
 NSString * AFStringFromNetworkReachabilityStatus(AFNetworkReachabilityStatus status) {
     switch (status) {
@@ -78,20 +79,21 @@ static AFNetworkReachabilityStatus AFNetworkReachabilityStatusForFlags(SCNetwork
  * a queued notification (for an earlier status condition) is processed after
  * the later update, resulting in the listener being left in the wrong state.
  */
-static void AFPostReachabilityStatusChange(SCNetworkReachabilityRef target, SCNetworkReachabilityFlags flags, AFNetworkReachabilityStatusBlock block) {
+static void AFPostReachabilityStatusChange(SCNetworkReachabilityRef target, SCNetworkReachabilityFlags flags, AFNetworkReachabilityStatusCallback block) {
     AFNetworkReachabilityStatus status = AFNetworkReachabilityStatusForFlags(flags);
     dispatch_async(dispatch_get_main_queue(), ^{
+        AFNetworkReachabilityManager *manager = nil;
         if (block) {
-            block(status);
+            manager = block(status);
         }
         NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
         NSDictionary *userInfo = @{ AFNetworkingReachabilityNotificationStatusItem: @(status) };
-        [notificationCenter postNotificationName:AFNetworkingReachabilityDidChangeNotification object:(__bridge id)target userInfo:userInfo];
+        [notificationCenter postNotificationName:AFNetworkingReachabilityDidChangeNotification object:manager userInfo:userInfo];
     });
 }
 
 static void AFNetworkReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkReachabilityFlags flags, void *info) {
-    AFPostReachabilityStatusChange(target, flags, (__bridge AFNetworkReachabilityStatusBlock)info);
+    AFPostReachabilityStatusChange(target, flags, (__bridge AFNetworkReachabilityStatusCallback)info);
 }
 
 
@@ -210,14 +212,15 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {
     }
 
     __weak __typeof(self)weakSelf = self;
-    AFNetworkReachabilityStatusBlock callback = ^(AFNetworkReachabilityStatus status) {
+    AFNetworkReachabilityStatusCallback callback = ^(AFNetworkReachabilityStatus status) {
         __strong __typeof(weakSelf)strongSelf = weakSelf;
 
         strongSelf.networkReachabilityStatus = status;
         if (strongSelf.networkReachabilityStatusBlock) {
             strongSelf.networkReachabilityStatusBlock(status);
         }
-
+        
+        return strongSelf;
     };
 
     SCNetworkReachabilityContext context = {0, (__bridge void *)callback, AFNetworkReachabilityRetainCallback, AFNetworkReachabilityReleaseCallback, NULL};
@@ -250,12 +253,6 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {
 
 - (void)setReachabilityStatusChangeBlock:(void (^)(AFNetworkReachabilityStatus status))block {
     self.networkReachabilityStatusBlock = block;
-}
-
-#pragma mark -
-
-- (SCNetworkReachabilityRef)currentNetworkReachability {
-    return self.networkReachability;
 }
 
 #pragma mark - NSKeyValueObserving

--- a/AFNetworking/AFNetworkReachabilityManager.m
+++ b/AFNetworking/AFNetworkReachabilityManager.m
@@ -79,7 +79,7 @@ static AFNetworkReachabilityStatus AFNetworkReachabilityStatusForFlags(SCNetwork
  * a queued notification (for an earlier status condition) is processed after
  * the later update, resulting in the listener being left in the wrong state.
  */
-static void AFPostReachabilityStatusChange(SCNetworkReachabilityRef target, SCNetworkReachabilityFlags flags, AFNetworkReachabilityStatusCallback block) {
+static void AFPostReachabilityStatusChange(SCNetworkReachabilityFlags flags, AFNetworkReachabilityStatusCallback block) {
     AFNetworkReachabilityStatus status = AFNetworkReachabilityStatusForFlags(flags);
     dispatch_async(dispatch_get_main_queue(), ^{
         AFNetworkReachabilityManager *manager = nil;
@@ -92,8 +92,8 @@ static void AFPostReachabilityStatusChange(SCNetworkReachabilityRef target, SCNe
     });
 }
 
-static void AFNetworkReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkReachabilityFlags flags, void *info) {
-    AFPostReachabilityStatusChange(target, flags, (__bridge AFNetworkReachabilityStatusCallback)info);
+static void AFNetworkReachabilityCallback(SCNetworkReachabilityRef __unused target, SCNetworkReachabilityFlags flags, void *info) {
+    AFPostReachabilityStatusChange(flags, (__bridge AFNetworkReachabilityStatusCallback)info);
 }
 
 
@@ -230,7 +230,7 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0),^{
         SCNetworkReachabilityFlags flags;
         if (SCNetworkReachabilityGetFlags(self.networkReachability, &flags)) {
-            AFPostReachabilityStatusChange(self.networkReachability, flags, callback);
+            AFPostReachabilityStatusChange(flags, callback);
         }
     });
 }

--- a/Tests/Tests/AFNetworkReachabilityManagerTests.m
+++ b/Tests/Tests/AFNetworkReachabilityManagerTests.m
@@ -125,24 +125,15 @@
     [self verifyReachabilityStatusBlockGetsCalledWithManager:self.domainReachability];
 }
 
-- (void)testDifferentReachabilityManagerNotificationPostsAndGets {
-    [self verifyReachabilityNotificationPostsAndGetsConsistenceWithPostsManager:self.domainReachability getsManager:self.addressReachability];
-}
-
-- (void)testSameReachabilityManagerNotificationPostsAndGets {
-    [self verifyReachabilityNotificationPostsAndGetsConsistenceWithPostsManager:self.addressReachability getsManager:self.addressReachability];
-}
-
-- (void)verifyReachabilityNotificationPostsAndGetsConsistenceWithPostsManager:(AFNetworkReachabilityManager *)postsManager getsManager:(AFNetworkReachabilityManager *)getsManager {
-    BOOL isSameReachabilityManager = [postsManager isEqual:getsManager];
+- (void)testObjectPostingReachabilityManagerNotification {
     [self expectationForNotification:AFNetworkingReachabilityDidChangeNotification
-                              object:nil
-                             handler:^BOOL(NSNotification *note) {
-                                 BOOL isSameReachabilityManagerPostsAndGets = [note.object isEqual:getsManager];
-                                 return isSameReachabilityManager == isSameReachabilityManagerPostsAndGets;
+                              object:self.domainReachability
+                             handler:^BOOL(NSNotification *notification) {
+                                 BOOL isObjectPostingNotification = [notification.object isEqual:self.domainReachability];
+                                 return isObjectPostingNotification;
                              }];
     
-    [postsManager startMonitoring];
+    [self.domainReachability startMonitoring];
     
     [self waitForExpectationsWithCommonTimeout];
 }

--- a/Tests/Tests/AFNetworkReachabilityManagerTests.m
+++ b/Tests/Tests/AFNetworkReachabilityManagerTests.m
@@ -126,25 +126,23 @@
 }
 
 - (void)testDifferentReachabilityManagerNotificationPostsAndGets {
-    [self verifyReachabilityNotificationPostsAndGetsConsistenceWithManager:self.domainReachability notificationManager:self.addressReachability];
+    [self verifyReachabilityNotificationPostsAndGetsConsistenceWithPostsManager:self.domainReachability getsManager:self.addressReachability];
 }
 
 - (void)testSameReachabilityManagerNotificationPostsAndGets {
-    [self verifyReachabilityNotificationPostsAndGetsConsistenceWithManager:self.addressReachability notificationManager:self.addressReachability];
+    [self verifyReachabilityNotificationPostsAndGetsConsistenceWithPostsManager:self.addressReachability getsManager:self.addressReachability];
 }
 
-- (void)verifyReachabilityNotificationPostsAndGetsConsistenceWithManager:(AFNetworkReachabilityManager *)currentManager notificationManager:(AFNetworkReachabilityManager *)noteManager {
-    BOOL isSameReachabilityManager = [currentManager isEqual:noteManager];
+- (void)verifyReachabilityNotificationPostsAndGetsConsistenceWithPostsManager:(AFNetworkReachabilityManager *)postsManager getsManager:(AFNetworkReachabilityManager *)getsManager {
+    BOOL isSameReachabilityManager = [postsManager isEqual:getsManager];
     [self expectationForNotification:AFNetworkingReachabilityDidChangeNotification
                               object:nil
                              handler:^BOOL(NSNotification *note) {
-                                 id currentReachabilityRef = (__bridge id)currentManager.currentNetworkReachability;
-                                 id noteReachabilityRef = note.object;
-                                 BOOL isSameReachabilityRef = [currentReachabilityRef isEqual:noteReachabilityRef];
-                                 return isSameReachabilityManager == isSameReachabilityRef;
+                                 BOOL isSameReachabilityManagerPostsAndGets = [note.object isEqual:getsManager];
+                                 return isSameReachabilityManager == isSameReachabilityManagerPostsAndGets;
                              }];
     
-    [noteManager startMonitoring];
+    [postsManager startMonitoring];
     
     [self waitForExpectationsWithCommonTimeout];
 }

--- a/Tests/Tests/AFNetworkReachabilityManagerTests.m
+++ b/Tests/Tests/AFNetworkReachabilityManagerTests.m
@@ -125,4 +125,28 @@
     [self verifyReachabilityStatusBlockGetsCalledWithManager:self.domainReachability];
 }
 
+- (void)testDifferentReachabilityManagerNotificationPostsAndGets {
+    [self verifyReachabilityNotificationPostsAndGetsConsistenceWithManager:self.domainReachability notificationManager:self.addressReachability];
+}
+
+- (void)testSameReachabilityManagerNotificationPostsAndGets {
+    [self verifyReachabilityNotificationPostsAndGetsConsistenceWithManager:self.addressReachability notificationManager:self.addressReachability];
+}
+
+- (void)verifyReachabilityNotificationPostsAndGetsConsistenceWithManager:(AFNetworkReachabilityManager *)currentManager notificationManager:(AFNetworkReachabilityManager *)noteManager {
+    BOOL isSameReachabilityManager = [currentManager isEqual:noteManager];
+    [self expectationForNotification:AFNetworkingReachabilityDidChangeNotification
+                              object:nil
+                             handler:^BOOL(NSNotification *note) {
+                                 id currentReachabilityRef = (__bridge id)currentManager.currentNetworkReachability;
+                                 id noteReachabilityRef = note.object;
+                                 BOOL isSameReachabilityRef = [currentReachabilityRef isEqual:noteReachabilityRef];
+                                 return isSameReachabilityManager == isSameReachabilityRef;
+                             }];
+    
+    [noteManager startMonitoring];
+    
+    [self waitForExpectationsWithCommonTimeout];
+}
+
 @end


### PR DESCRIPTION
there exists one problem [AFNetworkReachabilityManager shareManager] is singleton，but it also support that create other AFNetworkReachabilityManager by method ‘managerForDomain’ or ’managerForAddress‘. the two case is opposite.
so if network change, trigger posting AFNetworkingReachabilityDidChangeNotification , receiver can not know which is the actully sender，it will get multiple notification，then the receiver notification method would call multiple times, maybe cause continuously unexpectedly result.