### PR TITLE
(Infra) Make infra changes to cleanup project and simplify its maintenance

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,27 +1,33 @@
-<!--
-Hi, thanks so much for opening an issue! 🤗
+> ℹ Please fill out this template when filing an issue.
+> All lines beginning with an ℹ symbol instruct you with what info we expect. You can delete those lines once you've filled in the info.
+>
+> Per our [*CONTRIBUTING guidelines](https://github.com/AFNetworking/AFNetworking/blob/master/CONTRIBUTING.md), we use GitHub for
+> bugs and feature requests, not general support. Other issues should be opened on Stack Overflow with the tag `afnetworking`.
+>
+> Please remove this line and everything above it before submitting.
 
-To better pinpoint (and solve) the issue you're experiencing, we could use some information on your behalf.
+* [ ] I've read, understood, and done my best to follow the [*CONTRIBUTING guidelines](https://github.com/AFNetworking/AFNetworking/blob/master/CONTRIBUTING.md).
 
-Please let us know the following things:
+## What did you do?
 
-- What version of AFNetworking are you using?
-- What version of iOS are you running on?
-- What version of Swift (if any) are you running on?
-- What device(s) are you testing on? Are these simulators?
-- Is the issue you're experiencing reproducable in the example app?
+ℹ Please replace this with what you did.  
 
-In some cases it can be really helpful to provide a short example of your code.
-If so, please wrap these code blocks in backticks, like this:
+## What did you expect to happen?
 
-```objective-c
-*your code goes here*
-```
+ℹ Please replace this with what you expected to happen.  
 
-When referencing a dependency manager-related issue (think CocoaPods, Carthage, SPM), please add its configuration file and version to the issue.
-It would be helpful to put the contents in a code block too, using ```ruby for CocoaPods and ```swift for SwiftPM.
+## What happened instead?
 
-Also please make sure your title describes your problem well. Questions end with a question mark.
+ℹ Please replace this with of what happened instead.  
 
-Thanks again, and let us know if there are any other questions you might have.
--->
+## AFNetworking Environment
+
+**AFNetworking version:**
+**Xcode version:**
+**Swift version:**
+**Platform(s) running AFNetworking:**
+**macOS version running Xcode:**
+
+## Demo Project
+
+ℹ Please link to or upload a project we can download that reproduces the issue.

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,27 @@
+<!--
+Hi, thanks so much for opening an issue! 🤗
+
+To better pinpoint (and solve) the issue you're experiencing, we could use some information on your behalf.
+
+Please let us know the following things:
+
+- What version of AFNetworking are you using?
+- What version of iOS are you running on?
+- What version of Swift (if any) are you running on?
+- What device(s) are you testing on? Are these simulators?
+- Is the issue you're experiencing reproducable in the example app?
+
+In some cases it can be really helpful to provide a short example of your code.
+If so, please wrap these code blocks in backticks, like this:
+
+```objective-c
+*your code goes here*
+```
+
+When referencing a dependency manager-related issue (think CocoaPods, Carthage, SPM), please add its configuration file and version to the issue.
+It would be helpful to put the contents in a code block too, using ```ruby for CocoaPods and ```swift for SwiftPM.
+
+Also please make sure your title describes your problem well. Questions end with a question mark.
+
+Thanks again, and let us know if there are any other questions you might have.
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+What does this implement/fix? Explain your changes.
+---------------------------------------------------
+…
+
+Does this close any currently open issues?
+------------------------------------------
+…
+
+
+Any relevant logs, error output, etc?
+-------------------------------------
+<!--
+If the logs is quite long, please paste to https://ghostbin.com/ and insert the link here.
+-->
+
+Any other comments?
+-------------------
+…
+
+Where has this been tested?
+---------------------------
+**Devices/Simulators:** …
+
+**iOS version:** …
+
+**AFNetworking version:** …

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,26 +1,13 @@
-What does this implement/fix? Explain your changes.
----------------------------------------------------
-…
+### Issue Link :link:
+<!-- What issue does this fix? If an issue doesn't exist, remove this section. -->
 
-Does this close any currently open issues?
-------------------------------------------
-…
+### Goals :soccer:
+<!-- List the high-level objectives of this pull request. -->
+<!-- Include any relevant context. -->
 
+### Implementation Details :construction:
+<!-- Explain the reasoning behind any architectural changes. -->
+<!-- Highlight any new functionality. -->
 
-Any relevant logs, error output, etc?
--------------------------------------
-<!--
-If the logs is quite long, please paste to https://ghostbin.com/ and insert the link here.
--->
-
-Any other comments?
--------------------
-…
-
-Where has this been tested?
----------------------------
-**Devices/Simulators:** …
-
-**iOS version:** …
-
-**AFNetworking version:** …
+### Testing Details :mag:
+<!-- Describe what tests you've added for your changes. -->

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,33 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 14
+
+# Number of days of inactivity before a stale Issue or Pull Request is closed
+daysUntilClose: 7
+
+# Issues or Pull Requests with these labels will never be considered stale
+exemptLabels:
+  - "support"
+  - "bug"
+  - "security"
+
+# Label to use when marking as stale
+staleLabel: stale
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This issue has been marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. 
+
+# Comment to post when removing the stale label. Set to `false` to disable
+unmarkComment: false
+
+# Comment to post when closing a stale Issue or Pull Request. Set to `false` to disable
+closeComment: >
+  This issue has been auto-closed because there hasn't been any activity for at least 21 days.
+  However, we really appreciate your contribution, so thank you for that! 🙏
+  Also, feel free to [open a new issue](https://github.com/AFNetworking/AFNetworking/issues/new) if you still experience this problem 👍.
+
+# Limit to only `issues`
+only: issues

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ Perhaps the most important feature of all, however, is the amazing community of 
 
 - [Download AFNetworking](https://github.com/AFNetworking/AFNetworking/archive/master.zip) and try out the included Mac and iPhone example apps
 - Read the ["Getting Started" guide](https://github.com/AFNetworking/AFNetworking/wiki/Getting-Started-with-AFNetworking), [FAQ](https://github.com/AFNetworking/AFNetworking/wiki/AFNetworking-FAQ), or [other articles on the Wiki](https://github.com/AFNetworking/AFNetworking/wiki)
-- Check out the [documentation](http://cocoadocs.org/docsets/AFNetworking/) for a comprehensive look at all of the APIs available in AFNetworking
 
 ## Communication
 


### PR DESCRIPTION
- update readme - CocoaDocs are not used anymore
- add stale bot
- add issue template
- add pull request template

Re: Stale bot @jshier:
- please create new label "stale" that bot will use to mark stale Issues
- please configure the bot for this repo: https://github.com/apps/stale
After these two things ^^ are done, we can merge this.

More info: https://github.com/probot/stale

Thanks!