### PR TITLE
ignore https check if baseURL is not set

### DIFF
--- a/AFNetworking/AFHTTPSessionManager.m
+++ b/AFNetworking/AFHTTPSessionManager.m
@@ -101,7 +101,7 @@
 @dynamic securityPolicy;
 
 - (void)setSecurityPolicy:(AFSecurityPolicy *)securityPolicy {
-    if (securityPolicy.SSLPinningMode != AFSSLPinningModeNone && ![self.baseURL.scheme isEqualToString:@"https"]) {
+    if (securityPolicy.SSLPinningMode != AFSSLPinningModeNone && self.baseURL && ![self.baseURL.scheme isEqualToString:@"https"]) {
         NSString *pinningMode = @"Unknown Pinning Mode";
         switch (securityPolicy.SSLPinningMode) {
             case AFSSLPinningModeNone:        pinningMode = @"AFSSLPinningModeNone"; break;

--- a/Tests/Tests/AFHTTPSessionManagerTests.m
+++ b/Tests/Tests/AFHTTPSessionManagerTests.m
@@ -560,13 +560,13 @@
 - (void)testInvalidCertificatePinningSecurityPolicyWithoutBaseURL {
     AFHTTPSessionManager *manager = [[AFHTTPSessionManager alloc] init];
     AFSecurityPolicy *securityPolicy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModeCertificate];
-    XCTAssertThrowsSpecificNamed(manager.securityPolicy = securityPolicy, NSException, @"Invalid Security Policy");
+    XCTAssertNoThrow(manager.securityPolicy = securityPolicy);
 }
 
 - (void)testInvalidPublicKeyPinningSecurityPolicyWithoutBaseURL {
     AFHTTPSessionManager *manager = [[AFHTTPSessionManager alloc] init];
     AFSecurityPolicy *securityPolicy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModePublicKey];
-    XCTAssertThrowsSpecificNamed(manager.securityPolicy = securityPolicy, NSException, @"Invalid Security Policy");
+    XCTAssertNoThrow(manager.securityPolicy = securityPolicy);
 }
 
 # pragma mark - Server Trust


### PR DESCRIPTION
### Goals :soccer:
We should allow usage of security policy if URL construction is being managed outside of AFNetworking and not using `baseURL` variable.

### Implementation Details :construction:
Check usage of `https` only if `baseURL` is set. Otherwise assume it's user responsibility to use the right protocol.

### Testing Details :mag:
Tests are updated to validate new changes.
