### PR TITLE
Fix build error when using UIKit for Mac (Project Catalyst)

### DIFF
--- a/UIKit+AFNetworking/AFImageDownloader.m
+++ b/UIKit+AFNetworking/AFImageDownloader.m
@@ -120,7 +120,7 @@
     if ([[[UIDevice currentDevice] systemVersion] compare:@"8.2" options:NSNumericSearch] == NSOrderedAscending) {
         return [NSURLCache sharedURLCache];
     }
-#if TARGET_OS_MACCATALYST
+#if defined(TARGET_OS_MACCATALYST) && TARGET_OS_MACCATALYST
     return [[NSURLCache alloc] initWithMemoryCapacity:20 * 1024 * 1024
                                          diskCapacity:150 * 1024 * 1024
                                          directoryURL:[NSURL URLWithString:@"com.alamofire.imagedownloader"]];

--- a/UIKit+AFNetworking/AFImageDownloader.m
+++ b/UIKit+AFNetworking/AFImageDownloader.m
@@ -120,12 +120,17 @@
     if ([[[UIDevice currentDevice] systemVersion] compare:@"8.2" options:NSNumericSearch] == NSOrderedAscending) {
         return [NSURLCache sharedURLCache];
     }
-#if defined(TARGET_OS_MACCATALYST) && TARGET_OS_MACCATALYST
+#if TARGET_OS_MACCATALYST
     return [[NSURLCache alloc] initWithMemoryCapacity:20 * 1024 * 1024
                                          diskCapacity:150 * 1024 * 1024
                                          directoryURL:[NSURL URLWithString:@"com.alamofire.imagedownloader"]];
 #else
+#if AF_CAN_USE_AT_AVAILABLE
     if (@available(iOS 13.0, *)) {
+#else
+    if ([NSURLCache instancesRespondToSelector:@selector(initWithMemoryCapacity:diskCapacity:directoryURL:)])
+#endif
+    {
         return [[NSURLCache alloc] initWithMemoryCapacity:20 * 1024 * 1024
                                              diskCapacity:150 * 1024 * 1024
                                              directoryURL:[NSURL URLWithString:@"com.alamofire.imagedownloader"]];

--- a/UIKit+AFNetworking/AFImageDownloader.m
+++ b/UIKit+AFNetworking/AFImageDownloader.m
@@ -120,7 +120,7 @@
     if ([[[UIDevice currentDevice] systemVersion] compare:@"8.2" options:NSNumericSearch] == NSOrderedAscending) {
         return [NSURLCache sharedURLCache];
     }
-#if TARGET_OS_UIKITFORMAC
+#if TARGET_OS_MACCATALYST
     return [[NSURLCache alloc] initWithMemoryCapacity:20 * 1024 * 1024
                                          diskCapacity:150 * 1024 * 1024
                                          directoryURL:[NSURL URLWithString:@"com.alamofire.imagedownloader"]];

--- a/UIKit+AFNetworking/AFImageDownloader.m
+++ b/UIKit+AFNetworking/AFImageDownloader.m
@@ -126,7 +126,7 @@
                                          directoryURL:[NSURL URLWithString:@"com.alamofire.imagedownloader"]];
 #else
 #if AF_CAN_USE_AT_AVAILABLE
-    if (@available(iOS 13.0, *)) {
+    if (@available(iOS 13.0, *))
 #else
     if ([NSURLCache instancesRespondToSelector:@selector(initWithMemoryCapacity:diskCapacity:directoryURL:)])
 #endif

--- a/UIKit+AFNetworking/AFImageDownloader.m
+++ b/UIKit+AFNetworking/AFImageDownloader.m
@@ -120,9 +120,21 @@
     if ([[[UIDevice currentDevice] systemVersion] compare:@"8.2" options:NSNumericSearch] == NSOrderedAscending) {
         return [NSURLCache sharedURLCache];
     }
+#if TARGET_OS_UIKITFORMAC
     return [[NSURLCache alloc] initWithMemoryCapacity:20 * 1024 * 1024
                                          diskCapacity:150 * 1024 * 1024
-                                             diskPath:@"com.alamofire.imagedownloader"];
+                                         directoryURL:[NSURL URLWithString:@"com.alamofire.imagedownloader"]];
+#else
+    if (@available(iOS 13.0, *)) {
+        return [[NSURLCache alloc] initWithMemoryCapacity:20 * 1024 * 1024
+                                             diskCapacity:150 * 1024 * 1024
+                                             directoryURL:[NSURL URLWithString:@"com.alamofire.imagedownloader"]];
+    } else {
+        return [[NSURLCache alloc] initWithMemoryCapacity:20 * 1024 * 1024
+                                             diskCapacity:150 * 1024 * 1024
+                                                 diskPath:@"com.alamofire.imagedownloader"];
+    }
+#endif
 }
 
 + (NSURLSessionConfiguration *)defaultURLSessionConfiguration {


### PR DESCRIPTION
As the error states:

> 'initWithMemoryCapacity:diskCapacity:diskPath:' is unavailable: not
  available on macCatalyst

and it will also be deprecated in iOS 13.