### PR TITLE
Use low priority queue instead of background for SCNetworkReachabilityGetFlags()

### DIFF
--- a/AFNetworking/AFNetworkReachabilityManager.m
+++ b/AFNetworking/AFNetworkReachabilityManager.m
@@ -227,7 +227,7 @@ static void AFNetworkReachabilityReleaseCallback(const void *info) {
     SCNetworkReachabilitySetCallback(self.networkReachability, AFNetworkReachabilityCallback, &context);
     SCNetworkReachabilityScheduleWithRunLoop(self.networkReachability, CFRunLoopGetMain(), kCFRunLoopCommonModes);
 
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0),^{
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_LOW, 0),^{
         SCNetworkReachabilityFlags flags;
         if (SCNetworkReachabilityGetFlags(self.networkReachability, &flags)) {
             AFPostReachabilityStatusChange(flags, callback);


### PR DESCRIPTION
### Issue Link :link:
Close #4223, related https://github.com/Alamofire/Alamofire/pull/3207

Background queues may stop execution altogether in low power mode, so utility mode is recommended.

### Goals :soccer:
This PR changes `DISPATCH_QUEUE_PRIORITY_BACKGROUND` to `DISPATCH_QUEUE_PRIORITY_LOW` (maps to the `QOS_CLASS_UTILITY` class) for `SCNetworkReachabilityGetFlags()` in the method `-[AFNetworkReachabilityManager startMonitoring]`.

### Implementation Details :construction:
`DISPATCH_QUEUE_PRIORITY_BACKGROUND` -> `DISPATCH_QUEUE_PRIORITY_LOW`

### Testing Details :mag:
None, there's no way to test this behavior.
