### PR TITLE
Improve for-loop observed keyPaths for request serializer

### DIFF
--- a/AFNetworking/AFURLRequestSerialization.m
+++ b/AFNetworking/AFURLRequestSerialization.m
@@ -368,10 +368,8 @@ forHTTPHeaderField:(NSString *)field
     NSMutableURLRequest *mutableRequest = [[NSMutableURLRequest alloc] initWithURL:url];
     mutableRequest.HTTPMethod = method;
 
-    for (NSString *keyPath in AFHTTPRequestSerializerObservedKeyPaths()) {
-        if ([self.mutableObservedChangedKeyPaths containsObject:keyPath]) {
-            [mutableRequest setValue:[self valueForKeyPath:keyPath] forKey:keyPath];
-        }
+    for (NSString *keyPath in self.mutableObservedChangedKeyPaths) {
+        [mutableRequest setValue:[self valueForKeyPath:keyPath] forKey:keyPath];
     }
 
     mutableRequest = [[self requestBySerializingRequest:mutableRequest withParameters:parameters error:error] mutableCopy];


### PR DESCRIPTION
### Goals :soccer:

It's better to loop `mutableObservedChangedKeyPaths` directly: change loop count from `AFHTTPRequestSerializerObservedKeyPaths().count` (all) to `self.mutableObservedChangedKeyPaths.count` (actually needed).


Related PR https://github.com/AFNetworking/AFNetworking/pull/4253