### PR TITLE
Fix docblock

### DIFF
--- a/AFNetworking/AFURLSessionManager.h
+++ b/AFNetworking/AFURLSessionManager.h
@@ -316,10 +316,10 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param block A block object to be executed when a connection level authentication challenge has occurred. The block returns the disposition of the authentication challenge, and takes three arguments: the session, the authentication challenge, and a pointer to the credential that should be used to resolve the challenge.
 
- @warning Implementing a session authentication challenge handler yourself totally bypasses AFNetworking's security policy defined in `AFSecurityPolicy`. Make sure you fully understand the implications before implementing a custom session authentication challenge handler. If you do not want to bypass AFNetworking's security policy, use `setTaskDidReceiveAuthenticationChallengeBlock:` instead.
+ @warning Implementing a session authentication challenge handler yourself totally bypasses AFNetworking's security policy defined in `AFSecurityPolicy`. Make sure you fully understand the implications before implementing a custom session authentication challenge handler. If you do not want to bypass AFNetworking's security policy, use `-setAuthenticationChallengeHandler:` instead.
 
  @see -securityPolicy
- @see -setTaskDidReceiveAuthenticationChallengeBlock:
+ @see -setAuthenticationChallengeHandler:
  */
 - (void)setSessionDidReceiveAuthenticationChallengeBlock:(nullable NSURLSessionAuthChallengeDisposition (^)(NSURLSession *session, NSURLAuthenticationChallenge *challenge, NSURLCredential * _Nullable __autoreleasing * _Nullable credential))block;
 


### PR DESCRIPTION
### Issue Link :link:
https://github.com/AFNetworking/AFNetworking/issues/4573

### Goals :soccer:
`-setTaskDidReceiveAuthenticationChallengeBlock:` has been renamed to `-setAuthenticationChallengeHandler:` in v4, but the docblock still references the old method name.
