### PR TITLE
Fix MobileCoreServices renamed warning, close #4520

### DIFF
--- a/AFNetworking.podspec
+++ b/AFNetworking.podspec
@@ -21,14 +21,10 @@ Pod::Spec.new do |s|
 
   s.subspec 'Serialization' do |ss|
     ss.source_files = 'AFNetworking/AFURL{Request,Response}Serialization.{h,m}'
-    ss.watchos.frameworks = 'MobileCoreServices', 'CoreGraphics'
-    ss.ios.frameworks = 'MobileCoreServices', 'CoreGraphics'
-    ss.osx.frameworks = 'CoreServices'
   end
 
   s.subspec 'Security' do |ss|
     ss.source_files = 'AFNetworking/AFSecurityPolicy.{h,m}'
-    ss.frameworks = 'Security'
   end
 
   s.subspec 'Reachability' do |ss|
@@ -37,8 +33,6 @@ Pod::Spec.new do |s|
     ss.tvos.deployment_target = '9.0'
 
     ss.source_files = 'AFNetworking/AFNetworkReachabilityManager.{h,m}'
-
-    ss.frameworks = 'SystemConfiguration'
   end
 
   s.subspec 'NSURLSession' do |ss|


### PR DESCRIPTION
This warning appears when compiling **iOS/watchOS** AFNetworking installed from CocoaPods on Xcode 11.4.

![image](https://user-images.githubusercontent.com/526008/77892980-eecffd80-72a5-11ea-891b-78acd78d4b7c.png)

Also from `pod lib lint`:
```
- NOTE  | xcodebuild:  warning: MobileCoreServices has been renamed. Use CoreServices instead. (in target 'AFNetworking' from project 'Pods')
```

**Why no warning on tvOS?**

Because we did not configure `frameworks` attribute for tvOS `Serialization` subspec:

```ruby
  s.subspec 'Serialization' do |ss|
    ss.source_files = 'AFNetworking/AFURL{Request,Response}Serialization.{h,m}'
    ss.watchos.frameworks = 'MobileCoreServices', 'CoreGraphics'
    ss.ios.frameworks = 'MobileCoreServices', 'CoreGraphics'
    ss.osx.frameworks = 'CoreServices'
  end
```

**Why Xcode issues this warning?**

- CocoaPods will add build flag `-framework "MobileCoreServices"` becuase there is `ss.frameworks = 'MobileCoreServices'` in our podspec file. `-framework` flag tells Xcode to explicitly link `MobileCoreServices.framework`.
- From iOS 12, tvOS 12, watchOS 5, Apple moved (merged) MobileCoreServices code (`LSApplication***`, `UTType**` etc) on these platforms to the _new_ CoreServices framework which previously only available on macOS.
- In iOS 13.4 SDK (Xcode 11.4), Apple keeps the MobileCoreServices framework but points it to the CoreServices framework, you may check it out at `/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/System/Library/Frameworks/MobileCoreServices.framework/Headers`.
- Xcode currently issues this warning to want us to migrate MobileCoreServices to CoreServices.
- You may guess MobileCoreServices will be deleted from iOS SDK in the future.

**How to fix this warning?**

Do not explicitly link `MobileCoreServices.framework`, that's all, no code needs to be changed.

**#import statement**

You can continue to use `#import <MobileCoreServices/MobileCoreServices.h>` or `@import MobileCoreServices;` in your iOS/tvOS/watchOS app or library, before Apple remove the MobileCoreServices framework.

If your app or library is built for iOS 12+, tvOS 12+, watchOS 5+ or macOS, you can just import CoreServices:

```objc
#import <CoreServices/CoreServices.h>
```

Currently, for a cross-platform library or app, you can do conditional importing like AFNetworking does:

```objc
#import <TargetConditionals.h>

#if TARGET_OS_IOS || TARGET_OS_WATCH || TARGET_OS_TV
#import <MobileCoreServices/MobileCoreServices.h>
#else
#import <CoreServices/CoreServices.h>
#endif
```

Or using `__has_include` (may be forward compatibility):

```objc
#if __has_include(<MobileCoreServices/MobileCoreServices.h>)
#import <MobileCoreServices/MobileCoreServices.h>
#else
#import <CoreServices/CoreServices.h>
#endif
```

**Is it safe to remove all `frameworks` attributes in podspec?**

YES!

The auto-linking (CLANG_ENABLE_MODULES) is enabled by default in a Xcode/CocoaPods generated project. And that is why `AFNetworking/UIKit` pod-subspec can be built without specifying `UIKit` and `WebKit` dependencies:

```ruby
  s.subspec 'UIKit' do |ss|
    // ...
    ss.source_files = 'UIKit+AFNetworking'

    ss.frameworks = 'UIKit', 'WebKit' // omitted currently
  end
```
