### PR TITLE
Fix SPM Usage

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -34,4 +34,4 @@ let package = Package(name: "AFNetworking",
                                           targets: ["AFNetworking"])],
                       targets: [.target(name: "AFNetworking",
                                         path: "AFNetworking",
-                                        publicHeadersPath: "AFNetworking")])
+                                        publicHeadersPath: "")])


### PR DESCRIPTION
### Issue Link :link:
Original Package.swift introduced in 4.0.0 didn't work due to an improper header search path.

### Goals :soccer:
This PR fixes the Package.swift file by setting the `publicHeadersPath` value correctly.

### Implementation Details :construction:
As explained [here](https://forums.swift.org/t/can-i-use-swift-package-manager-in-obj-c-code/35463/16), the `publicHeadersPath` value is relative to the target directory, not the package file, so it should've been `""` instead of `"AFNetworking"`.

### Testing Details :mag:
Tested manually with a test project that was broken previously.
