### PR TITLE
feat: rerquest merge

### DIFF
--- a/AFNetworking.xcodeproj/project.pbxproj
+++ b/AFNetworking.xcodeproj/project.pbxproj
@@ -7,6 +7,30 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0D0427BA240EB90A003C1AC1 /* AFDataItemIdentifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D0427AC240EB909003C1AC1 /* AFDataItemIdentifier.m */; };
+		0D0427BB240EB90A003C1AC1 /* AFDataItemIdentifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D0427AC240EB909003C1AC1 /* AFDataItemIdentifier.m */; };
+		0D0427BC240EB90A003C1AC1 /* AFDataItemIdentifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D0427AC240EB909003C1AC1 /* AFDataItemIdentifier.m */; };
+		0D0427BD240EB90A003C1AC1 /* AFDataItemIdentifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D0427AC240EB909003C1AC1 /* AFDataItemIdentifier.m */; };
+		0D0427C6240EB90A003C1AC1 /* AFDataItemIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D0427AF240EB909003C1AC1 /* AFDataItemIdentifier.h */; };
+		0D0427C7240EB90A003C1AC1 /* AFDataItemIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D0427AF240EB909003C1AC1 /* AFDataItemIdentifier.h */; };
+		0D0427C8240EB90A003C1AC1 /* AFDataItemIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D0427AF240EB909003C1AC1 /* AFDataItemIdentifier.h */; };
+		0D0427C9240EB90A003C1AC1 /* AFDataItemIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D0427AF240EB909003C1AC1 /* AFDataItemIdentifier.h */; };
+		0D0427D4240EC797003C1AC1 /* AFDataItemReceiptorManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D0427D2240EC797003C1AC1 /* AFDataItemReceiptorManager.h */; };
+		0D0427D5240EC797003C1AC1 /* AFDataItemReceiptorManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D0427D2240EC797003C1AC1 /* AFDataItemReceiptorManager.h */; };
+		0D0427D6240EC797003C1AC1 /* AFDataItemReceiptorManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D0427D2240EC797003C1AC1 /* AFDataItemReceiptorManager.h */; };
+		0D0427D7240EC797003C1AC1 /* AFDataItemReceiptorManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D0427D2240EC797003C1AC1 /* AFDataItemReceiptorManager.h */; };
+		0D0427D8240EC797003C1AC1 /* AFDataItemReceiptorManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D0427D3240EC797003C1AC1 /* AFDataItemReceiptorManager.m */; };
+		0D0427D9240EC797003C1AC1 /* AFDataItemReceiptorManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D0427D3240EC797003C1AC1 /* AFDataItemReceiptorManager.m */; };
+		0D0427DA240EC797003C1AC1 /* AFDataItemReceiptorManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D0427D3240EC797003C1AC1 /* AFDataItemReceiptorManager.m */; };
+		0D0427DB240EC797003C1AC1 /* AFDataItemReceiptorManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D0427D3240EC797003C1AC1 /* AFDataItemReceiptorManager.m */; };
+		0D0427DE240EC95B003C1AC1 /* AFDataItemDownloader.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D0427DC240EC95B003C1AC1 /* AFDataItemDownloader.h */; };
+		0D0427DF240EC95B003C1AC1 /* AFDataItemDownloader.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D0427DC240EC95B003C1AC1 /* AFDataItemDownloader.h */; };
+		0D0427E0240EC95B003C1AC1 /* AFDataItemDownloader.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D0427DC240EC95B003C1AC1 /* AFDataItemDownloader.h */; };
+		0D0427E1240EC95B003C1AC1 /* AFDataItemDownloader.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D0427DC240EC95B003C1AC1 /* AFDataItemDownloader.h */; };
+		0D0427E2240EC95B003C1AC1 /* AFDataItemDownloader.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D0427DD240EC95B003C1AC1 /* AFDataItemDownloader.m */; };
+		0D0427E3240EC95B003C1AC1 /* AFDataItemDownloader.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D0427DD240EC95B003C1AC1 /* AFDataItemDownloader.m */; };
+		0D0427E4240EC95B003C1AC1 /* AFDataItemDownloader.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D0427DD240EC95B003C1AC1 /* AFDataItemDownloader.m */; };
+		0D0427E5240EC95B003C1AC1 /* AFDataItemDownloader.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D0427DD240EC95B003C1AC1 /* AFDataItemDownloader.m */; };
 		1BF9F9601C87832B00F1F35A /* AFImageResponseSerializerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1BF9F95F1C87832B00F1F35A /* AFImageResponseSerializerTests.m */; };
 		1BF9F9611C87843200F1F35A /* AFImageResponseSerializerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1BF9F95F1C87832B00F1F35A /* AFImageResponseSerializerTests.m */; };
 		1BF9F9621C87843300F1F35A /* AFImageResponseSerializerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1BF9F95F1C87832B00F1F35A /* AFImageResponseSerializerTests.m */; };
@@ -235,6 +259,12 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0D0427AC240EB909003C1AC1 /* AFDataItemIdentifier.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFDataItemIdentifier.m; sourceTree = "<group>"; };
+		0D0427AF240EB909003C1AC1 /* AFDataItemIdentifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFDataItemIdentifier.h; sourceTree = "<group>"; };
+		0D0427D2240EC797003C1AC1 /* AFDataItemReceiptorManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AFDataItemReceiptorManager.h; sourceTree = "<group>"; };
+		0D0427D3240EC797003C1AC1 /* AFDataItemReceiptorManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AFDataItemReceiptorManager.m; sourceTree = "<group>"; };
+		0D0427DC240EC95B003C1AC1 /* AFDataItemDownloader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AFDataItemDownloader.h; sourceTree = "<group>"; };
+		0D0427DD240EC95B003C1AC1 /* AFDataItemDownloader.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AFDataItemDownloader.m; sourceTree = "<group>"; };
 		1BF9F95F1C87832B00F1F35A /* AFImageResponseSerializerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFImageResponseSerializerTests.m; sourceTree = "<group>"; };
 		1F083A4920364648004D80C7 /* AFCompatibilityMacros.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AFCompatibilityMacros.h; sourceTree = "<group>"; };
 		1F8482BF220F386200718111 /* httpbinorg_03172020.cer */ = {isa = PBXFileReference; lastKnownFileType = file; path = httpbinorg_03172020.cer; sourceTree = "<group>"; };
@@ -378,6 +408,19 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0DB18069240D64EE00313E30 /* AFRequestMerge */ = {
+			isa = PBXGroup;
+			children = (
+				0D0427AF240EB909003C1AC1 /* AFDataItemIdentifier.h */,
+				0D0427AC240EB909003C1AC1 /* AFDataItemIdentifier.m */,
+				0D0427D2240EC797003C1AC1 /* AFDataItemReceiptorManager.h */,
+				0D0427D3240EC797003C1AC1 /* AFDataItemReceiptorManager.m */,
+				0D0427DC240EC95B003C1AC1 /* AFDataItemDownloader.h */,
+				0D0427DD240EC95B003C1AC1 /* AFDataItemDownloader.m */,
+			);
+			path = AFRequestMerge;
+			sourceTree = "<group>";
+		};
 		298D7C561BC2C88F00FD3B3E /* Tests */ = {
 			isa = PBXGroup;
 			children = (
@@ -481,6 +524,7 @@
 		2995222F1BBF104D00859F49 = {
 			isa = PBXGroup;
 			children = (
+				0DB18069240D64EE00313E30 /* AFRequestMerge */,
 				299522451BBF125A00859F49 /* AFNetworking */,
 				299522851BBF13C700859F49 /* UIKit+AFNetworking */,
 				2995223B1BBF104D00859F49 /* Supporting Files */,
@@ -584,6 +628,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0D0427E1240EC95B003C1AC1 /* AFDataItemDownloader.h in Headers */,
 				29D96E881BCC3D7D00F571A5 /* AFHTTPSessionManager.h in Headers */,
 				29D96E891BCC3D7D00F571A5 /* AFNetworkReachabilityManager.h in Headers */,
 				29D96E8A1BCC3D7D00F571A5 /* AFSecurityPolicy.h in Headers */,
@@ -598,7 +643,9 @@
 				29D96E981BCC406B00F571A5 /* UIImage+AFNetworking.h in Headers */,
 				29D96E991BCC406B00F571A5 /* UIImageView+AFNetworking.h in Headers */,
 				29D96E9A1BCC406B00F571A5 /* UIProgressView+AFNetworking.h in Headers */,
+				0D0427C9240EB90A003C1AC1 /* AFDataItemIdentifier.h in Headers */,
 				29D96E8E1BCC3D7D00F571A5 /* AFNetworking.h in Headers */,
+				0D0427D7240EC797003C1AC1 /* AFDataItemReceiptorManager.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -617,7 +664,10 @@
 				2995225E1BBF125A00859F49 /* AFURLSessionManager.h in Headers */,
 				2995225C1BBF125A00859F49 /* AFURLResponseSerialization.h in Headers */,
 				299522A21BBF13C700859F49 /* UIActivityIndicatorView+AFNetworking.h in Headers */,
+				0D0427D4240EC797003C1AC1 /* AFDataItemReceiptorManager.h in Headers */,
+				0D0427C6240EB90A003C1AC1 /* AFDataItemIdentifier.h in Headers */,
 				1F96D2A4203649560085FC3F /* AFCompatibilityMacros.h in Headers */,
+				0D0427DE240EC95B003C1AC1 /* AFDataItemDownloader.h in Headers */,
 				2995223D1BBF104D00859F49 /* AFNetworking.h in Headers */,
 				299522B01BBF13C700859F49 /* UIWebView+AFNetworking.h in Headers */,
 				299522AC1BBF13C700859F49 /* UIProgressView+AFNetworking.h in Headers */,
@@ -632,10 +682,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				29D96E7A1BCC3D6000F571A5 /* AFHTTPSessionManager.h in Headers */,
+				0D0427D5240EC797003C1AC1 /* AFDataItemReceiptorManager.h in Headers */,
 				29D96E7C1BCC3D6000F571A5 /* AFSecurityPolicy.h in Headers */,
 				1F96D2A5203649570085FC3F /* AFCompatibilityMacros.h in Headers */,
+				0D0427DF240EC95B003C1AC1 /* AFDataItemDownloader.h in Headers */,
 				29D96E7D1BCC3D6000F571A5 /* AFURLRequestSerialization.h in Headers */,
 				29D96E7E1BCC3D6000F571A5 /* AFURLResponseSerialization.h in Headers */,
+				0D0427C7240EB90A003C1AC1 /* AFDataItemIdentifier.h in Headers */,
 				29D96E7F1BCC3D6000F571A5 /* AFURLSessionManager.h in Headers */,
 				29D96E801BCC3D6000F571A5 /* AFNetworking.h in Headers */,
 			);
@@ -646,10 +699,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				29D96E811BCC3D7200F571A5 /* AFHTTPSessionManager.h in Headers */,
+				0D0427D6240EC797003C1AC1 /* AFDataItemReceiptorManager.h in Headers */,
 				29D96E821BCC3D7200F571A5 /* AFNetworkReachabilityManager.h in Headers */,
 				29D96E831BCC3D7200F571A5 /* AFSecurityPolicy.h in Headers */,
 				1F96D2A6203649570085FC3F /* AFCompatibilityMacros.h in Headers */,
 				29D96E841BCC3D7200F571A5 /* AFURLRequestSerialization.h in Headers */,
+				0D0427E0240EC95B003C1AC1 /* AFDataItemDownloader.h in Headers */,
+				0D0427C8240EB90A003C1AC1 /* AFDataItemIdentifier.h in Headers */,
 				29D96E851BCC3D7200F571A5 /* AFURLResponseSerialization.h in Headers */,
 				29D96E861BCC3D7200F571A5 /* AFURLSessionManager.h in Headers */,
 				29D96E871BCC3D7200F571A5 /* AFNetworking.h in Headers */,
@@ -824,6 +880,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 2995222F1BBF104D00859F49;
@@ -959,18 +1016,21 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0D0427E5240EC95B003C1AC1 /* AFDataItemDownloader.m in Sources */,
 				2987B0BD1BC408D900179A4C /* AFNetworkReachabilityManager.m in Sources */,
 				2987B0BE1BC408D900179A4C /* AFSecurityPolicy.m in Sources */,
 				2987B0BC1BC408D900179A4C /* AFHTTPSessionManager.m in Sources */,
 				2987B0C11BC408D900179A4C /* AFURLSessionManager.m in Sources */,
 				2987B0C71BC408F900179A4C /* UIProgressView+AFNetworking.m in Sources */,
 				2987B0BF1BC408D900179A4C /* AFURLRequestSerialization.m in Sources */,
+				0D0427BD240EB90A003C1AC1 /* AFDataItemIdentifier.m in Sources */,
 				2987B0C21BC408F900179A4C /* AFAutoPurgingImageCache.m in Sources */,
 				2987B0C51BC408F900179A4C /* UIButton+AFNetworking.m in Sources */,
 				2987B0C41BC408F900179A4C /* UIActivityIndicatorView+AFNetworking.m in Sources */,
 				2987B0C01BC408D900179A4C /* AFURLResponseSerialization.m in Sources */,
 				2987B0C61BC408F900179A4C /* UIImageView+AFNetworking.m in Sources */,
 				2987B0C31BC408F900179A4C /* AFImageDownloader.m in Sources */,
+				0D0427DB240EC797003C1AC1 /* AFDataItemReceiptorManager.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1057,9 +1117,12 @@
 				299522AA1BBF13C700859F49 /* UIImageView+AFNetworking.m in Sources */,
 				299522B11BBF13C700859F49 /* UIWebView+AFNetworking.m in Sources */,
 				299522591BBF125A00859F49 /* AFSecurityPolicy.m in Sources */,
+				0D0427BA240EB90A003C1AC1 /* AFDataItemIdentifier.m in Sources */,
 				299522A71BBF13C700859F49 /* UIButton+AFNetworking.m in Sources */,
+				0D0427E2240EC95B003C1AC1 /* AFDataItemDownloader.m in Sources */,
 				299522541BBF125A00859F49 /* AFHTTPSessionManager.m in Sources */,
 				2995225F1BBF125A00859F49 /* AFURLSessionManager.m in Sources */,
+				0D0427D8240EC797003C1AC1 /* AFDataItemReceiptorManager.m in Sources */,
 				2995225B1BBF125A00859F49 /* AFURLRequestSerialization.m in Sources */,
 				2995229D1BBF13C700859F49 /* AFAutoPurgingImageCache.m in Sources */,
 				299522A31BBF13C700859F49 /* UIActivityIndicatorView+AFNetworking.m in Sources */,
@@ -1075,9 +1138,12 @@
 			files = (
 				299522711BBF133400859F49 /* AFURLSessionManager.m in Sources */,
 				2995226F1BBF133400859F49 /* AFURLRequestSerialization.m in Sources */,
+				0D0427D9240EC797003C1AC1 /* AFDataItemReceiptorManager.m in Sources */,
 				2995226E1BBF133400859F49 /* AFSecurityPolicy.m in Sources */,
 				299522701BBF133400859F49 /* AFURLResponseSerialization.m in Sources */,
 				2995226D1BBF133400859F49 /* AFHTTPSessionManager.m in Sources */,
+				0D0427BB240EB90A003C1AC1 /* AFDataItemIdentifier.m in Sources */,
+				0D0427E3240EC95B003C1AC1 /* AFDataItemDownloader.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1086,9 +1152,12 @@
 			buildActionMask = 2147483647;
 			files = (
 				299522801BBF13A100859F49 /* AFNetworkReachabilityManager.m in Sources */,
+				0D0427DA240EC797003C1AC1 /* AFDataItemReceiptorManager.m in Sources */,
+				0D0427E4240EC95B003C1AC1 /* AFDataItemDownloader.m in Sources */,
 				299522811BBF13A100859F49 /* AFSecurityPolicy.m in Sources */,
 				2995227F1BBF13A100859F49 /* AFHTTPSessionManager.m in Sources */,
 				299522841BBF13A100859F49 /* AFURLSessionManager.m in Sources */,
+				0D0427BC240EB90A003C1AC1 /* AFDataItemIdentifier.m in Sources */,
 				299522821BBF13A100859F49 /* AFURLRequestSerialization.m in Sources */,
 				299522831BBF13A100859F49 /* AFURLResponseSerialization.m in Sources */,
 			);
@@ -1136,6 +1205,7 @@
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WARNING_CFLAGS = "";
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Debug;
@@ -1161,6 +1231,7 @@
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WARNING_CFLAGS = "";
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Release;
@@ -1315,7 +1386,7 @@
 				GCC_WARN_CHECK_SWITCH_STATEMENTS = YES;
 				GCC_WARN_INITIALIZER_NOT_FULLY_BRACKETED = YES;
 				GCC_WARN_MISSING_PARENTHESES = YES;
-				GCC_WARN_SHADOW = YES;
+				GCC_WARN_SHADOW = NO;
 				GCC_WARN_SIGN_COMPARE = YES;
 				GCC_WARN_STRICT_SELECTOR_MATCH = YES;
 				GCC_WARN_TYPECHECK_CALLS_TO_PRINTF = YES;
@@ -1390,7 +1461,7 @@
 				GCC_WARN_CHECK_SWITCH_STATEMENTS = YES;
 				GCC_WARN_INITIALIZER_NOT_FULLY_BRACKETED = YES;
 				GCC_WARN_MISSING_PARENTHESES = YES;
-				GCC_WARN_SHADOW = YES;
+				GCC_WARN_SHADOW = NO;
 				GCC_WARN_SIGN_COMPARE = YES;
 				GCC_WARN_STRICT_SELECTOR_MATCH = YES;
 				GCC_WARN_TYPECHECK_CALLS_TO_PRINTF = YES;
@@ -1432,6 +1503,7 @@
 				PRODUCT_NAME = AFNetworking;
 				SKIP_INSTALL = YES;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WARNING_CFLAGS = "";
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Debug;
@@ -1455,6 +1527,7 @@
 				PRODUCT_NAME = AFNetworking;
 				SKIP_INSTALL = YES;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WARNING_CFLAGS = "";
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Release;
@@ -1479,6 +1552,7 @@
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 4;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WARNING_CFLAGS = "";
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Debug;
@@ -1503,6 +1577,7 @@
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 4;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WARNING_CFLAGS = "";
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Release;
@@ -1530,6 +1605,7 @@
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WARNING_CFLAGS = "";
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Debug;
@@ -1557,6 +1633,7 @@
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WARNING_CFLAGS = "";
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Release;

--- a/AFRequestMerge/AFDataItemDownloader.h
+++ b/AFRequestMerge/AFDataItemDownloader.h
@@ -1,0 +1,82 @@
+//
+//  AFDataItemDownloader.h
+//  AFNetworking
+//
+//  Created by jufan wang on 2020/3/4.
+//  Copyright © 2020 AFNetworking. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "AFDataItemIdentifier.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+
+@interface AFDataItemDownloader : NSObject
+
+/**
+ Creates a data item downloader  for category which is marked by dataCategoryID if not existed .
+ 
+ @param delegate the real downloader for data item .
+ @param dataCategoryID data category marks the some kind of data items .
+ 
+ @return a data item downloader for category dataCategoryID .
+*/
++ (instancetype)creatDownloaderWithDelegate:(id<AFDataItemDownloaderDelegate>)delegate
+                             dataCategoryID:(NSString *)dataCategoryID;
+
+/**
+ Return a data item downloader  for category which is marked by dataCategoryID if existed .
+ 
+ @param dataCategoryID data category marks the some kind of data items .
+ 
+ @return a data item downloader for category dataCategoryID or nil if not existed .
+*/
++ (instancetype)getDownloaderWithDataCategoryID:(NSString *)dataCategoryID;
+
+/**
+ Remove a data item downloader  for category which is marked by dataCategoryID if existed .
+ 
+ @param dataCategoryID data category marks the some kind of data items .
+*/
++ (void)removeDownloaderWithDataCategoryID:(NSString *)dataCategoryID;
+
+@property (nonatomic, strong) id<AFDataItemDownloaderCacher> cache;
+
+/**
+ Waits for retryTimeInterval seconds before retrying download  if currentRequestCount is equal to maxRequestCount .
+*/
+@property (atomic, assign) NSTimeInterval retryTimeInterval;
+
+/**
+ The  time interval for retrying download  if the max request connection arrived .
+*/
+@property (nonatomic, assign, readonly) NSInteger maxRequestCount; //Default  1
+
+/**
+ The  request count  if currentRequestCount is equal to maxRequestCount there no request will be happens.
+*/
+@property (nonatomic, assign, readonly) NSInteger currentRequestCount;
+
+/*
+ Get the data item associated with the given ID .
+ @param dataID the data item id which will be added to the data item list if the cacher return nil. The next request will merge certain count of data item ids into a single request .
+ */
+- (void)getDataItemWithID:(NSString *)dataID
+                  success:(AFDataItemReceiptorSuccessBlock)success
+                  failure:(AFDataItemReceiptorFailureBlock)failure;
+
+/*
+ if the comming dataItemVersion is bigger than local cached , update the data item .
+*/
+- (void)updateData:(NSArray<id<AFDataItemIdentifier>> *)dataIDsList;
+
+/*
+ Get the data item associated with the given ID in memory cache .
+*/
+- (nullable id<AFDataItemIdentifier>)memoryDataItemWithID:(NSString *)dataID;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/AFRequestMerge/AFDataItemDownloader.m
+++ b/AFRequestMerge/AFDataItemDownloader.m
@@ -1,0 +1,424 @@
+//
+//  AFDataItemDownloader.m
+//  AFNetworking
+//
+//  Created by jufan wang on 2020/3/4.
+//  Copyright © 2020 AFNetworking. All rights reserved.
+//
+
+#import "AFDataItemDownloader.h"
+#import "AFDataItemReceiptorManager.h"
+//#include <os/lock.h>
+
+@interface AFDataResponseHandler : NSObject
+@property (nonatomic, copy) NSString *dataItemID;
+@property (nonatomic, copy) NSString *dataItemVersion;
+@property (nonatomic, copy) void (^successBlock)(id<AFDataItemIdentifier> data);
+@property (nonatomic, copy) void (^failureBlock)(NSString *dataItemID, NSError* error);
+@end
+@implementation AFDataResponseHandler
+- (instancetype)initWithSuccess:(nullable void (^)(id<AFDataItemIdentifier> data))success
+                        failure:(nullable void (^)(NSString *dataItemID, NSError* error))failure {
+    if (self = [self init]) {
+        self.successBlock = success;
+        self.failureBlock = failure;
+    }
+    return self;
+}
+- (NSString *)description {
+    return [NSString stringWithFormat: @"<VVDataResponseHandler>requesterID: %@", self.dataItemID];
+}
+@end
+
+@interface AFDataDownloaderMergedTask : NSObject
+@property (nonatomic, copy) NSString *dataItemID;
+@property (nonatomic, copy) NSString *dataItemVersion;
+
+@property (nonatomic, strong) NSMutableArray<AFDataResponseHandler*> *responseHandlers;
+@end
+@implementation AFDataDownloaderMergedTask
+- (instancetype)init {
+    if (self = [super init]) {
+        self.responseHandlers = [[NSMutableArray alloc] init];
+    }
+    return self;
+}
+- (void)addResponseHandler:(AFDataResponseHandler*)handler {
+    [self.responseHandlers addObject:handler];
+}
+- (void)removeResponseHandler:(AFDataResponseHandler*)handler {
+    [self.responseHandlers removeObject:handler];
+}
+@end
+
+
+@interface AFDataItemDownloader() {
+    //    os_unfair_lock _unfairLock;
+}
+
+@property (nonatomic, strong) NSMutableDictionary<NSString *, AFDataDownloaderMergedTask *> *queuedMergedTasks;
+@property (nonatomic, strong) NSMutableDictionary<NSString *, AFDataDownloaderMergedTask *> *mergedTasks;
+
+@property (nonatomic, strong) dispatch_queue_t requestQueue;
+@property (nonatomic, strong) dispatch_queue_t callbackQueue;
+@property (nonatomic, strong) dispatch_queue_t responseQueue;
+
+@property (nonatomic, strong) dispatch_semaphore_t semphore;
+
+@property (nonatomic, assign) NSInteger maxRequestCount;
+@property (nonatomic, assign) NSInteger currentRequestCount;
+
+@property (class, nonatomic, strong) NSMutableDictionary<NSString *, AFDataItemDownloader *> *downloaders;
+
+@property (nonatomic, assign) CFAbsoluteTime preTimeInterval;
+@property (nonatomic, strong) NSTimer *timer;
+
+@property (nonatomic, copy) NSString *categoryID;
+
+@property (nonatomic, strong) id<AFDataItemDownloaderDelegate> dataLoaderDelegate;
+
+@property (nonatomic, weak) AFDataItemReceiptorManager *receiptorManager;
+
+@end
+
+
+@implementation AFDataItemDownloader
+
+@synthesize dataLoaderDelegate = _dataLoaderDelegate;
+
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wshadow-ivar"
+
+static NSMutableDictionary<NSString *, AFDataItemDownloader *> *_downloaders;
+
++ (NSMutableDictionary<NSString *, AFDataItemDownloader *> *)downloaders {
+    
+    if (!_downloaders) {
+        _downloaders = [NSMutableDictionary dictionary];
+    }
+    return _downloaders;
+}
++ (void)setDownloaders:(NSMutableDictionary<NSString *, AFDataItemDownloader *> *)downloaders {
+    _downloaders = downloaders;
+}
+
++ (instancetype)creatDownloaderWithDelegate:(id<AFDataItemDownloaderDelegate>)delegate
+                             dataCategoryID:(NSString *)dataCategoryID {
+    if (!delegate || !dataCategoryID) {
+        return nil;
+    }
+    AFDataItemDownloader *downloader = nil;
+    @synchronized (self) {
+        downloader = [[self downloaders] objectForKey:dataCategoryID];
+        if (!downloader) {
+            downloader = [[AFDataItemDownloader alloc] init];
+            downloader.dataLoaderDelegate = delegate;
+            downloader.categoryID = dataCategoryID;
+            [[self downloaders] setObject:downloader forKey:dataCategoryID];
+        }
+    }
+    return downloader;
+}
++ (void)removeDownloaderWithDataCategoryID:(NSString *)dataCategoryID {
+    if (!dataCategoryID) {
+        return;
+    }
+    @synchronized (self) {
+        [[self downloaders] removeObjectForKey:dataCategoryID];
+    }
+}
++ (instancetype)getDownloaderWithDataCategoryID:(NSString *)dataCategoryID {
+    AFDataItemDownloader *downloader = nil;
+    @synchronized (self) {
+        downloader = [[self downloaders] objectForKey:dataCategoryID];
+    }
+    return downloader;
+}
+
+- (instancetype)init {
+    if (self = [super init]) {
+        //        _unfairLock = OS_UNFAIR_LOCK_INIT;
+        _semphore = dispatch_semaphore_create(1);
+        _queuedMergedTasks = [[NSMutableDictionary alloc] init];
+        _mergedTasks = [[NSMutableDictionary alloc] init];
+        
+        _requestQueue = dispatch_queue_create("com.af.dataItemDownloader.requestQueue", DISPATCH_QUEUE_SERIAL);
+        _responseQueue = dispatch_queue_create("com.af.dataItemDownloader.responsequeue", DISPATCH_QUEUE_CONCURRENT);
+        _callbackQueue = dispatch_queue_create("com.af.dataItemDownloader.callbackQueue", DISPATCH_QUEUE_SERIAL);
+        
+        _retryTimeInterval = 1;
+        _preTimeInterval = CFAbsoluteTimeGetCurrent();
+        _maxRequestCount = 1;
+        _currentRequestCount = 0;
+    }
+    return self;
+}
+
+- (void)startTimer {
+    if (!self.timer) {
+        self.timer = [NSTimer timerWithTimeInterval:self.retryTimeInterval
+                                             target:self
+                                           selector:@selector(timerDispatch)
+                                           userInfo:nil
+                                            repeats:true];
+        [[NSRunLoop mainRunLoop] addTimer:self.timer forMode:NSDefaultRunLoopMode];
+        [self.timer fire];
+    }
+}
+
+- (void)timerDispatch {
+    __weak __typeof(self) weakSelf = self;
+    dispatch_async(self.requestQueue, ^{
+        __strong __typeof(weakSelf) self = weakSelf;
+        [self tryDispatch];
+    });
+}
+
+- (void)finishTimer {
+    [self.timer invalidate];
+    self.timer = nil;
+}
+
+- (void)setDataLoaderDelegate:(id<AFDataItemDownloaderDelegate>)dataLoaderDelegate {
+    _dataLoaderDelegate = dataLoaderDelegate;
+    _maxRequestCount = [_dataLoaderDelegate dataItemDownLoaderMaxHTTPConnection:self];
+}
+
+- (void)downloaderLock {
+    //    os_unfair_lock_lock(&(_unfairLock));
+    dispatch_semaphore_wait(self.semphore, DISPATCH_TIME_FOREVER);
+}
+
+- (void)downloaderUnlock {
+    //    os_unfair_lock_unlock(&(_unfairLock));
+    dispatch_semaphore_signal(self.semphore);
+}
+
+- (nullable id<AFDataItemIdentifier>)memoryDataItemWithID:(NSString *)dataID {
+    return (id<AFDataItemIdentifier>)[self.cache memoryObjectForKey:dataID];
+}
+
+- (AFDataItemReceiptorManager *)receiptorManager {
+    AFDataItemReceiptorManager *receiptorManager = _receiptorManager;
+    if (!receiptorManager) {
+        receiptorManager = [AFDataItemReceiptorManager managerForDataCategoryID:self.categoryID];
+        _receiptorManager = receiptorManager;
+    }
+    return receiptorManager;
+}
+
+- (void)getDataItemWithID:(NSString *)dataItemID
+                  success:(AFDataItemReceiptorSuccessBlock)success
+                  failure:(AFDataItemReceiptorFailureBlock)failure {
+    if (!dataItemID || !success || !failure) {
+        return;
+    }
+    __weak __typeof(self) weakSelf = self;
+    dispatch_async(self.requestQueue, ^{
+        __strong __typeof(weakSelf) self = weakSelf;
+        if (!self) {
+            return ;
+        }
+        [self downloaderLock];
+        id<AFDataItemIdentifier> wrapper = (id<AFDataItemIdentifier>)[self.cache objectForKey:dataItemID];
+        if (wrapper) {
+            if (success) {
+                dispatch_async(self.callbackQueue, ^{
+                    success(wrapper);
+                });
+            }
+            [self downloaderUnlock];
+            return;
+        }
+        
+        AFDataDownloaderMergedTask *mergedTask = nil;
+        mergedTask = self.mergedTasks[dataItemID];
+        
+        if (!mergedTask) {
+            mergedTask = self.queuedMergedTasks[dataItemID];
+        }
+        
+        if (mergedTask) {
+            AFDataResponseHandler *responseHandler = [[AFDataResponseHandler alloc] initWithSuccess:success failure:failure];
+            responseHandler.dataItemID = dataItemID;
+            [mergedTask addResponseHandler:responseHandler];
+            [self downloaderUnlock];
+            dispatch_async(self.requestQueue, ^{
+                [self tryDispatch];
+            });
+            return;
+        };
+        
+        mergedTask = [[AFDataDownloaderMergedTask alloc] init];
+        mergedTask.dataItemID = dataItemID;
+        self.mergedTasks[dataItemID] = mergedTask;
+        
+        AFDataResponseHandler *handler = [[AFDataResponseHandler alloc] initWithSuccess:success failure:failure];
+        handler.dataItemID = dataItemID;
+        [mergedTask addResponseHandler:handler];
+        
+        [self downloaderUnlock];
+        dispatch_async(self.requestQueue, ^{
+            [self tryDispatch];
+        });
+    });
+}
+
+- (void)tryDispatch {
+    NSArray * requestIDs = [self requestDataIDs];
+    if (requestIDs.count) {
+        [self downloaderLock];
+        self.currentRequestCount++;
+        [self downloaderUnlock];
+        
+        __weak __typeof(self) weakSelf = self;
+        [self.dataLoaderDelegate dataItemDownLoader:self
+                                           loadData:requestIDs
+                                       successBlock:^(NSArray<NSString *> *dataItemIDs,
+                                                      NSArray<id<AFDataItemIdentifier, NSCoding>> * _Nonnull response) {
+            __strong __typeof(weakSelf) self = weakSelf;
+            if (!self) {
+                return ;
+            }
+            response = [response copy];
+            dispatch_async(self.responseQueue, ^{
+                [self downloaderLock];
+                self.currentRequestCount--;
+                NSMutableArray<AFDataResponseHandler *> *finishTasks = [NSMutableArray array];
+                for (id<AFDataItemIdentifier, NSCoding> data in response) {
+                    [self.cache setObject:data forKey:[data dataItemID]];
+                    AFDataDownloaderMergedTask *mergedTask = self.queuedMergedTasks[[data dataItemID]];
+                    if (mergedTask) {
+                        self.queuedMergedTasks[[data dataItemID]] = nil;
+                        [finishTasks addObjectsFromArray:mergedTask.responseHandlers];
+                    }
+                }
+                for (NSString *dataID in dataItemIDs) {
+                    if (self.queuedMergedTasks[dataID]) {
+                        self.queuedMergedTasks[dataID] = nil;
+                    }
+                    if (self.mergedTasks[dataID]) {
+                        self.mergedTasks[dataID] = nil;
+                    }
+                }
+                [self downloaderUnlock];
+                
+                dispatch_async(self.requestQueue, ^{
+                    [self tryDispatch];
+                });
+                dispatch_async(self.callbackQueue, ^{
+                    for (AFDataResponseHandler *handler in finishTasks) {
+                        id<AFDataItemIdentifier> dataItem = (id<AFDataItemIdentifier>)[self.cache objectForKey:handler.dataItemID];
+                        if (handler.successBlock) {
+                            handler.successBlock(dataItem);
+                        }
+                    }
+                    [self.receiptorManager dataItemsUpdated:response];
+                });
+            });
+        } failureBlock:^(NSArray<NSString *> * _Nonnull dataItemIDs,
+                         NSError * _Nullable error) {
+            __strong __typeof(weakSelf) self = weakSelf;
+            if (!self) {
+                return ;
+            }
+            dispatch_async(self.responseQueue, ^{
+                [self downloaderLock];
+                self.currentRequestCount--;
+                NSMutableArray<AFDataResponseHandler *> *finishTasks = [NSMutableArray array];
+                
+                for (NSString *dataItemID in dataItemIDs) {
+                    AFDataDownloaderMergedTask *mergedTask = self.queuedMergedTasks[dataItemID];
+                    if (mergedTask) {
+                        self.queuedMergedTasks[dataItemID] = nil;
+                        [finishTasks addObjectsFromArray:mergedTask.responseHandlers];
+                    }
+                    if (self.queuedMergedTasks[dataItemID]) {
+                        self.queuedMergedTasks[dataItemID] = nil;
+                    }
+                    if (self.mergedTasks[dataItemID]) {
+                        self.mergedTasks[dataItemID] = nil;
+                    }
+                }
+                [self downloaderUnlock];
+                
+                dispatch_async(self.callbackQueue, ^{
+                    for (AFDataResponseHandler *handler in finishTasks) {
+                        id<AFDataItemIdentifier> dataItem = (id<AFDataItemIdentifier>)[self.cache objectForKey:handler.dataItemID];
+                        if (handler.failureBlock) {
+                            handler.failureBlock(dataItem.dataItemID, error);
+                        }
+                    }
+                });
+            });
+        }];
+    }
+}
+
+- (NSArray *)requestDataIDs {
+    NSMutableArray *dataIDs = [NSMutableArray array];
+    [self downloaderLock];
+    NSTimeInterval currentTimeInterval = CFAbsoluteTimeGetCurrent();
+    if (currentTimeInterval - self.preTimeInterval >= self.retryTimeInterval) {
+        self.preTimeInterval = currentTimeInterval;
+        if (self.currentRequestCount < self.maxRequestCount) {
+            NSArray *keys = [self.mergedTasks allKeys];
+            int couter = 0;
+            NSInteger pageSize = [self.dataLoaderDelegate dataItemDownLoaderPageSize:self];
+            for (NSString *dataID in keys) {
+                if (couter++ > pageSize) {
+                    break;
+                }
+                [dataIDs addObject:dataID];
+                self.queuedMergedTasks[dataID] = self.mergedTasks[dataID];
+                self.mergedTasks[dataID] = nil;
+            }
+        }
+        if (!dataIDs.count) {
+            [self finishTimer];
+        }
+    } else {
+        [self startTimer];
+    }
+    [self downloaderUnlock];
+    return [dataIDs copy];
+}
+
+- (void)updateData:(NSArray<id<AFDataItemIdentifier>> *)dataIDsList {
+    __weak __typeof(self) weakSelf = self;
+    dispatch_async(self.requestQueue, ^{
+        __strong __typeof(weakSelf) self = weakSelf;
+        if (!self) {
+            return;
+        }
+        for (id<AFDataItemIdentifier> data in dataIDsList) {
+            if (!data.dataItemID) {
+                continue;
+            }
+            [self downloaderLock];
+            if (self.mergedTasks[data.dataItemID]
+                || self.queuedMergedTasks[data.dataItemID]) {
+                [self downloaderUnlock];
+                continue;
+            }
+            [self downloaderUnlock];
+            id<AFDataItemIdentifier> storeData = (id<AFDataItemIdentifier>)[self.cache objectForKey:[data dataItemID]];
+            if ([data updatedCompareTo:storeData] || !storeData) {
+                AFDataDownloaderMergedTask *mergedTask = [[AFDataDownloaderMergedTask alloc] init];
+                mergedTask.dataItemVersion = data.dataItemVersion;
+                mergedTask.dataItemID = data.dataItemID;
+                self.mergedTasks[data.dataItemID] = mergedTask;
+                [self.cache removeObjectForKey:data.dataItemID];
+            }
+        }
+        dispatch_async(self.requestQueue, ^{
+            [self tryDispatch];
+        });
+    });
+}
+
+#pragma clang diagnostic pop
+
+@end
+

--- a/AFRequestMerge/AFDataItemIdentifier.h
+++ b/AFRequestMerge/AFDataItemIdentifier.h
@@ -1,0 +1,75 @@
+//
+//  AFDataItemIdentifier.h
+//  AFNetworking iOS
+//
+//  Created by jufan wang on 2020/3/3.
+//  Copyright © 2020 AFNetworking. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol AFDataItemIdentifier;
+
+typedef void (^AFDataItemDownloadSuccessBlock)(NSArray<NSString *> *dataItemIDs,
+                                           NSArray<id<AFDataItemIdentifier, NSCoding>> *dataItemList);
+typedef void (^AFDataItemDownloadFailureBlock)(NSArray<NSString *> *dataItemIDs,
+                                               NSError * _Nullable error);
+
+typedef void (^AFDataItemReceiptorSuccessBlock)(_Nullable id<AFDataItemIdentifier> dataItem);
+typedef void (^AFDataItemReceiptorFailureBlock)(NSString *dataItemID, NSError * _Nullable error);
+
+
+@protocol AFDataItemIdentifier <NSObject>
+@required
+@property (nonatomic, copy) NSString *dataItemID;
+@property (nonatomic, copy) NSString *dataItemVersion;
+- (BOOL)updatedCompareTo:(id<AFDataItemIdentifier>)dataItemIdentifier;
+@end
+@interface AFDataItemIdentifier : NSObject<AFDataItemIdentifier>
+@end
+
+
+@protocol AFDataItemReceiptor <AFDataItemIdentifier>
+@optional
+- (void)dataItemUpdated:(id<AFDataItemIdentifier>)dataItem;
+@end
+
+
+@class AFDataItemDownloader;
+
+@protocol AFDataItemDownloaderDelegate <NSObject>
+
+@required
+
+- (void)dataItemDownLoader:(AFDataItemDownloader *)dataDownLoader
+              loadData:(NSArray *)dataItemIDs
+          successBlock:(AFDataItemDownloadSuccessBlock)successBlock
+          failureBlock:(AFDataItemDownloadFailureBlock)failureBlock;
+
+- (NSInteger)dataItemDownLoaderPageSize:(AFDataItemDownloader *)dataDownLoader;
+
+- (NSInteger)dataItemDownLoaderMaxHTTPConnection:(AFDataItemDownloader *)dataDownLoader;
+
+@end
+
+
+@protocol AFDataItemDownloaderCacher
+
+@required
+
+@property (nonatomic, assign) NSTimeInterval ageLimit;
+@property (nonatomic, assign) NSTimeInterval invalidCachingTime;
+
+- (void)setObject:(nullable id<AFDataItemIdentifier>)object forKey:(NSString *)key;
+
+- (nullable id<AFDataItemIdentifier>)objectForKey:(NSString *)key;
+
+- (void)removeObjectForKey:(NSString *)key;
+
+- (nullable id<AFDataItemIdentifier>)memoryObjectForKey:(NSString *)key;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/AFRequestMerge/AFDataItemIdentifier.m
+++ b/AFRequestMerge/AFDataItemIdentifier.m
@@ -1,0 +1,38 @@
+//
+//  AFDataItemIdentifier.m
+//  AFNetworking iOS
+//
+//  Created by jufan wang on 2020/3/3.
+//  Copyright © 2020 AFNetworking. All rights reserved.
+//
+
+#import "AFDataItemIdentifier.h"
+
+
+@implementation AFDataItemIdentifier
+
+@synthesize dataItemVersion = _dataItemVersion;
+@synthesize dataItemID = _dataItemID;
+
+- (void)encodeWithCoder:(NSCoder *)coder {
+    if (self.dataItemID) {
+        [coder encodeObject:self.dataItemID forKey:@"dataItemID"];
+    }
+    if (self.dataItemVersion) {
+        [coder encodeObject:self.dataItemVersion forKey:@"dataItemVersion"];
+    }
+}
+
+- (BOOL)updatedCompareTo:(id<AFDataItemIdentifier>)dataItemIdentifier {
+    return [dataItemIdentifier.dataItemVersion compare:self.dataItemVersion] == NSOrderedAscending;
+}
+
+- (nullable instancetype)initWithCoder:(NSCoder *)coder {
+    if (self = [super init]) {
+        _dataItemID = [coder decodeObjectForKey:@"dataItemID"];
+        _dataItemVersion = [coder decodeObjectForKey:@"dataItemVersion"];
+    }
+    return self;
+}
+
+@end

--- a/AFRequestMerge/AFDataItemReceiptorManager.h
+++ b/AFRequestMerge/AFDataItemReceiptorManager.h
@@ -1,0 +1,31 @@
+//
+//  AFDataItemReceiptorManager.h
+//  AFNetworking
+//
+//  Created by jufan wang on 2020/3/4.
+//  Copyright © 2020 AFNetworking. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "AFDataItemIdentifier.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface AFDataItemReceiptorManager : NSObject
+
++ (instancetype)managerForDataCategoryID:(NSString *)dataCategoryID;
++ (void)removeManagerForDataCategoryID:(NSString *)dataCategoryID;
+
+- (void)cancel:(NSString *)dataItemID forRecceipter:(id<AFDataItemReceiptor>)receiptor;
+
+- (void)dataItemForID:(NSString *)dataItemID
+           recceipter:(id<AFDataItemReceiptor>)receiptor
+         successBlock:(AFDataItemReceiptorSuccessBlock)successBlock
+         failureBlock:(AFDataItemReceiptorFailureBlock)failureBlock;
+
+- (void)dataItemsUpdated:(NSArray<id<AFDataItemIdentifier>> *)dataItems;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/AFRequestMerge/AFDataItemReceiptorManager.m
+++ b/AFRequestMerge/AFDataItemReceiptorManager.m
@@ -1,0 +1,305 @@
+//
+//  AFDataItemReceiptorManager.m
+//  AFNetworking
+//
+//  Created by jufan wang on 2020/3/4.
+//  Copyright © 2020 AFNetworking. All rights reserved.
+//
+
+#import "AFDataItemReceiptorManager.h"
+#import "AFDataItemDownloader.h"
+
+
+static NSString * kAFDataItemReceiptorError = @"kAFDataItemReceiptorError";
+
+#define kAFDataItemReceiptorErrorCodeCancel 1001
+#define kAFDataItemReceiptorErrorCodeParameter 1002
+
+@interface AFDataItemReceiptorHandler : NSObject
+@property (nonatomic, copy) NSString *dataItemID;
+@property (nonatomic, weak) id<AFDataItemReceiptor> dataReceiptor;
+@property (nonatomic, copy) AFDataItemReceiptorSuccessBlock successBlock;
+@property (nonatomic, copy) AFDataItemReceiptorFailureBlock failureBlock;
+@end
+@implementation AFDataItemReceiptorHandler
+- (NSString *)description {
+    return [NSString stringWithFormat: @"<AFDataItemReceiptorHandler>: %@", self];
+}
+@end
+
+@interface AFDataItemReceiptorHandlersManager : NSObject
+@property (nonatomic, strong) NSMutableDictionary<NSString *,NSNumber *> *requestPinnings;
+@property (nonatomic, strong) NSMutableDictionary<NSString *, NSMutableArray<AFDataItemReceiptorHandler *> *> *request2Handlers;
+@end
+@implementation AFDataItemReceiptorHandlersManager
+
+- (instancetype)init {
+    if (self = [super init]) {
+        _request2Handlers = [NSMutableDictionary dictionary];
+    }
+    return self;
+}
+- (NSMutableArray *)handlesForDataItemID:(NSString *)dataItemID {
+    if (!dataItemID) {
+        return nil;
+    }
+    NSMutableArray *handlers = [self.request2Handlers objectForKey:dataItemID];
+    if (!handlers) {
+        handlers = [NSMutableArray array];
+        [self.request2Handlers setObject:handlers forKey:[dataItemID copy]];
+    }
+    return handlers;
+}
+
+- (void)addHandler:(AFDataItemReceiptorHandler *)handler
+     forDataItemID:(NSString *)dataItemID {
+    if (!handler || !dataItemID) {
+        return;
+    }
+    [[self handlesForDataItemID:[dataItemID copy]] addObject:handler];
+}
+
+- (NSArray<id<AFDataItemReceiptor>> *)removeHandlersForDataItemID:(NSString *)dataItemID {
+    if (!dataItemID) {
+       return nil;
+    }
+   NSArray *handlers = [[self.request2Handlers objectForKey:dataItemID] copy];
+   handlers = [handlers valueForKey:@"dataReceiptor"];
+    [self.request2Handlers removeObjectForKey:dataItemID];
+   return handlers;
+}
+
+
+- (BOOL)pinningForDataItemID:(NSString *)dataItemID {
+    return [[self.requestPinnings objectForKey:dataItemID] boolValue];
+}
+- (void)updatePinning:(BOOL)pinning forDataItemID:(NSString *)dataItemID {
+    if (!dataItemID) {
+        return;
+    }
+    [self.requestPinnings setObject:@(pinning) forKey:[dataItemID copy]];
+}
+
+- (void)cancel:(NSString *)dataItemID forRecceipter:(id)receiptor {
+    if (!dataItemID || !receiptor) {
+        return;
+    }
+    NSMutableArray *handlers = [self handlesForDataItemID:dataItemID];
+    NSArray *ihandlers = [handlers copy];
+    for (AFDataItemReceiptorHandler *handler in ihandlers) {
+        if ([handler.dataItemID isEqualToString:dataItemID]
+            && [handler.dataReceiptor isEqual:receiptor]) {
+            NSError *error = [NSError errorWithDomain:kAFDataItemReceiptorError
+                                                 code:kAFDataItemReceiptorErrorCodeCancel
+                                             userInfo:nil];
+            if (handler.failureBlock) {
+                handler.failureBlock(dataItemID, error);
+            }
+        }
+    }
+    if (!handlers.count) {
+        [self removeHandlersForDataItemID:dataItemID];
+    }
+}
+
+- (NSString *)description {
+    return [NSString stringWithFormat: @"<AFDataItemReceiptorHandlersManager>: %@", self];
+}
+
+@end
+
+
+@interface AFDataItemReceiptorManager()
+@property (class, nonatomic, strong) NSMutableDictionary<NSString *, AFDataItemReceiptorManager *> *receiptorsManager;
+@property (nonatomic, strong) AFDataItemReceiptorHandlersManager *handlersManager;
+@property (nonatomic, strong) dispatch_queue_t responseQueue;
+@property (nonatomic, strong) dispatch_queue_t requestQueue;
+@property (nonatomic, copy) NSString * dataCategoryID;
+@property (nonatomic, strong) NSHashTable<id<AFDataItemReceiptor>> *receiptors;
+
+@property (nonatomic, weak) AFDataItemDownloader *downLoader;
+
+@end
+
+@implementation AFDataItemReceiptorManager
+
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wshadow-ivar"
+
+static NSMutableDictionary<NSString *, AFDataItemReceiptorManager *> *_receiptorsManager;
+
++ (NSMutableDictionary<NSString *, AFDataItemReceiptorManager *> *)receiptorsManager {
+    if (!_receiptorsManager) {
+        _receiptorsManager = [NSMutableDictionary dictionary];
+    }
+    return _receiptorsManager;
+}
++ (void)setReceiptorsManager:(NSMutableDictionary<NSString *,AFDataItemReceiptorManager *> *)receiptorsManager {
+    _receiptorsManager = receiptorsManager;
+}
+
++ (instancetype)managerForDataCategoryID:(NSString *)dataCategoryID {
+    if (!dataCategoryID) {
+        return nil;
+    }
+    AFDataItemReceiptorManager *mananger = nil;
+    @synchronized (self) {
+        mananger = [[[self class] receiptorsManager] objectForKey:dataCategoryID];
+        if (!mananger) {
+            mananger = [[AFDataItemReceiptorManager alloc] init];
+            [[[self class] receiptorsManager] setObject:mananger
+                                                 forKey:[dataCategoryID copy]];
+            mananger.dataCategoryID = dataCategoryID;
+        }
+    }
+    return mananger;
+}
++ (void)removeManagerForDataCategoryID:(NSString *)dataCategoryID {
+    if (!dataCategoryID) {
+        return ;
+    }
+    @synchronized (self) {
+        [[[self class] receiptorsManager] removeObjectForKey:dataCategoryID];
+    }
+}
+
+- (instancetype)init {
+    if (self = [super init]) {
+        _handlersManager = [[AFDataItemReceiptorHandlersManager alloc] init];
+        _requestQueue = dispatch_queue_create("com.af.dataItemReceiptorManager.requestQueue", DISPATCH_QUEUE_SERIAL);
+        _responseQueue = dispatch_queue_create("com.af.dataItemReceiptorManager.responsequeue", DISPATCH_QUEUE_CONCURRENT);
+        _receiptors = [NSHashTable hashTableWithOptions:NSPointerFunctionsWeakMemory];
+    }
+    return self;
+}
+
+- (AFDataItemDownloader *)downLoader {
+    AFDataItemDownloader *downLoader = _downLoader;
+    if (!downLoader) {
+        downLoader = [AFDataItemDownloader getDownloaderWithDataCategoryID:self.dataCategoryID];
+        _downLoader = downLoader;
+    }
+    return downLoader;
+}
+
+- (void)dataItemForID:(NSString *)dataItemID
+           recceipter:(id<AFDataItemReceiptor>)receiptor
+         successBlock:(AFDataItemReceiptorSuccessBlock)successBlock
+         failureBlock:(AFDataItemReceiptorFailureBlock)failureBlock {
+    
+    if (!dataItemID || !receiptor || !successBlock || !failureBlock) {
+        if (failureBlock) {
+            NSError *error = [NSError errorWithDomain:kAFDataItemReceiptorError
+                                                 code:kAFDataItemReceiptorErrorCodeCancel
+                                             userInfo:nil];
+            failureBlock(dataItemID, error);
+        }
+        return;
+    }
+    
+    id<AFDataItemIdentifier> dataItem = [self.downLoader memoryDataItemWithID:dataItemID];
+    if (dataItem) {
+        successBlock(dataItem);
+        __weak __typeof(self) weakSelf = self;
+        dispatch_async(self.requestQueue, ^{
+            __strong typeof(weakSelf) self = weakSelf;
+            [self.receiptors addObject:receiptor];
+        });
+        return;
+    }
+    
+    __weak __typeof(self) weakSelf = self;
+    dispatch_async(self.requestQueue, ^{
+        __strong typeof(weakSelf) self = weakSelf;
+        if (!self) {
+            return ;
+        }
+        [self.receiptors removeObject:receiptor];
+        AFDataItemReceiptorHandler *handler = [[AFDataItemReceiptorHandler alloc] init];
+        handler.successBlock = successBlock;
+        handler.failureBlock = failureBlock;
+        handler.dataReceiptor = receiptor;
+        handler.dataItemID = dataItemID;
+        [self.handlersManager addHandler:handler forDataItemID:dataItemID];
+        if ([self.handlersManager pinningForDataItemID:dataItemID]) {
+            return;
+        }
+        [self.handlersManager updatePinning:YES forDataItemID:dataItemID];
+        [self.downLoader getDataItemWithID:dataItemID success:^(id<AFDataItemIdentifier>  _Nonnull dataItem) {
+            dispatch_async(self.requestQueue, ^{
+                NSString *dataItemIDSuccess = dataItem.dataItemID;
+                NSArray *handlers = [[self.handlersManager handlesForDataItemID:dataItemIDSuccess] copy];
+                [self.handlersManager updatePinning:NO forDataItemID:dataItemIDSuccess];
+                NSArray *receiptors = [self.handlersManager removeHandlersForDataItemID:dataItemID];
+                for (id<AFDataItemReceiptor> receiptor in receiptors) {
+                    [self.receiptors addObject:receiptor];
+                }
+                dispatch_async(self.responseQueue, ^{
+                    for (AFDataItemReceiptorHandler *handler in handlers) {
+                        if (handler.successBlock) {
+                            handler.successBlock(dataItem);
+                        }
+                    }
+                });
+            });
+        } failure:^(NSString * _Nonnull dataItemID, NSError * _Nonnull error) {
+            dispatch_async(self.requestQueue, ^{
+                NSArray *handlers = [[self.handlersManager handlesForDataItemID:dataItemID] copy];
+                [self.handlersManager updatePinning:NO forDataItemID:dataItemID];
+                NSArray *receiptors = [self.handlersManager removeHandlersForDataItemID:dataItemID];
+                for (id<AFDataItemReceiptor> receiptor in receiptors) {
+                    [self.receiptors addObject:receiptor];
+                }
+                dispatch_async(self.requestQueue, ^{
+                    for (AFDataItemReceiptorHandler *handler in handlers) {
+                        if (handler.failureBlock) {
+                            handler.failureBlock(dataItemID, error);
+                        }
+                    }
+                });
+            });
+        }];
+    });
+}
+
+- (void)cancel:(NSString *)dataItemID forRecceipter:(id<AFDataItemReceiptor>)receiptor {
+    if (!dataItemID || !receiptor) {
+        return;
+    }
+    __weak __typeof(self) weakSelf = self;
+    dispatch_async(self.requestQueue, ^{
+        __strong __typeof(weakSelf) self = weakSelf;
+        [self.handlersManager cancel:dataItemID forRecceipter:receiptor];
+        [self.receiptors removeObject:receiptor];
+    });
+}
+
+- (void)dataItemsUpdated:(NSArray<id<AFDataItemIdentifier>> *)dataItems {
+    __weak __typeof(self) weakSelf = self;
+    dataItems = [dataItems copy];
+    dispatch_async(self.requestQueue, ^{
+        __strong __typeof(weakSelf) self = weakSelf;
+        if (!self) {
+            return;
+        }
+        NSHashTable *receiptors = [self.receiptors copy];
+        dispatch_async(self.responseQueue, ^{
+            for (id<AFDataItemReceiptor> receiptor in receiptors) {
+                if ([receiptor respondsToSelector:@selector(dataItemID)]
+                    && [receiptor respondsToSelector:@selector(dataItemUpdated:)]) {
+                    for (id<AFDataItemIdentifier> dataItem in dataItems) {
+                        if ([dataItem.dataItemID isEqualToString:receiptor.dataItemID]) {
+                            [receiptor dataItemUpdated:dataItem];
+                            break;
+                        }
+                    }
+                }
+            }
+        });
+    });
+}
+
+#pragma clang diagnostic pop
+
+@end


### PR DESCRIPTION
1. Merge multiple requests of the some data item  to one but return one by one .
2. Merge a list of different data item requests to one but return one by one  .
3. Automatic notify the receiptor when data item was refreshed one by one .
It's an excellent solution to reduce the complexity of response for request with an id .