### PR TITLE
Fix UIKit+AFNetworking.h

### DIFF
--- a/UIKit+AFNetworking/UIKit+AFNetworking.h
+++ b/UIKit+AFNetworking/UIKit+AFNetworking.h
@@ -20,23 +20,24 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#if TARGET_OS_IOS || TARGET_OS_TV
-#import <UIKit/UIKit.h>
+#import <TargetConditionals.h>
 
 #ifndef _UIKIT_AFNETWORKING_
     #define _UIKIT_AFNETWORKING_
 
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS || TARGET_OS_TV
     #import "AFAutoPurgingImageCache.h"
     #import "AFImageDownloader.h"
+    #import "UIActivityIndicatorView+AFNetworking.h"
+    #import "UIButton+AFNetworking.h"
+    #import "UIImageView+AFNetworking.h"
+    #import "UIProgressView+AFNetworking.h"
+#endif
+
+#if TARGET_OS_IOS
     #import "AFNetworkActivityIndicatorManager.h"
     #import "UIRefreshControl+AFNetworking.h"
     #import "WKWebView+AFNetworking.h"
 #endif
 
-    #import "UIActivityIndicatorView+AFNetworking.h"
-    #import "UIButton+AFNetworking.h"
-    #import "UIImageView+AFNetworking.h"
-    #import "UIProgressView+AFNetworking.h"
 #endif /* _UIKIT_AFNETWORKING_ */
-#endif


### PR DESCRIPTION
For manual installation, adding `|| TARGET_OS_TV` conditional to expose some categories to tvOS.