### PR TITLE
Improve podspec

### DIFF
--- a/AFNetworking.podspec
+++ b/AFNetworking.podspec
@@ -8,6 +8,10 @@ Pod::Spec.new do |s|
   s.authors  = { 'Mattt Thompson' => 'm@mattt.me' }
   s.source   = { :git => 'https://github.com/AFNetworking/AFNetworking.git', :tag => s.version }
 
+  s.pod_target_xcconfig = {
+    'PRODUCT_BUNDLE_IDENTIFIER' => 'com.alamofire.AFNetworking'
+  }
+
   s.source_files = 'AFNetworking/AFNetworking.h'
 
   pch_AF = <<-EOS

--- a/AFNetworking.podspec
+++ b/AFNetworking.podspec
@@ -8,7 +8,6 @@ Pod::Spec.new do |s|
   s.authors  = { 'Mattt Thompson' => 'm@mattt.me' }
   s.source   = { :git => 'https://github.com/AFNetworking/AFNetworking.git', :tag => s.version }
 
-  s.public_header_files = 'AFNetworking/AFNetworking.h'
   s.source_files = 'AFNetworking/AFNetworking.h'
 
   pch_AF = <<-EOS
@@ -33,7 +32,6 @@ EOS
 
   s.subspec 'Serialization' do |ss|
     ss.source_files = 'AFNetworking/AFURL{Request,Response}Serialization.{h,m}'
-    ss.public_header_files = 'AFNetworking/AFURL{Request,Response}Serialization.h'
     ss.watchos.frameworks = 'MobileCoreServices', 'CoreGraphics'
     ss.ios.frameworks = 'MobileCoreServices', 'CoreGraphics'
     ss.osx.frameworks = 'CoreServices'
@@ -41,7 +39,6 @@ EOS
 
   s.subspec 'Security' do |ss|
     ss.source_files = 'AFNetworking/AFSecurityPolicy.{h,m}'
-    ss.public_header_files = 'AFNetworking/AFSecurityPolicy.h'
     ss.frameworks = 'Security'
   end
 
@@ -51,7 +48,6 @@ EOS
     ss.tvos.deployment_target = '9.0'
 
     ss.source_files = 'AFNetworking/AFNetworkReachabilityManager.{h,m}'
-    ss.public_header_files = 'AFNetworking/AFNetworkReachabilityManager.h'
 
     ss.frameworks = 'SystemConfiguration'
   end
@@ -64,7 +60,6 @@ EOS
     ss.dependency 'AFNetworking/Security'
 
     ss.source_files = 'AFNetworking/AF{URL,HTTP}SessionManager.{h,m}', 'AFNetworking/AFCompatibilityMacros.h'
-    ss.public_header_files = 'AFNetworking/AF{URL,HTTP}SessionManager.h', 'AFNetworking/AFCompatibilityMacros.h'
   end
 
   s.subspec 'UIKit' do |ss|
@@ -72,7 +67,6 @@ EOS
     ss.tvos.deployment_target = '9.0'
     ss.dependency 'AFNetworking/NSURLSession'
 
-    ss.public_header_files = 'UIKit+AFNetworking/*.h'
     ss.source_files = 'UIKit+AFNetworking'
   end
 end

--- a/AFNetworking.podspec
+++ b/AFNetworking.podspec
@@ -6,12 +6,11 @@ Pod::Spec.new do |s|
   s.homepage = 'https://github.com/AFNetworking/AFNetworking'
   s.social_media_url = 'https://twitter.com/AFNetworking'
   s.authors  = { 'Mattt Thompson' => 'm@mattt.me' }
-  s.source   = { :git => 'https://github.com/AFNetworking/AFNetworking.git', :tag => s.version, :submodules => true }
-  s.requires_arc = true
-  
+  s.source   = { :git => 'https://github.com/AFNetworking/AFNetworking.git', :tag => s.version }
+
   s.public_header_files = 'AFNetworking/AFNetworking.h'
   s.source_files = 'AFNetworking/AFNetworking.h'
-  
+
   pch_AF = <<-EOS
 #ifndef TARGET_OS_IOS
   #define TARGET_OS_IOS TARGET_OS_IPHONE
@@ -26,12 +25,12 @@ Pod::Spec.new do |s|
 #endif
 EOS
   s.prefix_header_contents = pch_AF
-  
+
   s.ios.deployment_target = '9.0'
   s.osx.deployment_target = '10.10'
   s.watchos.deployment_target = '2.0'
   s.tvos.deployment_target = '9.0'
-  
+
   s.subspec 'Serialization' do |ss|
     ss.source_files = 'AFNetworking/AFURL{Request,Response}Serialization.{h,m}'
     ss.public_header_files = 'AFNetworking/AFURL{Request,Response}Serialization.h'

--- a/AFNetworking.podspec
+++ b/AFNetworking.podspec
@@ -14,21 +14,6 @@ Pod::Spec.new do |s|
 
   s.source_files = 'AFNetworking/AFNetworking.h'
 
-  pch_AF = <<-EOS
-#ifndef TARGET_OS_IOS
-  #define TARGET_OS_IOS TARGET_OS_IPHONE
-#endif
-
-#ifndef TARGET_OS_WATCH
-  #define TARGET_OS_WATCH 0
-#endif
-
-#ifndef TARGET_OS_TV
-  #define TARGET_OS_TV 0
-#endif
-EOS
-  s.prefix_header_contents = pch_AF
-
   s.ios.deployment_target = '9.0'
   s.osx.deployment_target = '10.10'
   s.watchos.deployment_target = '2.0'


### PR DESCRIPTION
- Removed unnecessary `submodules` parameter from `source` attribute.
- Removed `requires_arc = true` since `requires_arc` defaults to `true`.
- Removed redundant [`public_header_files`](https://guides.cocoapods.org/syntax/podspec.html#public_header_files): if no public headers are specified then all the headers in `source_files` are considered public.
- Removed `prefix_header_contents`: since v4 requires Xcode 11+, these TARGET_OS definitions become unnecessary.
- Fixed bundle identifier for CocoaPods generated framework: change `org.cocoapods.AFNetworking` to `com.alamofire.AFNetworking`.
- Formatted podspec file: trimmed white space for blank lines.
