### PR TITLE
Separate bundle identifier for watchOS target

### DIFF
--- a/AFNetworking.podspec
+++ b/AFNetworking.podspec
@@ -8,16 +8,17 @@ Pod::Spec.new do |s|
   s.authors  = { 'Mattt Thompson' => 'm@mattt.me' }
   s.source   = { :git => 'https://github.com/AFNetworking/AFNetworking.git', :tag => s.version }
 
-  s.pod_target_xcconfig = {
-    'PRODUCT_BUNDLE_IDENTIFIER' => 'com.alamofire.AFNetworking'
-  }
-
-  s.source_files = 'AFNetworking/AFNetworking.h'
-
   s.ios.deployment_target = '9.0'
   s.osx.deployment_target = '10.10'
   s.watchos.deployment_target = '2.0'
   s.tvos.deployment_target = '9.0'
+
+  s.ios.pod_target_xcconfig = { 'PRODUCT_BUNDLE_IDENTIFIER' => 'com.alamofire.AFNetworking' }
+  s.osx.pod_target_xcconfig = { 'PRODUCT_BUNDLE_IDENTIFIER' => 'com.alamofire.AFNetworking' }
+  s.watchos.pod_target_xcconfig = { 'PRODUCT_BUNDLE_IDENTIFIER' => 'com.alamofire.AFNetworking-watchOS' }
+  s.tvos.pod_target_xcconfig = { 'PRODUCT_BUNDLE_IDENTIFIER' => 'com.alamofire.AFNetworking' }
+
+  s.source_files = 'AFNetworking/AFNetworking.h'
 
   s.subspec 'Serialization' do |ss|
     ss.source_files = 'AFNetworking/AFURL{Request,Response}Serialization.{h,m}'


### PR DESCRIPTION
As discussed in https://github.com/AFNetworking/AFNetworking/pull/4528#discussion_r399952269 and https://github.com/AFNetworking/AFNetworking/pull/4530

Change framework bundle identifier For CocoaPods installation:
- iOS/macOS/tvOS: `com.alamofire.AFNetworking`
- watchOS: `com.alamofire.AFNetworking-watchOS`