### PR TITLE
Fixed CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER warnings

### DIFF
--- a/AFNetworking/AFHTTPSessionManager.h
+++ b/AFNetworking/AFHTTPSessionManager.h
@@ -25,7 +25,7 @@
 #endif
 #import <TargetConditionals.h>
 
-#import "AFURLSessionManager.h"
+#import <AFNetworking/AFURLSessionManager.h>
 
 /**
  `AFHTTPSessionManager` is a subclass of `AFURLSessionManager` with convenience methods for making HTTP requests. When a `baseURL` is provided, requests made with the `GET` / `POST` / et al. convenience methods can be made with relative paths.

--- a/AFNetworking/AFURLSessionManager.h
+++ b/AFNetworking/AFURLSessionManager.h
@@ -22,12 +22,12 @@
 
 #import <Foundation/Foundation.h>
 
-#import "AFURLResponseSerialization.h"
-#import "AFURLRequestSerialization.h"
-#import "AFSecurityPolicy.h"
-#import "AFCompatibilityMacros.h"
+#import <AFNetworking/AFURLResponseSerialization.h>
+#import <AFNetworking/AFURLRequestSerialization.h>
+#import <AFNetworking/AFSecurityPolicy.h>
+#import <AFNetworking/AFCompatibilityMacros.h>
 #if !TARGET_OS_WATCH
-#import "AFNetworkReachabilityManager.h"
+#import <AFNetworking/AFNetworkReachabilityManager.h>
 #endif
 
 /**

--- a/UIKit+AFNetworking/AFImageDownloader.h
+++ b/UIKit+AFNetworking/AFImageDownloader.h
@@ -24,8 +24,8 @@
 #if TARGET_OS_IOS || TARGET_OS_TV 
 
 #import <Foundation/Foundation.h>
-#import "AFAutoPurgingImageCache.h"
-#import "AFHTTPSessionManager.h"
+#import <AFNetworking/AFAutoPurgingImageCache.h>
+#import <AFNetworking/AFHTTPSessionManager.h>
 
 NS_ASSUME_NONNULL_BEGIN
 


### PR DESCRIPTION
### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
- Fixes warnings when CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER flag is activated in the build settings
- Flag is per default activated for Xcode Version 12
- for frameworks who integrate AFNetworking via Carthage the above warning will appear in the project if not fixed

