### PR TITLE
Use a synchronous dispatch barrier block for mutable header writes

### DIFF
--- a/AFNetworking/AFURLRequestSerialization.m
+++ b/AFNetworking/AFURLRequestSerialization.m
@@ -313,7 +313,7 @@ static void *AFHTTPRequestSerializerObserverContext = &AFHTTPRequestSerializerOb
 - (void)setValue:(NSString *)value
 forHTTPHeaderField:(NSString *)field
 {
-    dispatch_barrier_async(self.requestHeaderModificationQueue, ^{
+    dispatch_barrier_sync(self.requestHeaderModificationQueue, ^{
         [self.mutableHTTPRequestHeaders setValue:value forKey:field];
     });
 }
@@ -335,7 +335,7 @@ forHTTPHeaderField:(NSString *)field
 }
 
 - (void)clearAuthorizationHeader {
-    dispatch_barrier_async(self.requestHeaderModificationQueue, ^{
+    dispatch_barrier_sync(self.requestHeaderModificationQueue, ^{
         [self.mutableHTTPRequestHeaders removeObjectForKey:@"Authorization"];
     });
 }


### PR DESCRIPTION
I've been seeing a race condition where the `mutableHTTPRequestHeaders` has been deallocated inside of the block.

This PR pulls in changes from https://github.com/tmm1/AFNetworking/commit/32760e7a3a1cca2817ec498708182ec99584651a and then extends it based on [this comment](https://github.com/AFNetworking/AFNetworking/pull/3891#issuecomment-544337995).

It should help with https://github.com/AFNetworking/AFNetworking/issues/3636
and supersedes https://github.com/AFNetworking/AFNetworking/pull/3891.