### PR TITLE
Fix redirect test: use httpbingo service instead

### DIFF
--- a/Tests/Tests/AFHTTPSessionManagerTests.m
+++ b/Tests/Tests/AFHTTPSessionManagerTests.m
@@ -103,7 +103,7 @@
 
     XCTestExpectation *expectation = [self expectationWithDescription:@"Request should succeed"];
 
-    NSURLRequest *redirectRequest = [NSURLRequest requestWithURL:[NSURL URLWithString:@"/redirect/1" relativeToURL:self.baseURL]];
+    NSURLRequest *redirectRequest = [NSURLRequest requestWithURL:[NSURL URLWithString:@"https://httpbingo.org/redirect/1"]];
     NSURLSessionDataTask *redirectTask = [self.sessionManager dataTaskWithRequest:redirectRequest uploadProgress:nil downloadProgress:nil
                                                          completionHandler:^(NSURLResponse *response, id responseObject, NSError *error) {
         blockError = error;


### PR DESCRIPTION
### Issue Link :link:
postmanlabs/httpbin#617

### Goals :soccer:
This PR replaces the httpbin.org service with [httpbingo.org](https://httpbingo.org) for the redirect test, because currently httpbin's redirect is returning a 404 response.

### Implementation Details :construction:
Change the request URL in `testThatRedirectBlockIsCalledWhen302IsEncountered` from `<HTTPBIN_BASE_URL>/redirect/1` to `https://httpbingo.org/redirect/1`.

### Testing Details :mag:
All tests can pass now.
