### PR TITLE
Fix AFNetworking UIWebView extensions migrated to WKWebView

### DIFF
--- a/AFNetworking.podspec
+++ b/AFNetworking.podspec
@@ -69,7 +69,7 @@ EOS
   end
 
   s.subspec 'UIKit' do |ss|
-    ss.ios.deployment_target = '8.0'
+    ss.ios.deployment_target = '9.0'
     ss.tvos.deployment_target = '9.0'
     ss.dependency 'AFNetworking/NSURLSession'
 

--- a/AFNetworking.xcodeproj/project.pbxproj
+++ b/AFNetworking.xcodeproj/project.pbxproj
@@ -144,8 +144,6 @@
 		299522AD1BBF13C700859F49 /* UIProgressView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 299522971BBF13C700859F49 /* UIProgressView+AFNetworking.m */; };
 		299522AE1BBF13C700859F49 /* UIRefreshControl+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 299522981BBF13C700859F49 /* UIRefreshControl+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		299522AF1BBF13C700859F49 /* UIRefreshControl+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 299522991BBF13C700859F49 /* UIRefreshControl+AFNetworking.m */; };
-		299522B01BBF13C700859F49 /* UIWebView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 2995229A1BBF13C700859F49 /* UIWebView+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		299522B11BBF13C700859F49 /* UIWebView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 2995229B1BBF13C700859F49 /* UIWebView+AFNetworking.m */; };
 		29D3413F1C20D46400A7D266 /* AFCompoundResponseSerializerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 29D3413E1C20D46400A7D266 /* AFCompoundResponseSerializerTests.m */; };
 		29D341401C20D46400A7D266 /* AFCompoundResponseSerializerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 29D3413E1C20D46400A7D266 /* AFCompoundResponseSerializerTests.m */; };
 		29D341411C20D46400A7D266 /* AFCompoundResponseSerializerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 29D3413E1C20D46400A7D266 /* AFCompoundResponseSerializerTests.m */; };
@@ -176,11 +174,13 @@
 		29D96E981BCC406B00F571A5 /* UIImage+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 299522921BBF13C700859F49 /* UIImage+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		29D96E991BCC406B00F571A5 /* UIImageView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 299522931BBF13C700859F49 /* UIImageView+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		29D96E9A1BCC406B00F571A5 /* UIProgressView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 299522961BBF13C700859F49 /* UIProgressView+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		29F5EF031C47E64F008B976A /* AFUIWebViewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 29F5EF021C47E64F008B976A /* AFUIWebViewTests.m */; };
 		2D4563901DB1179D00AE4812 /* AFXMLParserResponseSerializerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D45638F1DB1179D00AE4812 /* AFXMLParserResponseSerializerTests.m */; };
 		2D4563911DB117A200AE4812 /* AFXMLParserResponseSerializerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D45638F1DB1179D00AE4812 /* AFXMLParserResponseSerializerTests.m */; };
 		2D4563921DB117A200AE4812 /* AFXMLParserResponseSerializerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D45638F1DB1179D00AE4812 /* AFXMLParserResponseSerializerTests.m */; };
 		2D4563941DB11DDB00AE4812 /* AFXMLDocumentResponseSerializerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D4563931DB11DDB00AE4812 /* AFXMLDocumentResponseSerializerTests.m */; };
+		323D83E2231D185400C5BFC6 /* WKWebView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 323D83E0231D185400C5BFC6 /* WKWebView+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		323D83E3231D185400C5BFC6 /* WKWebView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 323D83E1231D185400C5BFC6 /* WKWebView+AFNetworking.m */; };
+		323D83E5231D188400C5BFC6 /* AFWKWebViewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 323D83E4231D188400C5BFC6 /* AFWKWebViewTests.m */; };
 		5F4323BB1BF63741003B8749 /* Equifax_Secure_Certificate_Authority_Root.cer in Resources */ = {isa = PBXBuildFile; fileRef = 5F4323B31BF63741003B8749 /* Equifax_Secure_Certificate_Authority_Root.cer */; };
 		5F4323BC1BF63741003B8749 /* Equifax_Secure_Certificate_Authority_Root.cer in Resources */ = {isa = PBXBuildFile; fileRef = 5F4323B31BF63741003B8749 /* Equifax_Secure_Certificate_Authority_Root.cer */; };
 		5F4323BD1BF63741003B8749 /* Equifax_Secure_Certificate_Authority_Root.cer in Resources */ = {isa = PBXBuildFile; fileRef = 5F4323B31BF63741003B8749 /* Equifax_Secure_Certificate_Authority_Root.cer */; };
@@ -302,12 +302,12 @@
 		299522971BBF13C700859F49 /* UIProgressView+AFNetworking.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIProgressView+AFNetworking.m"; sourceTree = "<group>"; };
 		299522981BBF13C700859F49 /* UIRefreshControl+AFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIRefreshControl+AFNetworking.h"; sourceTree = "<group>"; };
 		299522991BBF13C700859F49 /* UIRefreshControl+AFNetworking.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIRefreshControl+AFNetworking.m"; sourceTree = "<group>"; };
-		2995229A1BBF13C700859F49 /* UIWebView+AFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIWebView+AFNetworking.h"; sourceTree = "<group>"; };
-		2995229B1BBF13C700859F49 /* UIWebView+AFNetworking.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIWebView+AFNetworking.m"; sourceTree = "<group>"; };
 		29D3413E1C20D46400A7D266 /* AFCompoundResponseSerializerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFCompoundResponseSerializerTests.m; sourceTree = "<group>"; };
-		29F5EF021C47E64F008B976A /* AFUIWebViewTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFUIWebViewTests.m; sourceTree = "<group>"; };
 		2D45638F1DB1179D00AE4812 /* AFXMLParserResponseSerializerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFXMLParserResponseSerializerTests.m; sourceTree = "<group>"; };
 		2D4563931DB11DDB00AE4812 /* AFXMLDocumentResponseSerializerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFXMLDocumentResponseSerializerTests.m; sourceTree = "<group>"; };
+		323D83E0231D185400C5BFC6 /* WKWebView+AFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "WKWebView+AFNetworking.h"; sourceTree = "<group>"; };
+		323D83E1231D185400C5BFC6 /* WKWebView+AFNetworking.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "WKWebView+AFNetworking.m"; sourceTree = "<group>"; };
+		323D83E4231D188400C5BFC6 /* AFWKWebViewTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFWKWebViewTests.m; sourceTree = "<group>"; };
 		5F4323B31BF63741003B8749 /* Equifax_Secure_Certificate_Authority_Root.cer */ = {isa = PBXFileReference; lastKnownFileType = file; path = Equifax_Secure_Certificate_Authority_Root.cer; sourceTree = "<group>"; };
 		5F4323B41BF63741003B8749 /* GeoTrust_Global_CA-cross.cer */ = {isa = PBXFileReference; lastKnownFileType = file; path = "GeoTrust_Global_CA-cross.cer"; sourceTree = "<group>"; };
 		5F4323B51BF63741003B8749 /* google.com.cer */ = {isa = PBXFileReference; lastKnownFileType = file; path = google.com.cer; sourceTree = "<group>"; };
@@ -468,7 +468,7 @@
 				298D7C8D1BC2C88F00FD3B3E /* AFUIImageViewTests.m */,
 				298D7C8E1BC2C88F00FD3B3E /* AFUIRefreshControlTests.m */,
 				2960BAC21C1B2F1A00BA02F0 /* AFUIButtonTests.m */,
-				29F5EF021C47E64F008B976A /* AFUIWebViewTests.m */,
+				323D83E4231D188400C5BFC6 /* AFWKWebViewTests.m */,
 			);
 			name = "AFNetworking UIKit Tests";
 			sourceTree = "<group>";
@@ -552,8 +552,8 @@
 				299522971BBF13C700859F49 /* UIProgressView+AFNetworking.m */,
 				299522981BBF13C700859F49 /* UIRefreshControl+AFNetworking.h */,
 				299522991BBF13C700859F49 /* UIRefreshControl+AFNetworking.m */,
-				2995229A1BBF13C700859F49 /* UIWebView+AFNetworking.h */,
-				2995229B1BBF13C700859F49 /* UIWebView+AFNetworking.m */,
+				323D83E0231D185400C5BFC6 /* WKWebView+AFNetworking.h */,
+				323D83E1231D185400C5BFC6 /* WKWebView+AFNetworking.m */,
 			);
 			path = "UIKit+AFNetworking";
 			sourceTree = "<group>";
@@ -610,11 +610,11 @@
 				299522A91BBF13C700859F49 /* UIImageView+AFNetworking.h in Headers */,
 				2995229E1BBF13C700859F49 /* AFImageDownloader.h in Headers */,
 				2995225E1BBF125A00859F49 /* AFURLSessionManager.h in Headers */,
+				323D83E2231D185400C5BFC6 /* WKWebView+AFNetworking.h in Headers */,
 				2995225C1BBF125A00859F49 /* AFURLResponseSerialization.h in Headers */,
 				299522A21BBF13C700859F49 /* UIActivityIndicatorView+AFNetworking.h in Headers */,
 				1F96D2A4203649560085FC3F /* AFCompatibilityMacros.h in Headers */,
 				2995223D1BBF104D00859F49 /* AFNetworking.h in Headers */,
-				299522B01BBF13C700859F49 /* UIWebView+AFNetworking.h in Headers */,
 				299522AC1BBF13C700859F49 /* UIProgressView+AFNetworking.h in Headers */,
 				299522A61BBF13C700859F49 /* UIButton+AFNetworking.h in Headers */,
 				299522A01BBF13C700859F49 /* AFNetworkActivityIndicatorManager.h in Headers */,
@@ -819,6 +819,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 2995222F1BBF104D00859F49;
@@ -1009,8 +1010,8 @@
 				298D7CD91BC2CAF200FD3B3E /* AFNetworkReachabilityManagerTests.m in Sources */,
 				297824AA1BC2DAD80041C395 /* AFAutoPurgingImageCacheTests.m in Sources */,
 				298D7C981BC2CA2500FD3B3E /* AFURLSessionManagerTests.m in Sources */,
+				323D83E5231D188400C5BFC6 /* AFWKWebViewTests.m in Sources */,
 				297824AC1BC2DB450041C395 /* AFImageDownloaderTests.m in Sources */,
-				29F5EF031C47E64F008B976A /* AFUIWebViewTests.m in Sources */,
 				2D4563901DB1179D00AE4812 /* AFXMLParserResponseSerializerTests.m in Sources */,
 				298D7CD51BC2CAEC00FD3B3E /* AFHTTPSessionManagerTests.m in Sources */,
 				298D7CD71BC2CAEF00FD3B3E /* AFJSONSerializationTests.m in Sources */,
@@ -1047,10 +1048,10 @@
 				299522571BBF125A00859F49 /* AFNetworkReachabilityManager.m in Sources */,
 				299522AF1BBF13C700859F49 /* UIRefreshControl+AFNetworking.m in Sources */,
 				299522AA1BBF13C700859F49 /* UIImageView+AFNetworking.m in Sources */,
-				299522B11BBF13C700859F49 /* UIWebView+AFNetworking.m in Sources */,
 				299522591BBF125A00859F49 /* AFSecurityPolicy.m in Sources */,
 				299522A71BBF13C700859F49 /* UIButton+AFNetworking.m in Sources */,
 				299522541BBF125A00859F49 /* AFHTTPSessionManager.m in Sources */,
+				323D83E3231D185400C5BFC6 /* WKWebView+AFNetworking.m in Sources */,
 				2995225F1BBF125A00859F49 /* AFURLSessionManager.m in Sources */,
 				2995225B1BBF125A00859F49 /* AFURLRequestSerialization.m in Sources */,
 				2995229D1BBF13C700859F49 /* AFAutoPurgingImageCache.m in Sources */,

--- a/Framework/AFNetworking.h
+++ b/Framework/AFNetworking.h
@@ -60,7 +60,7 @@ FOUNDATION_EXPORT const unsigned char AFNetworkingVersionString[];
 #if TARGET_OS_IOS
 #import <AFNetworking/AFNetworkActivityIndicatorManager.h>
 #import <AFNetworking/UIRefreshControl+AFNetworking.h>
-#import <AFNetworking/UIWebView+AFNetworking.h>
+#import <AFNetworking/WKWebView+AFNetworking.h>
 #endif
 
 

--- a/Tests/Tests/AFWKWebViewTests.m
+++ b/Tests/Tests/AFWKWebViewTests.m
@@ -1,10 +1,23 @@
+// AFWKWebViewTests.m
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
-//  AFWKWebViewTests.m
-//  AFNetworking
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
 //
-//  Created by Sebastiaan Seegers on 02/09/2019.
-//  Copyright © 2019 AFNetworking. All rights reserved.
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
 //
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 
 #import <XCTest/XCTest.h>
 #import "AFTestCase.h"

--- a/Tests/Tests/AFWKWebViewTests.m
+++ b/Tests/Tests/AFWKWebViewTests.m
@@ -1,40 +1,27 @@
-// AFUIWebViewTests.h
-// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
+//  AFWKWebViewTests.m
+//  AFNetworking
 //
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
+//  Created by Sebastiaan Seegers on 02/09/2019.
+//  Copyright © 2019 AFNetworking. All rights reserved.
 //
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
 
 #import <XCTest/XCTest.h>
 #import "AFTestCase.h"
-#import "UIWebView+AFNetworking.h"
+#import "WKWebView+AFNetworking.h"
 
-@interface AFUIWebViewTests : AFTestCase
+@interface AFWKWebViewTests : AFTestCase
 
-@property (nonatomic, strong) UIWebView *webView;
+@property (nonatomic, strong) WKWebView *webView;
 @property (nonatomic, strong) NSURLRequest *HTMLRequest;
 
 @end
 
-@implementation AFUIWebViewTests
+@implementation AFWKWebViewTests
 
-- (void)setUp {
+-(void)setUp {
     [super setUp];
-    self.webView = [UIWebView new];
+    self.webView = [WKWebView new];
     self.HTMLRequest = [NSURLRequest requestWithURL:[self.baseURL URLByAppendingPathComponent:@"html"]];
 }
 
@@ -46,12 +33,11 @@
      success:^NSString * _Nonnull(NSHTTPURLResponse * _Nonnull response, NSString * _Nonnull HTML) {
          [expectation fulfill];
          return HTML;
-     }
-     failure:nil];
+     } failure:nil];
     [self waitForExpectationsWithCommonTimeout];
 }
 
-- (void)testNULLProgressDoesNotCauseCrash {
+- (void)testNUllProgressDoesNotCauseCrash {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Request should succeed"];
     [self.webView
      loadRequest:self.HTMLRequest
@@ -59,8 +45,7 @@
      success:^NSString * _Nonnull(NSHTTPURLResponse * _Nonnull response, NSString * _Nonnull HTML) {
          [expectation fulfill];
          return HTML;
-     }
-     failure:nil];
+     } failure:nil];
     [self waitForExpectationsWithCommonTimeout];
 }
 
@@ -89,15 +74,14 @@
      loadRequest:customHeaderRequest
      progress:NULL
      success:^NSString * _Nonnull(NSHTTPURLResponse * _Nonnull response, NSString * _Nonnull string) {
-         // Here string is actually JSON.
+         // Here string is actually JSON
          NSDictionary<NSString *, NSDictionary *> *responseObject = [NSJSONSerialization JSONObjectWithData:[string dataUsingEncoding:NSUTF8StringEncoding] options:(NSJSONReadingOptions)0 error:nil];
-
+         
          NSDictionary<NSString *, NSString *> *headers = responseObject[@"headers"];
          XCTAssertTrue([headers[@"Custom-Header-Field"] isEqualToString:@"Custom-Header-Value"]);
          [expectation fulfill];
          return string;
-     }
-     failure:nil];
+     } failure:nil];
     [self waitForExpectationsWithCommonTimeout];
 }
 

--- a/Tests/Tests/AFWKWebViewTests.m
+++ b/Tests/Tests/AFWKWebViewTests.m
@@ -13,6 +13,7 @@
 @interface AFWKWebViewTests : AFTestCase
 
 @property (nonatomic, strong) WKWebView *webView;
+@property (nonatomic, strong) WKNavigation *navigation;
 @property (nonatomic, strong) NSURLRequest *HTMLRequest;
 
 @end
@@ -22,6 +23,7 @@
 -(void)setUp {
     [super setUp];
     self.webView = [WKWebView new];
+    self.navigation = [WKNavigation new];
     self.HTMLRequest = [NSURLRequest requestWithURL:[self.baseURL URLByAppendingPathComponent:@"html"]];
 }
 
@@ -29,11 +31,12 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"Request should succeed"];
     [self.webView
      loadRequest:self.HTMLRequest
+     navigation:self.navigation
      progress:nil
      success:^NSString * _Nonnull(NSHTTPURLResponse * _Nonnull response, NSString * _Nonnull HTML) {
          [expectation fulfill];
          return HTML;
-     } failure:nil];
+    } failure:nil];
     [self waitForExpectationsWithCommonTimeout];
 }
 
@@ -41,6 +44,7 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"Request should succeed"];
     [self.webView
      loadRequest:self.HTMLRequest
+     navigation:self.navigation
      progress:NULL
      success:^NSString * _Nonnull(NSHTTPURLResponse * _Nonnull response, NSString * _Nonnull HTML) {
          [expectation fulfill];
@@ -54,12 +58,12 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"Request should succeed"];
     [self.webView
      loadRequest:self.HTMLRequest
+     navigation:self.navigation
      progress:&progress
      success:^NSString * _Nonnull(NSHTTPURLResponse * _Nonnull response, NSString * _Nonnull HTML) {
          [expectation fulfill];
          return HTML;
-     }
-     failure:nil];
+    } failure:nil];
     [self keyValueObservingExpectationForObject:progress
                                         keyPath:@"fractionCompleted"
                                   expectedValue:@(1.0)];
@@ -72,16 +76,17 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"Request should succeed"];
     [self.webView
      loadRequest:customHeaderRequest
+     navigation:self.navigation
      progress:NULL
      success:^NSString * _Nonnull(NSHTTPURLResponse * _Nonnull response, NSString * _Nonnull string) {
          // Here string is actually JSON
          NSDictionary<NSString *, NSDictionary *> *responseObject = [NSJSONSerialization JSONObjectWithData:[string dataUsingEncoding:NSUTF8StringEncoding] options:(NSJSONReadingOptions)0 error:nil];
-         
+
          NSDictionary<NSString *, NSString *> *headers = responseObject[@"headers"];
          XCTAssertTrue([headers[@"Custom-Header-Field"] isEqualToString:@"Custom-Header-Value"]);
          [expectation fulfill];
          return string;
-     } failure:nil];
+    } failure:nil];
     [self waitForExpectationsWithCommonTimeout];
 }
 

--- a/UIKit+AFNetworking/UIKit+AFNetworking.h
+++ b/UIKit+AFNetworking/UIKit+AFNetworking.h
@@ -31,7 +31,7 @@
     #import "AFImageDownloader.h"
     #import "AFNetworkActivityIndicatorManager.h"
     #import "UIRefreshControl+AFNetworking.h"
-    #import "UIWebView+AFNetworking.h"
+    #import "WKWebView+AFNetworking.h"
 #endif
 
     #import "UIActivityIndicatorView+AFNetworking.h"

--- a/UIKit+AFNetworking/WKWebView+AFNetworking.h
+++ b/UIKit+AFNetworking/WKWebView+AFNetworking.h
@@ -30,11 +30,13 @@ NS_ASSUME_NONNULL_BEGIN
  Asynchronously loads the specified request.
  
  @param request A URL request identifying the location of the content to load. This must not be `nil`.
+ @param navigation The WKNavigation object that containts information for tracking the loading progress of a webpage. This must not be `nil`.
  @param progress A progress object monitoring the current download progress.
  @param success A block object to be executed when the request finishes loading successfully. This block returns the HTML string to be loaded by the web view, and takes two arguments: the response, and the response string.
  @param failure A block object to be executed when the data task finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes a single argument: the error that occurred.
  */
 - (void)loadRequest:(NSURLRequest *)request
+         navigation:(WKNavigation * _Nonnull)navigation
            progress:(NSProgress * _Nullable __autoreleasing * _Nullable)progress
             success:(nullable NSString * (^)(NSHTTPURLResponse *response, NSString *HTML))success
             failure:(nullable void (^)(NSError *error))failure;
@@ -43,6 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
  Asynchronously loads the data associated with a particular request with a specified MIME type and text encoding.
  
  @param request A URL request identifying the location of the content to load. This must not be `nil`.
+ @param navigation The WKNavigation object that containts information for tracking the loading progress of a webpage.  This must not be `nil`.
  @param MIMEType The MIME type of the content. Defaults to the content type of the response if not specified.
  @param textEncodingName The IANA encoding name, as in `utf-8` or `utf-16`. Defaults to the response text encoding if not specified.
  @param progress A progress object monitoring the current download progress.
@@ -50,6 +53,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param failure A block object to be executed when the data task finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes a single argument: the error that occurred.
  */
 - (void)loadRequest:(NSURLRequest *)request
+         navigation:(WKNavigation * _Nonnull)navigation
            MIMEType:(nullable NSString *)MIMEType
    textEncodingName:(nullable NSString *)textEncodingName
            progress:(NSProgress * _Nullable __autoreleasing * _Nullable)progress

--- a/UIKit+AFNetworking/WKWebView+AFNetworking.h
+++ b/UIKit+AFNetworking/WKWebView+AFNetworking.h
@@ -1,23 +1,10 @@
-// UIWebView+AFNetworking.h
-// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
+//  WkWebView+AFNetworking.h
+//  AFNetworking iOS
 //
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
+//  Created by Sebastiaan Seegers on 02/09/2019.
+//  Copyright © 2019 AFNetworking. All rights reserved.
 //
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
 
 #import <Foundation/Foundation.h>
 
@@ -26,26 +13,22 @@
 #if TARGET_OS_IOS
 
 #import <UIKit/UIKit.h>
+#import <WebKit/WebKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 @class AFHTTPSessionManager;
 
-/**
- This category adds methods to the UIKit framework's `UIWebView` class. The methods in this category provide increased control over the request cycle, including progress monitoring and success / failure handling.
-
- @discussion When using these category methods, make sure to assign `delegate` for the web view, which implements `–webView:shouldStartLoadWithRequest:navigationType:` appropriately. This allows for tapped links to be loaded through AFNetworking, and can ensure that `canGoBack` & `canGoForward` update their values correctly.
- */
-@interface UIWebView (AFNetworking)
+@interface WKWebView (AFNetworking)
 
 /**
- The session manager used to download all requests.
+ The session manager used to download all request
  */
 @property (nonatomic, strong) AFHTTPSessionManager *sessionManager;
 
 /**
  Asynchronously loads the specified request.
-
+ 
  @param request A URL request identifying the location of the content to load. This must not be `nil`.
  @param progress A progress object monitoring the current download progress.
  @param success A block object to be executed when the request finishes loading successfully. This block returns the HTML string to be loaded by the web view, and takes two arguments: the response, and the response string.
@@ -58,11 +41,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Asynchronously loads the data associated with a particular request with a specified MIME type and text encoding.
-
+ 
  @param request A URL request identifying the location of the content to load. This must not be `nil`.
  @param MIMEType The MIME type of the content. Defaults to the content type of the response if not specified.
  @param textEncodingName The IANA encoding name, as in `utf-8` or `utf-16`. Defaults to the response text encoding if not specified.
-@param progress A progress object monitoring the current download progress.
+ @param progress A progress object monitoring the current download progress.
  @param success A block object to be executed when the request finishes loading successfully. This block returns the data to be loaded by the web view and takes two arguments: the response, and the downloaded data.
  @param failure A block object to be executed when the data task finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes a single argument: the error that occurred.
  */

--- a/UIKit+AFNetworking/WKWebView+AFNetworking.h
+++ b/UIKit+AFNetworking/WKWebView+AFNetworking.h
@@ -1,10 +1,23 @@
+// WkWebView+AFNetworking.h
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
-//  WkWebView+AFNetworking.h
-//  AFNetworking iOS
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
 //
-//  Created by Sebastiaan Seegers on 02/09/2019.
-//  Copyright © 2019 AFNetworking. All rights reserved.
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
 //
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 
 #import <Foundation/Foundation.h>
 

--- a/UIKit+AFNetworking/WKWebView+AFNetworking.m
+++ b/UIKit+AFNetworking/WKWebView+AFNetworking.m
@@ -1,25 +1,12 @@
-// UIWebView+AFNetworking.m
-// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
+//  WkWebView+AFNetworking.m
+//  AFNetworking iOS
 //
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
+//  Created by Sebastiaan Seegers on 02/09/2019.
+//  Copyright © 2019 AFNetworking. All rights reserved.
 //
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
 
-#import "UIWebView+AFNetworking.h"
+#import "WKWebView+AFNetworking.h"
 
 #import <objc/runtime.h>
 
@@ -29,11 +16,11 @@
 #import "AFURLResponseSerialization.h"
 #import "AFURLRequestSerialization.h"
 
-@interface UIWebView (_AFNetworking)
+@interface WKWebView (_AFNetworking)
 @property (readwrite, nonatomic, strong, setter = af_setURLSessionTask:) NSURLSessionDataTask *af_URLSessionTask;
 @end
 
-@implementation UIWebView (_AFNetworking)
+@implementation WKWebView (_AFNetworking)
 
 - (NSURLSessionDataTask *)af_URLSessionTask {
     return (NSURLSessionDataTask *)objc_getAssociatedObject(self, @selector(af_URLSessionTask));
@@ -47,7 +34,7 @@
 
 #pragma mark -
 
-@implementation UIWebView (AFNetworking)
+@implementation WKWebView (AFNetworking)
 
 - (AFHTTPSessionManager *)sessionManager {
     static AFHTTPSessionManager *_af_defaultHTTPSessionManager = nil;
@@ -57,7 +44,7 @@
         _af_defaultHTTPSessionManager.requestSerializer = [AFHTTPRequestSerializer serializer];
         _af_defaultHTTPSessionManager.responseSerializer = [AFHTTPResponseSerializer serializer];
     });
-
+    
     return objc_getAssociatedObject(self, @selector(sessionManager)) ?: _af_defaultHTTPSessionManager;
 }
 
@@ -71,7 +58,7 @@
     dispatch_once(&onceToken, ^{
         _af_defaultResponseSerializer = [AFHTTPResponseSerializer serializer];
     });
-
+    
     return objc_getAssociatedObject(self, @selector(responseSerializer)) ?: _af_defaultResponseSerializer;
 }
 
@@ -83,10 +70,9 @@
 
 - (void)loadRequest:(NSURLRequest *)request
            progress:(NSProgress * _Nullable __autoreleasing * _Nullable)progress
-            success:(NSString * (^)(NSHTTPURLResponse *response, NSString *HTML))success
-            failure:(void (^)(NSError *error))failure
-{
-    [self loadRequest:request MIMEType:nil textEncodingName:nil progress:progress success:^NSData *(NSHTTPURLResponse *response, NSData *data) {
+            success:(nullable NSString * (^)(NSHTTPURLResponse *response, NSString *HTML))success
+            failure:(nullable void (^)(NSError *error))failure {
+    [self loadRequest:request MIMEType:nil textEncodingName:nil progress:progress success:^NSData * _Nonnull(NSHTTPURLResponse * _Nonnull response, NSData * _Nonnull data) {
         NSStringEncoding stringEncoding = NSUTF8StringEncoding;
         if (response.textEncodingName) {
             CFStringEncoding encoding = CFStringConvertIANACharSetNameToEncoding((CFStringRef)response.textEncodingName);
@@ -94,61 +80,57 @@
                 stringEncoding = CFStringConvertEncodingToNSStringEncoding(encoding);
             }
         }
-
+        
         NSString *string = [[NSString alloc] initWithData:data encoding:stringEncoding];
         if (success) {
             string = success(response, string);
         }
-
+        
         return [string dataUsingEncoding:stringEncoding];
     } failure:failure];
 }
 
 - (void)loadRequest:(NSURLRequest *)request
-           MIMEType:(NSString *)MIMEType
-   textEncodingName:(NSString *)textEncodingName
+           MIMEType:(nullable NSString *)MIMEType
+   textEncodingName:(nullable NSString *)textEncodingName
            progress:(NSProgress * _Nullable __autoreleasing * _Nullable)progress
-            success:(NSData * (^)(NSHTTPURLResponse *response, NSData *data))success
-            failure:(void (^)(NSError *error))failure
-{
+            success:(nullable NSData * (^)(NSHTTPURLResponse *response, NSData *data))success
+            failure:(nullable void (^)(NSError *error))failure {
     NSParameterAssert(request);
-
+    
     if (self.af_URLSessionTask.state == NSURLSessionTaskStateRunning || self.af_URLSessionTask.state == NSURLSessionTaskStateSuspended) {
         [self.af_URLSessionTask cancel];
     }
     self.af_URLSessionTask = nil;
-
+    
     __weak __typeof(self)weakSelf = self;
     __block NSURLSessionDataTask *dataTask;
-    dataTask = [self.sessionManager
-                dataTaskWithRequest:request
-                uploadProgress:nil
-                downloadProgress:nil
-                completionHandler:^(NSURLResponse * _Nonnull response, id  _Nonnull responseObject, NSError * _Nullable error) {
-                    __strong __typeof(weakSelf) strongSelf = weakSelf;
-                    if (error) {
-                        if (failure) {
-                            failure(error);
-                        }
-                    } else {
-                        if (success) {
-                            success((NSHTTPURLResponse *)response, responseObject);
-                        }
-                        [strongSelf loadData:responseObject MIMEType:MIMEType textEncodingName:textEncodingName baseURL:[dataTask.currentRequest URL]];
-
-                        if ([strongSelf.delegate respondsToSelector:@selector(webViewDidFinishLoad:)]) {
-                            [strongSelf.delegate webViewDidFinishLoad:strongSelf];
-                        }
-                    }
-                }];
+    __strong __typeof(weakSelf) strongSelf = weakSelf;
+    __strong __typeof(weakSelf.navigationDelegate) strongSelfDelegate = strongSelf.navigationDelegate;
+    dataTask = [self.sessionManager dataTaskWithRequest:request uploadProgress:nil downloadProgress:nil completionHandler:^(NSURLResponse * _Nonnull response, id  _Nullable responseObject, NSError * _Nullable error) {
+        if (error) {
+            if (failure) {
+                failure(error);
+            }
+        } else {
+            if (success) {
+                success((NSHTTPURLResponse *)response, responseObject);
+            }
+            [strongSelf loadData:responseObject MIMEType:MIMEType characterEncodingName:textEncodingName baseURL:[dataTask.currentRequest URL]];
+            
+            if ([strongSelfDelegate respondsToSelector:@selector(webView:didFinishNavigation:)]) {
+                [strongSelfDelegate webView:strongSelf didFinishNavigation:strongSelfDelegate];
+            }
+        }
+    }];
     self.af_URLSessionTask = dataTask;
     if (progress != nil) {
         *progress = [self.sessionManager downloadProgressForTask:dataTask];
     }
     [self.af_URLSessionTask resume];
-
-    if ([self.delegate respondsToSelector:@selector(webViewDidStartLoad:)]) {
-        [self.delegate webViewDidStartLoad:self];
+    
+    if ([strongSelfDelegate respondsToSelector:@selector(webView:didStartProvisionalNavigation:)]) {
+        [strongSelfDelegate webView:self didStartProvisionalNavigation:strongSelfDelegate];
     }
 }
 

--- a/UIKit+AFNetworking/WKWebView+AFNetworking.m
+++ b/UIKit+AFNetworking/WKWebView+AFNetworking.m
@@ -1,10 +1,23 @@
+// WkWebView+AFNetworking.m
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
 //
-//  WkWebView+AFNetworking.m
-//  AFNetworking iOS
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
 //
-//  Created by Sebastiaan Seegers on 02/09/2019.
-//  Copyright © 2019 AFNetworking. All rights reserved.
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
 //
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 
 #import "WKWebView+AFNetworking.h"
 

--- a/UIKit+AFNetworking/WKWebView+AFNetworking.m
+++ b/UIKit+AFNetworking/WKWebView+AFNetworking.m
@@ -69,10 +69,11 @@
 #pragma mark -
 
 - (void)loadRequest:(NSURLRequest *)request
+         navigation:(WKNavigation * _Nonnull)navigation
            progress:(NSProgress * _Nullable __autoreleasing * _Nullable)progress
             success:(nullable NSString * (^)(NSHTTPURLResponse *response, NSString *HTML))success
             failure:(nullable void (^)(NSError *error))failure {
-    [self loadRequest:request MIMEType:nil textEncodingName:nil progress:progress success:^NSData * _Nonnull(NSHTTPURLResponse * _Nonnull response, NSData * _Nonnull data) {
+    [self loadRequest:request navigation:navigation MIMEType:nil textEncodingName:nil progress:progress success:^NSData * _Nonnull(NSHTTPURLResponse * _Nonnull response, NSData * _Nonnull data) {
         NSStringEncoding stringEncoding = NSUTF8StringEncoding;
         if (response.textEncodingName) {
             CFStringEncoding encoding = CFStringConvertIANACharSetNameToEncoding((CFStringRef)response.textEncodingName);
@@ -91,6 +92,7 @@
 }
 
 - (void)loadRequest:(NSURLRequest *)request
+         navigation:(WKNavigation * _Nonnull)navigation
            MIMEType:(nullable NSString *)MIMEType
    textEncodingName:(nullable NSString *)textEncodingName
            progress:(NSProgress * _Nullable __autoreleasing * _Nullable)progress
@@ -119,7 +121,7 @@
             [strongSelf loadData:responseObject MIMEType:MIMEType characterEncodingName:textEncodingName baseURL:[dataTask.currentRequest URL]];
             
             if ([strongSelfDelegate respondsToSelector:@selector(webView:didFinishNavigation:)]) {
-                [strongSelfDelegate webView:strongSelf didFinishNavigation:strongSelfDelegate];
+                [strongSelfDelegate webView:strongSelf didFinishNavigation:navigation];
             }
         }
     }];
@@ -130,7 +132,7 @@
     [self.af_URLSessionTask resume];
     
     if ([strongSelfDelegate respondsToSelector:@selector(webView:didStartProvisionalNavigation:)]) {
-        [strongSelfDelegate webView:self didStartProvisionalNavigation:strongSelfDelegate];
+        [strongSelfDelegate webView:self didStartProvisionalNavigation:navigation];
     }
 }
 


### PR DESCRIPTION
I've tried to remove the UIWebView references + extensions in favor of the WKWebview. Since Apple now throws warnings when submitting apps with UIWebView references (and soon will start rejecting apps using UIWebViews). I have NOT tested this myself since time constraints, also I don't really know if the Unit tests are correct with the WKNavigation object.