### PR TITLE
Fix ServerTrustError crash.

### DIFF
--- a/AFNetworking/AFHTTPSessionManager.h
+++ b/AFNetworking/AFHTTPSessionManager.h
@@ -271,14 +271,14 @@ NS_ASSUME_NONNULL_BEGIN
 
  @see -dataTaskWithRequest:uploadProgress:downloadProgress:completionHandler:
  */
-- (NSURLSessionDataTask *)dataTaskWithHTTPMethod:(NSString *)method
-                                       URLString:(NSString *)URLString
-                                      parameters:(nullable id)parameters
-                                         headers:(nullable NSDictionary <NSString *, NSString *> *)headers
-                                  uploadProgress:(nullable void (^)(NSProgress *uploadProgress)) uploadProgress
-                                downloadProgress:(nullable void (^)(NSProgress *downloadProgress)) downloadProgress
-                                         success:(nullable void (^)(NSURLSessionDataTask *task, id _Nullable responseObject))success
-                                         failure:(nullable void (^)(NSURLSessionDataTask * _Nullable task, NSError *error))failure;
+- (nullable NSURLSessionDataTask *)dataTaskWithHTTPMethod:(NSString *)method
+                                                URLString:(NSString *)URLString
+                                               parameters:(nullable id)parameters
+                                                  headers:(nullable NSDictionary <NSString *, NSString *> *)headers
+                                           uploadProgress:(nullable void (^)(NSProgress *uploadProgress))uploadProgress
+                                         downloadProgress:(nullable void (^)(NSProgress *downloadProgress))downloadProgress
+                                                  success:(nullable void (^)(NSURLSessionDataTask *task, id _Nullable responseObject))success
+                                                  failure:(nullable void (^)(NSURLSessionDataTask * _Nullable task, NSError *error))failure;
 
 @end
 

--- a/AFNetworking/AFHTTPSessionManager.m
+++ b/AFNetworking/AFHTTPSessionManager.m
@@ -180,7 +180,7 @@
     NSError *serializationError = nil;
     NSMutableURLRequest *request = [self.requestSerializer multipartFormRequestWithMethod:@"POST" URLString:[[NSURL URLWithString:URLString relativeToURL:self.baseURL] absoluteString] parameters:parameters constructingBodyWithBlock:block error:&serializationError];
     for (NSString *headerField in headers.keyEnumerator) {
-        [request addValue:headers[headerField] forHTTPHeaderField:headerField];
+        [request setValue:headers[headerField] forHTTPHeaderField:headerField];
     }
     if (serializationError) {
         if (failure) {
@@ -261,7 +261,7 @@
     NSError *serializationError = nil;
     NSMutableURLRequest *request = [self.requestSerializer requestWithMethod:method URLString:[[NSURL URLWithString:URLString relativeToURL:self.baseURL] absoluteString] parameters:parameters error:&serializationError];
     for (NSString *headerField in headers.keyEnumerator) {
-        [request addValue:headers[headerField] forHTTPHeaderField:headerField];
+        [request setValue:headers[headerField] forHTTPHeaderField:headerField];
     }
     if (serializationError) {
         if (failure) {

--- a/AFNetworking/AFURLRequestSerialization.h
+++ b/AFNetworking/AFURLRequestSerialization.h
@@ -216,7 +216,7 @@ forHTTPHeaderField:(NSString *)field;
 
  @param block A block that defines a process of encoding parameters into a query string. This block returns the query string and takes three arguments: the request, the parameters to encode, and the error that occurred when attempting to encode parameters for the given request.
  */
-- (void)setQueryStringSerializationWithBlock:(nullable NSString * (^)(NSURLRequest *request, id parameters, NSError * __autoreleasing *error))block;
+- (void)setQueryStringSerializationWithBlock:(nullable NSString * _Nullable (^)(NSURLRequest *request, id parameters, NSError * __autoreleasing *error))block;
 
 ///-------------------------------
 /// @name Creating Request Objects
@@ -234,10 +234,10 @@ forHTTPHeaderField:(NSString *)field;
 
  @return An `NSMutableURLRequest` object.
  */
-- (NSMutableURLRequest *)requestWithMethod:(NSString *)method
-                                 URLString:(NSString *)URLString
-                                parameters:(nullable id)parameters
-                                     error:(NSError * _Nullable __autoreleasing *)error;
+- (nullable NSMutableURLRequest *)requestWithMethod:(NSString *)method
+                                          URLString:(NSString *)URLString
+                                         parameters:(nullable id)parameters
+                                              error:(NSError * _Nullable __autoreleasing *)error;
 
 /**
  Creates an `NSMutableURLRequest` object with the specified HTTP method and URLString, and constructs a `multipart/form-data` HTTP body, using the specified parameters and multipart form data block. See http://www.w3.org/TR/html4/interact/forms.html#h-17.13.4.2

--- a/AFNetworking/AFURLSessionManager.h
+++ b/AFNetworking/AFURLSessionManager.h
@@ -447,6 +447,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)setDownloadTaskDidResumeBlock:(nullable void (^)(NSURLSession *session, NSURLSessionDownloadTask *downloadTask, int64_t fileOffset, int64_t expectedTotalBytes))block;
 
++ (nonnull NSError *)serverTrustErrorWithServerTrust:(nonnull SecTrustRef)serverTrust url:(nonnull NSURL *)url;
+
 @end
 
 ///--------------------

--- a/AFNetworking/AFURLSessionManager.h
+++ b/AFNetworking/AFURLSessionManager.h
@@ -447,8 +447,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)setDownloadTaskDidResumeBlock:(nullable void (^)(NSURLSession *session, NSURLSessionDownloadTask *downloadTask, int64_t fileOffset, int64_t expectedTotalBytes))block;
 
-+ (nonnull NSError *)serverTrustErrorWithServerTrust:(nonnull SecTrustRef)serverTrust url:(nonnull NSURL *)url;
-
 @end
 
 ///--------------------

--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -168,6 +168,21 @@ typedef void (^AFURLSessionTaskCompletionHandler)(NSURLResponse *response, id re
 
 static const void * const AuthenticationChallengeErrorKey = &AuthenticationChallengeErrorKey;
 
+static NSError * ServerTrustError(SecTrustRef serverTrust, NSURL *url)
+{
+    NSBundle *CFNetworkBundle = [NSBundle bundleWithIdentifier:@"com.apple.CFNetwork"];
+    NSString *defaultValue = @"The certificate for this server is invalid. You might be connecting to a server that is pretending to be “%@” which could put your confidential information at risk.";
+    NSString *descriptionFormat = NSLocalizedStringWithDefaultValue(@"Err-1202.w", nil, CFNetworkBundle, defaultValue, @"") ?: defaultValue;
+    NSString *localizedDescription = [descriptionFormat componentsSeparatedByString:@"%@"].count <= 2 ? [NSString localizedStringWithFormat:descriptionFormat, url.host] : descriptionFormat;
+    NSDictionary *userInfo = @{
+        NSURLErrorFailingURLErrorKey: url,
+        NSURLErrorFailingURLStringErrorKey: url.absoluteString,
+        NSURLErrorFailingURLPeerTrustErrorKey: (__bridge id)serverTrust,
+        NSLocalizedDescriptionKey: localizedDescription
+    };
+    return [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorServerCertificateUntrusted userInfo:userInfo];
+}
+
 #pragma mark - NSURLSessionTaskDelegate
 
 - (void)URLSession:(__unused NSURLSession *)session
@@ -994,7 +1009,7 @@ didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
             disposition = NSURLSessionAuthChallengeUseCredential;
             credential = [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust];
         } else {
-            objc_setAssociatedObject(task, AuthenticationChallengeErrorKey, [AFURLSessionManager serverTrustErrorWithServerTrust:challenge.protectionSpace.serverTrust url:task.currentRequest.URL], OBJC_ASSOCIATION_RETAIN);
+            objc_setAssociatedObject(task, AuthenticationChallengeErrorKey, ServerTrustError(challenge.protectionSpace.serverTrust, task.currentRequest.URL), OBJC_ASSOCIATION_RETAIN);
             disposition = NSURLSessionAuthChallengeCancelAuthenticationChallenge;
         }
     }
@@ -1242,24 +1257,6 @@ expectedTotalBytes:(int64_t)expectedTotalBytes
 
 - (instancetype)copyWithZone:(NSZone *)zone {
     return [[[self class] allocWithZone:zone] initWithSessionConfiguration:self.session.configuration];
-}
-
-#pragma mark - Authentication helpers
-
-+ (nonnull NSError *)serverTrustErrorWithServerTrust:(nonnull SecTrustRef)serverTrust url:(nonnull NSURL *)url {
-
-        NSBundle *CFNetworkBundle = [NSBundle bundleWithIdentifier:@"com.apple.CFNetwork"];
-    NSString *defaultValue = @"The certificate for this server is invalid. You might be connecting to a server that is pretending to be “%@” which could put your confidential information at risk.";
-    NSString *descriptionFormat = NSLocalizedStringWithDefaultValue(@"Err-1202.w", nil, CFNetworkBundle, defaultValue, @"") ?: defaultValue;
-    NSString *localizedDescription = [descriptionFormat componentsSeparatedByString:@"%@"].count <= 2 ? [NSString localizedStringWithFormat:descriptionFormat, url.host] : descriptionFormat;
-    NSDictionary *userInfo = @{
-        NSURLErrorFailingURLErrorKey: url,
-        NSURLErrorFailingURLStringErrorKey: url.absoluteString,
-        NSURLErrorFailingURLPeerTrustErrorKey: (__bridge id)serverTrust,
-        NSLocalizedDescriptionKey: localizedDescription
-    };
-    return [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorServerCertificateUntrusted userInfo:userInfo];
-
 }
 
 @end

--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -1006,7 +1006,7 @@ didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
     }
 }
 
-- (nonnull NSError *)serverTrustErrorForServerTrust:(SecTrustRef)serverTrust url:(NSURL *)url
+- (nonnull NSError *)serverTrustErrorForServerTrust:(nullable SecTrustRef)serverTrust url:(nullable NSURL *)url
 {
     NSBundle *CFNetworkBundle = [NSBundle bundleWithIdentifier:@"com.apple.CFNetwork"];
     NSString *defaultValue = @"The certificate for this server is invalid. You might be connecting to a server that is pretending to be “%@” which could put your confidential information at risk.";

--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -168,21 +168,6 @@ typedef void (^AFURLSessionTaskCompletionHandler)(NSURLResponse *response, id re
 
 static const void * const AuthenticationChallengeErrorKey = &AuthenticationChallengeErrorKey;
 
-static NSError * ServerTrustError(SecTrustRef serverTrust, NSURL *url)
-{
-    NSBundle *CFNetworkBundle = [NSBundle bundleWithIdentifier:@"com.apple.CFNetwork"];
-    NSString *defaultValue = @"The certificate for this server is invalid. You might be connecting to a server that is pretending to be “%@” which could put your confidential information at risk.";
-    NSString *descriptionFormat = NSLocalizedStringWithDefaultValue(@"Err-1202.w", nil, CFNetworkBundle, defaultValue, @"") ?: defaultValue;
-    NSString *localizedDescription = [descriptionFormat componentsSeparatedByString:@"%@"].count <= 2 ? [NSString localizedStringWithFormat:descriptionFormat, url.host] : descriptionFormat;
-    NSDictionary *userInfo = @{
-        NSURLErrorFailingURLErrorKey: url,
-        NSURLErrorFailingURLStringErrorKey: url.absoluteString,
-        NSURLErrorFailingURLPeerTrustErrorKey: (__bridge id)serverTrust,
-        NSLocalizedDescriptionKey: localizedDescription
-    };
-    return [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorServerCertificateUntrusted userInfo:userInfo];
-}
-
 #pragma mark - NSURLSessionTaskDelegate
 
 - (void)URLSession:(__unused NSURLSession *)session
@@ -1009,7 +994,9 @@ didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
             disposition = NSURLSessionAuthChallengeUseCredential;
             credential = [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust];
         } else {
-            objc_setAssociatedObject(task, AuthenticationChallengeErrorKey, ServerTrustError(challenge.protectionSpace.serverTrust, task.currentRequest.URL), OBJC_ASSOCIATION_RETAIN);
+            objc_setAssociatedObject(task, AuthenticationChallengeErrorKey,
+                                     [self serverTrustErrorForServerTrust:challenge.protectionSpace.serverTrust url:task.currentRequest.URL],
+                                     OBJC_ASSOCIATION_RETAIN);
             disposition = NSURLSessionAuthChallengeCancelAuthenticationChallenge;
         }
     }
@@ -1017,6 +1004,31 @@ didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
     if (completionHandler) {
         completionHandler(disposition, credential);
     }
+}
+
+- (nonnull NSError *)serverTrustErrorForServerTrust:(SecTrustRef)serverTrust url:(NSURL *)url
+{
+    NSBundle *CFNetworkBundle = [NSBundle bundleWithIdentifier:@"com.apple.CFNetwork"];
+    NSString *defaultValue = @"The certificate for this server is invalid. You might be connecting to a server that is pretending to be “%@” which could put your confidential information at risk.";
+    NSString *descriptionFormat = NSLocalizedStringWithDefaultValue(@"Err-1202.w", nil, CFNetworkBundle, defaultValue, @"") ?: defaultValue;
+    NSString *localizedDescription = [descriptionFormat componentsSeparatedByString:@"%@"].count <= 2 ? [NSString localizedStringWithFormat:descriptionFormat, url.host] : descriptionFormat;
+    NSMutableDictionary *userInfo = [@{
+        NSLocalizedDescriptionKey: localizedDescription
+    } mutableCopy];
+
+    if (serverTrust) {
+        userInfo[NSURLErrorFailingURLPeerTrustErrorKey] = (__bridge id)serverTrust;
+    }
+
+    if (url) {
+        userInfo[NSURLErrorFailingURLErrorKey] = url;
+
+        if (url.absoluteString) {
+            userInfo[NSURLErrorFailingURLStringErrorKey] = url.absoluteString;
+        }
+    }
+
+    return [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorServerCertificateUntrusted userInfo:userInfo];
 }
 
 - (void)URLSession:(NSURLSession *)session

--- a/AFNetworking/AFURLSessionManager.m
+++ b/AFNetworking/AFURLSessionManager.m
@@ -986,8 +986,7 @@ didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
             @throw [NSException exceptionWithName:@"Invalid Return Value" reason:@"The return value from the authentication challenge handler must be nil, an NSError, an NSURLCredential or an NSNumber." userInfo:nil];
         }
     } else {
-        // serverTrust is nil if the authentication method of the protection space is not server trust
-        evaluateServerTrust = challenge.protectionSpace.serverTrust != nil;
+        evaluateServerTrust = [challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust];
     }
 
     if (evaluateServerTrust) {

--- a/Package.swift
+++ b/Package.swift
@@ -34,4 +34,4 @@ let package = Package(name: "AFNetworking",
                                           targets: ["AFNetworking"])],
                       targets: [.target(name: "AFNetworking",
                                         path: "AFNetworking",
-                                        publicHeadersPath: "AFNetworking")])
+                                        publicHeadersPath: "")])

--- a/Tests/Tests/AFHTTPSessionManagerTests.m
+++ b/Tests/Tests/AFHTTPSessionManagerTests.m
@@ -606,4 +606,12 @@
     [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
 }
 
+static const void * const AuthenticationChallengeErrorKey = &AuthenticationChallengeErrorKey;
+
+- (void)testServerTrustErrorCrash {
+    NSURLProtectionSpace *space = [[NSURLProtectionSpace alloc] initWithHost:@"https://pinning-test.badssl.com" port:443 protocol:nil realm:nil authenticationMethod:NSURLAuthenticationMethodClientCertificate];
+    XCTAssertNil((__bridge id)space.serverTrust);
+    XCTAssertThrows([AFURLSessionManager serverTrustErrorWithServerTrust:space.serverTrust url:[NSURL URLWithString:@"https://pinning-test.badssl.com"]]);
+}
+
 @end

--- a/Tests/Tests/AFHTTPSessionManagerTests.m
+++ b/Tests/Tests/AFHTTPSessionManagerTests.m
@@ -206,6 +206,33 @@
     [self waitForExpectationsWithTimeout:10.0 handler:nil];
 }
 
+- (void)testSettingHTTPHeadersPerRequestCanReplaceTheDefaultValueSpecifiedInRequestSerializer {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Request should succeed"];
+
+    [self.sessionManager.requestSerializer setValue:@"foo value"
+                                 forHTTPHeaderField:@"X-Foo"];
+    [self.sessionManager.requestSerializer setValue:@"bar value"
+                                 forHTTPHeaderField:@"X-Bar"];
+
+    NSURLSessionDataTask *testTask =
+        [self.sessionManager dataTaskWithHTTPMethod:@"GET"
+                                          URLString:@"get"
+                                         parameters:nil
+                                            headers:@{ @"X-Foo": @"request value" }
+                                     uploadProgress:nil
+                                   downloadProgress:nil
+                                            success:^(NSURLSessionDataTask * _Nonnull task, id _Nullable responseObject) {
+        XCTAssertTrue([task.originalRequest.allHTTPHeaderFields[@"X-Foo"] isEqualToString:@"request value"]);
+        XCTAssertTrue([task.originalRequest.allHTTPHeaderFields[@"X-Bar"] isEqualToString:@"bar value"]);
+        [expectation fulfill];
+    }
+                                            failure:nil];
+
+    [testTask resume];
+
+    [self waitForExpectationsWithCommonTimeout];
+}
+
 #pragma mark - NSCoding
 
 - (void)testSupportsSecureCoding {
@@ -380,6 +407,8 @@
 
 - (void)testPOST {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Request should succeed"];
+    [self.sessionManager.requestSerializer setValue:@"default value"
+                                 forHTTPHeaderField:@"field"];
     [self.sessionManager
      POST:@"post"
      parameters:@{@"key":@"value"}
@@ -396,6 +425,8 @@
 
 - (void)testPOSTWithConstructingBody {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Request should succeed"];
+    [self.sessionManager.requestSerializer setValue:@"default value"
+                                 forHTTPHeaderField:@"field"];
     [self.sessionManager
      POST:@"post"
      parameters:@{@"key":@"value"}
@@ -419,6 +450,8 @@
 
 - (void)testPUT {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Request should succeed"];
+    [self.sessionManager.requestSerializer setValue:@"default value"
+                                 forHTTPHeaderField:@"field"];
     [self.sessionManager
      PUT:@"put"
      parameters:@{@"key":@"value"}
@@ -434,6 +467,8 @@
 
 - (void)testDELETE {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Request should succeed"];
+    [self.sessionManager.requestSerializer setValue:@"default value"
+                                 forHTTPHeaderField:@"field"];
     [self.sessionManager
      DELETE:@"delete"
      parameters:@{@"key":@"value"}
@@ -449,6 +484,8 @@
 
 - (void)testPATCH {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Request should succeed"];
+    [self.sessionManager.requestSerializer setValue:@"default value"
+                                 forHTTPHeaderField:@"field"];
     [self.sessionManager
      PATCH:@"patch"
      parameters:@{@"key":@"value"}

--- a/Tests/Tests/AFSecurityPolicyTests.m
+++ b/Tests/Tests/AFSecurityPolicyTests.m
@@ -26,23 +26,6 @@
 
 @end
 
-static SecTrustRef AFUTTrustChainForCertsInDirectory(NSString *directoryPath) {
-    NSArray *certFileNames = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:directoryPath error:nil];
-    NSMutableArray *certs  = [NSMutableArray arrayWithCapacity:[certFileNames count]];
-    for (NSString *path in certFileNames) {
-        NSData *certData = [NSData dataWithContentsOfFile:[directoryPath stringByAppendingPathComponent:path]];
-        SecCertificateRef cert = SecCertificateCreateWithData(NULL, (__bridge CFDataRef)(certData));
-        [certs addObject:(__bridge_transfer id)(cert)];
-    }
-
-    SecPolicyRef policy = SecPolicyCreateBasicX509();
-    SecTrustRef trust = NULL;
-    SecTrustCreateWithCertificates((__bridge CFTypeRef)(certs), policy, &trust);
-    CFRelease(policy);
-
-    return trust;
-}
-
 static SecTrustRef AFUTHTTPBinOrgServerTrust() {
     NSString *bundlePath = [[NSBundle bundleForClass:[AFSecurityPolicyTests class]] resourcePath];
     NSString *serverCertDirectoryPath = [bundlePath stringByAppendingPathComponent:@"HTTPBinOrgServerTrustChain"];

--- a/Tests/Tests/AFTestCase.h
+++ b/Tests/Tests/AFTestCase.h
@@ -21,6 +21,8 @@
 
 #import <XCTest/XCTest.h>
 
+SecTrustRef AFUTTrustChainForCertsInDirectory(NSString *directoryPath);
+
 @interface AFTestCase : XCTestCase
 
 @property (nonatomic, strong, readonly) NSURL *baseURL;

--- a/Tests/Tests/AFTestCase.m
+++ b/Tests/Tests/AFTestCase.m
@@ -21,6 +21,23 @@
 
 #import "AFTestCase.h"
 
+SecTrustRef AFUTTrustChainForCertsInDirectory(NSString *directoryPath) {
+    NSArray *certFileNames = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:directoryPath error:nil];
+    NSMutableArray *certs  = [NSMutableArray arrayWithCapacity:[certFileNames count]];
+    for (NSString *path in certFileNames) {
+        NSData *certData = [NSData dataWithContentsOfFile:[directoryPath stringByAppendingPathComponent:path]];
+        SecCertificateRef cert = SecCertificateCreateWithData(NULL, (__bridge CFDataRef)(certData));
+        [certs addObject:(__bridge_transfer id)(cert)];
+    }
+    
+    SecPolicyRef policy = SecPolicyCreateBasicX509();
+    SecTrustRef trust = NULL;
+    SecTrustCreateWithCertificates((__bridge CFTypeRef)(certs), policy, &trust);
+    CFRelease(policy);
+    
+    return trust;
+}
+
 @implementation AFTestCase
 
 - (void)setUp {


### PR DESCRIPTION
### Issue Link :link:
#4541

### Goals :soccer:
This PR builds on #4542 and #4552 to fix the crash seen when attempting to create an error for a `nil` `SecTrustRef`. It combines both approaches:

- Ensure we only attempt to check the trusts when `[challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust]` is `YES`.
- When creating an error, ensure proper nullability checks when inserting values into the `userInfo` dictionary, as even in the `NSURLAuthenticationMethodServerTrust` case, the values can be `nil`.

### Implementation Details :construction:
This PR makes the previous 

```objc
static NSError * ServerTrustError(SecTrustRef serverTrust, NSURL *url)
```
 convenience function into an internal method on `AFURLSessionManager`

```objc
- (nonnull NSError *)serverTrustErrorForServerTrust:(SecTrustRef)serverTrust url:(NSURL *)url`
```

to enable testing and adds additional checking internally to ensure no `nil` values are inserted into the dictionary.

### Testing Details :mag:
Tests were added for each permutation of parameters to the new method. To enable this, a `SecTrust` creation function was moved into `AFTestCase` to enable its use in other tests.
