### PR TITLE
Replace instead of appending to the default header

### DIFF
--- a/AFNetworking/AFHTTPSessionManager.m
+++ b/AFNetworking/AFHTTPSessionManager.m
@@ -180,7 +180,7 @@
     NSError *serializationError = nil;
     NSMutableURLRequest *request = [self.requestSerializer multipartFormRequestWithMethod:@"POST" URLString:[[NSURL URLWithString:URLString relativeToURL:self.baseURL] absoluteString] parameters:parameters constructingBodyWithBlock:block error:&serializationError];
     for (NSString *headerField in headers.keyEnumerator) {
-        [request addValue:headers[headerField] forHTTPHeaderField:headerField];
+        [request setValue:headers[headerField] forHTTPHeaderField:headerField];
     }
     if (serializationError) {
         if (failure) {
@@ -261,7 +261,7 @@
     NSError *serializationError = nil;
     NSMutableURLRequest *request = [self.requestSerializer requestWithMethod:method URLString:[[NSURL URLWithString:URLString relativeToURL:self.baseURL] absoluteString] parameters:parameters error:&serializationError];
     for (NSString *headerField in headers.keyEnumerator) {
-        [request addValue:headers[headerField] forHTTPHeaderField:headerField];
+        [request setValue:headers[headerField] forHTTPHeaderField:headerField];
     }
     if (serializationError) {
         if (failure) {

--- a/Tests/Tests/AFHTTPSessionManagerTests.m
+++ b/Tests/Tests/AFHTTPSessionManagerTests.m
@@ -200,6 +200,33 @@
     [self waitForExpectationsWithTimeout:10.0 handler:nil];
 }
 
+- (void)testSettingHTTPHeadersPerRequestCanReplaceTheDefaultValueSpecifiedInRequestSerializer {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Request should succeed"];
+
+    [self.sessionManager.requestSerializer setValue:@"foo value"
+                                 forHTTPHeaderField:@"X-Foo"];
+    [self.sessionManager.requestSerializer setValue:@"bar value"
+                                 forHTTPHeaderField:@"X-Bar"];
+
+    NSURLSessionDataTask *testTask =
+        [self.sessionManager dataTaskWithHTTPMethod:@"GET"
+                                          URLString:@"get"
+                                         parameters:nil
+                                            headers:@{ @"X-Foo": @"request value" }
+                                     uploadProgress:nil
+                                   downloadProgress:nil
+                                            success:^(NSURLSessionDataTask * _Nonnull task, id _Nullable responseObject) {
+        XCTAssertTrue([task.originalRequest.allHTTPHeaderFields[@"X-Foo"] isEqualToString:@"request value"]);
+        XCTAssertTrue([task.originalRequest.allHTTPHeaderFields[@"X-Bar"] isEqualToString:@"bar value"]);
+        [expectation fulfill];
+    }
+                                            failure:nil];
+
+    [testTask resume];
+
+    [self waitForExpectationsWithCommonTimeout];
+}
+
 #pragma mark - NSCoding
 
 - (void)testSupportsSecureCoding {
@@ -374,6 +401,8 @@
 
 - (void)testPOST {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Request should succeed"];
+    [self.sessionManager.requestSerializer setValue:@"default value"
+                                 forHTTPHeaderField:@"field"];
     [self.sessionManager
      POST:@"post"
      parameters:@{@"key":@"value"}
@@ -390,6 +419,8 @@
 
 - (void)testPOSTWithConstructingBody {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Request should succeed"];
+    [self.sessionManager.requestSerializer setValue:@"default value"
+                                 forHTTPHeaderField:@"field"];
     [self.sessionManager
      POST:@"post"
      parameters:@{@"key":@"value"}
@@ -413,6 +444,8 @@
 
 - (void)testPUT {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Request should succeed"];
+    [self.sessionManager.requestSerializer setValue:@"default value"
+                                 forHTTPHeaderField:@"field"];
     [self.sessionManager
      PUT:@"put"
      parameters:@{@"key":@"value"}
@@ -428,6 +461,8 @@
 
 - (void)testDELETE {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Request should succeed"];
+    [self.sessionManager.requestSerializer setValue:@"default value"
+                                 forHTTPHeaderField:@"field"];
     [self.sessionManager
      DELETE:@"delete"
      parameters:@{@"key":@"value"}
@@ -443,6 +478,8 @@
 
 - (void)testPATCH {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Request should succeed"];
+    [self.sessionManager.requestSerializer setValue:@"default value"
+                                 forHTTPHeaderField:@"field"];
     [self.sessionManager
      PATCH:@"patch"
      parameters:@{@"key":@"value"}


### PR DESCRIPTION
Related issue: https://github.com/AFNetworking/AFNetworking/issues/4549
For configuring headers to an individual request, in general, we prefer to replace the default value, instead of appending things to the default value with a comma, right?
In my opinion, using `setValue` is more reasonable and clearer.