### PR TITLE
Logical repair

### DIFF
--- a/AFNetworking/AFURLRequestSerialization.m
+++ b/AFNetworking/AFURLRequestSerialization.m
@@ -366,10 +366,12 @@ forHTTPHeaderField:(NSString *)field
 
     NSMutableURLRequest *mutableRequest = [[NSMutableURLRequest alloc] initWithURL:url];
     mutableRequest.HTTPMethod = method;
-
-    for (NSString *keyPath in AFHTTPRequestSerializerObservedKeyPaths()) {
-        if ([self.mutableObservedChangedKeyPaths containsObject:keyPath]) {
-            [mutableRequest setValue:[self valueForKeyPath:keyPath] forKey:keyPath];
+					     
+    if (self.mutableObservedChangedKeyPaths.count) {
+        for (NSString *keyPath in AFHTTPRequestSerializerObservedKeyPaths()) {
+            if ([self.mutableObservedChangedKeyPaths containsObject:keyPath]) {
+                [mutableRequest setValue:[self valueForKeyPath:keyPath] forKey:keyPath];
+            }
         }
     }
 


### PR DESCRIPTION
Logical repair : self.mutableObservedChangedKeyPaths maybe is empty But the loop is still in execution
If there is no element, it should skip