### PR TITLE
AFNetworking 2.0 - Fix empty content crash on AFHTTPSessionManager.post

### DIFF
--- a/AFNetworking/AFHTTPSessionManager.h
+++ b/AFNetworking/AFHTTPSessionManager.h
@@ -181,7 +181,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (nullable NSURLSessionDataTask *)POST:(NSString *)URLString
                     parameters:(nullable id)parameters
-                       success:(nullable void (^)(NSURLSessionDataTask *task, id responseObject))success
+                       success:(nullable void (^)(NSURLSessionDataTask *task, id __nullable responseObject))success
                        failure:(nullable void (^)(NSURLSessionDataTask * __nullable task, NSError *error))failure;
 
 /**
@@ -198,7 +198,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSURLSessionDataTask *)POST:(NSString *)URLString
                     parameters:(nullable id)parameters
      constructingBodyWithBlock:(nullable void (^)(id <AFMultipartFormData> formData))block
-                       success:(nullable void (^)(NSURLSessionDataTask *task, id responseObject))success
+                       success:(nullable void (^)(NSURLSessionDataTask *task, id __nullable responseObject))success
                        failure:(nullable void (^)(NSURLSessionDataTask * __nullable task, NSError *error))failure;
 
 /**

--- a/AFNetworking/AFHTTPSessionManager.m
+++ b/AFNetworking/AFHTTPSessionManager.m
@@ -136,7 +136,7 @@
 
 - (NSURLSessionDataTask *)POST:(NSString *)URLString
                     parameters:(id)parameters
-                       success:(void (^)(NSURLSessionDataTask *task, id responseObject))success
+                       success:(void (^)(NSURLSessionDataTask *task, id _nullable responseObject))success
                        failure:(void (^)(NSURLSessionDataTask *task, NSError *error))failure
 {
     NSURLSessionDataTask *dataTask = [self dataTaskWithHTTPMethod:@"POST" URLString:URLString parameters:parameters success:success failure:failure];
@@ -149,7 +149,7 @@
 - (NSURLSessionDataTask *)POST:(NSString *)URLString
                     parameters:(id)parameters
      constructingBodyWithBlock:(void (^)(id <AFMultipartFormData> formData))block
-                       success:(void (^)(NSURLSessionDataTask *task, id responseObject))success
+                       success:(void (^)(NSURLSessionDataTask *task, id _nullable responseObject))success
                        failure:(void (^)(NSURLSessionDataTask *task, NSError *error))failure
 {
     NSError *serializationError = nil;


### PR DESCRIPTION
If you are consuming the AFHTTPSessionManager from swift on xcode 9.3 or above, this will crash when the response has no content (204). This is because of strict closure signature in swift.