### PR TITLE
use cocoapods cdn instead of github as specs source

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ $ gem install cocoapods
 To integrate AFNetworking into your Xcode project using CocoaPods, specify it in your `Podfile`:
 
 ```ruby
-source 'https://github.com/CocoaPods/Specs.git'
+source 'https://cdn.cocoapods.org/'
 platform :ios, '8.0'
 
 target 'TargetName' do


### PR DESCRIPTION
if you still use github as specs source in your podfile, you will encounter rate limitation at some point. you must use cocoapods cdn. 
see here for more info: https://blog.cocoapods.org/CocoaPods-1.7.2/