### PR TITLE
remove scheduleInRunLoop in requestWithMultipartFormRequest:writingSt…

### DIFF
--- a/AFNetworking/AFURLRequestSerialization.m
+++ b/AFNetworking/AFURLRequestSerialization.m
@@ -426,8 +426,6 @@ forHTTPHeaderField:(NSString *)field
     __block NSError *error = nil;
 
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        [inputStream scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
-        [outputStream scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
 
         [inputStream open];
         [outputStream open];

--- a/Example/AFNetworking Example.xcodeproj/xcshareddata/xcschemes/watchOS Example.xcscheme
+++ b/Example/AFNetworking Example.xcodeproj/xcshareddata/xcschemes/watchOS Example.xcscheme
@@ -96,7 +96,7 @@
       allowLocationSimulation = "YES">
       <RemoteRunnable
          runnableDebuggingMode = "2"
-         BundleIdentifier = "com.apple.carousel"
+         BundleIdentifier = "com.apple.Carousel"
          RemotePath = "/iOS Example">
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -122,7 +122,7 @@
       debugDocumentVersioning = "YES">
       <RemoteRunnable
          runnableDebuggingMode = "2"
-         BundleIdentifier = "com.apple.carousel"
+         BundleIdentifier = "com.apple.Carousel"
          RemotePath = "/iOS Example">
          <BuildableReference
             BuildableIdentifier = "primary"


### PR DESCRIPTION
…reamContentsToFile:completionHandler of AFURLRequestSerialization

`[inputStream scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
  [outputStream scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];` 
the code is unnecessay. here is the reasons:
1. runloop does not run in other thread .
2. read and write from stream using Polling model, runloop is needless
