### PR TITLE
Disable 'Zombie Objects' diagnostics for tvOS scheme

### DIFF
--- a/AFNetworking.xcodeproj/xcshareddata/xcschemes/AFNetworking tvOS.xcscheme
+++ b/AFNetworking.xcodeproj/xcshareddata/xcschemes/AFNetworking tvOS.xcscheme
@@ -102,13 +102,6 @@
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>
-      <AdditionalOptions>
-         <AdditionalOption
-            key = "NSZombieEnabled"
-            value = "YES"
-            isEnabled = "YES">
-         </AdditionalOption>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"


### PR DESCRIPTION
### Goals :soccer:
Disables Zombie Object diagnostics for tvOS scheme

### Implementation Details :construction:
Diagnostics shouldn't be enabled by default. Specifically, this causes the framework for tvOS to be build with Zombie Objects enabled when installed using Carthage. Zombie Objects prevent objects from ever being freed up, which means AFNetworking is (potentially) constantly leaking memory on tvOS.

To be perfectly honest, I can't find any documentation stating whether having Zombie Objects enabled in the scheme causes them to be enabled in the resulting binary, and I don't see anything indicating one way or the other. I could be totally wrong in how this is actually handled for release builds. I'm assuming it's safer to disable it, but I'm not certain how to empirically verify that.

### Testing Details :mag:
I just unchecked the "Zombie Objects" diagnostics option in `AFNetworking tvOS.xcscheme`