### PR TITLE
Fix Crash :nil the uploadProgress and downloadProgress, when AFURLSessionManagerTaskDelegate dealloc

### DIFF
--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -179,6 +179,9 @@ typedef void (^AFURLSessionTaskCompletionHandler)(NSURLResponse *response, id re
 - (void)dealloc {
     [self.downloadProgress removeObserver:self forKeyPath:NSStringFromSelector(@selector(fractionCompleted))];
     [self.uploadProgress removeObserver:self forKeyPath:NSStringFromSelector(@selector(fractionCompleted))];
+    self.downloadProgress = nil;
+    self.uploadProgress = nil;
+
 }
 
 #pragma mark - NSProgress Tracking


### PR DESCRIPTION
I encounter this crash, which maybe caused by multiple threads operation.
So I nil the NSProgress property when dealloc.

libobjc.A.dylib | objc_msgSend + 16
-- | --
1 Foundation | -[NSProgress dealloc] + 192
2 Gundam | -[AFURLSessionManagerTaskDelegate .cxx_destruct] (AFURLSessionManager.m:127)
3 libobjc.A.dylib | object_cxxDestructFromClass(objc_object*, objc_class*) + 148
4 libobjc.A.dylib | objc_destructInstance + 68
5 libobjc.A.dylib | object_dispose + 16
6 Gundam | -[AFURLSessionManagerTaskDelegate dealloc] (AFURLSessionManager.m:171)
7 Gundam | __destroy_helper_block_ (m:244)
8 libsystem_blocks.dylib | _Block_release + 152
9 libdispatch.dylib | __dispatch_client_callout + 16
10 libdispatch.dylib | __dispatch_main_queue_callback_4CF$VARIANT$armv81 + 528
11 CoreFoundation | ___CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__ + 12
12 CoreFoundation | ___CFRunLoopRun + 2272
13 CoreFoundation | CFRunLoopRunSpecific + 552
14 GraphicsServices | GSEventRunModal + 100
15 UIKit | UIApplicationMain + 236

