### PR TITLE
Fix travis CI build stall on osx image xcode7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_install:
   # Force bundler 1.12.5 because version 1.13 has issues, see https://github.com/fastlane/fastlane/issues/6065#issuecomment-246044617
   - gem uninstall bundler -v '>1.12.5' --force --executables || echo "bundler >1.12.5 is not installed"
   - gem install bundler -v 1.12.5 --no-rdoc --no-ri --no-document --quiet
-  - gem install fastlane --no-rdoc --no-ri --no-document --quiet
+  - gem install fastlane -v 2.109.1 --no-rdoc --no-ri --no-document --quiet
   - gem install cocoapods --no-rdoc --no-ri --no-document --quiet
 script:
   - set -o pipefail


### PR DESCRIPTION
@jshier, this is the second in a series of PRs that aim to breakdown #4439 into smaller chunks.
This one updates the travis yaml file to use a pinned version of fastlane. 
The latest versions of fastlane caused a build stall on osx image xcode7.3.

We used the last successful travis build to identify what version of fastlane was used there and pinned fastlane to that version. 
It is unknown if a more recent (but not more recent than 2.127.1) version causes the same behavior. 
We do know that versions released after, and including, 2.127.1 cause this behavior.