### PR TITLE
Fix podspec #trivial #important

### DIFF
--- a/AFNetworking.podspec
+++ b/AFNetworking.podspec
@@ -27,7 +27,7 @@ Pod::Spec.new do |s|
 EOS
   s.prefix_header_contents = pch_AF
   
-  s.ios.deployment_target = '7.0'
+  s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.9'
   s.watchos.deployment_target = '2.0'
   s.tvos.deployment_target = '9.0'
@@ -47,7 +47,7 @@ EOS
   end
 
   s.subspec 'Reachability' do |ss|
-    ss.ios.deployment_target = '7.0'
+    ss.ios.deployment_target = '8.0'
     ss.osx.deployment_target = '10.9'
     ss.tvos.deployment_target = '9.0'
 
@@ -69,7 +69,7 @@ EOS
   end
 
   s.subspec 'UIKit' do |ss|
-    ss.ios.deployment_target = '7.0'
+    ss.ios.deployment_target = '8.0'
     ss.tvos.deployment_target = '9.0'
     ss.dependency 'AFNetworking/NSURLSession'
 


### PR DESCRIPTION
- Fix podspec as library version supports iOS 8+ (in project) but podspec says iOS 7+

Note: We should release new version with this fix I think.