### PR TITLE
Fix 

### DIFF
--- a/Tests/Tests/AFUIImageViewTests.m
+++ b/Tests/Tests/AFUIImageViewTests.m
@@ -74,6 +74,51 @@
     [self waitForExpectationsWithCommonTimeout];
 }
 
+- (void)testThatDuplicateRequestOnlyCalledLastTime {
+    XCTAssertNil(self.imageView.image);
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Request should fail"];
+    [self.imageView
+     setImageWithURLRequest:self.jpegURLRequest
+     placeholderImage:nil
+     success:^(NSURLRequest * _Nonnull request, NSHTTPURLResponse * _Nullable response, UIImage * _Nonnull image) {
+        XCTFail("repeat requests should be called only the last time");
+     }
+     failure:nil];
+    
+    [self.imageView
+     setImageWithURLRequest:self.error404URLRequest
+     placeholderImage:nil
+     success:nil
+     failure:^(NSURLRequest * _Nonnull request, NSHTTPURLResponse * _Nullable response, NSError * _Nonnull error) {
+        [expectation fulfill];
+    }];
+    [self waitForExpectationsWithCommonTimeout];
+}
+
+- (void)testThatDuplicateSameRequestOnlyCalledLastTime {
+    XCTAssertNil(self.imageView.image);
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Request should succeed"];
+    [self.imageView
+     setImageWithURLRequest:self.jpegURLRequest
+     placeholderImage:nil
+     success:^(NSURLRequest * _Nonnull request, NSHTTPURLResponse * _Nullable response, UIImage * _Nonnull image) {
+        XCTFail("repeat requests should be called only the last time");
+     }
+     failure:nil];
+    
+    __block UIImage *responseImage;
+    [self.imageView
+     setImageWithURLRequest:self.jpegURLRequest
+     placeholderImage:nil
+     success:^(NSURLRequest * _Nonnull request, NSHTTPURLResponse * _Nullable response, UIImage * _Nonnull image) {
+        responseImage = image;
+        [expectation fulfill];
+     }
+     failure:nil];
+    [self waitForExpectationsWithCommonTimeout];
+    XCTAssertNotNil(responseImage);
+}
+
 - (void)testThatPlaceholderImageIsSetIfRequestFails {
     UIImage *placeholder = [UIImage imageNamed:@"logo"];
     XCTestExpectation *expectation = [self expectationWithDescription:@"Request should fail"];

--- a/UIKit+AFNetworking/UIImageView+AFNetworking.m
+++ b/UIKit+AFNetworking/UIImageView+AFNetworking.m
@@ -84,11 +84,9 @@
         return;
     }
     
-    if ([self isActiveTaskURLEqualToURLRequest:urlRequest]) {
-        return;
+    if (![self isActiveTaskURLEqualToURLRequest:urlRequest]) {
+        [self cancelImageDownloadTask];
     }
-    
-    [self cancelImageDownloadTask];
 
     AFImageDownloader *downloader = [[self class] sharedImageDownloader];
     id <AFImageRequestCache> imageCache = downloader.imageCache;
@@ -134,6 +132,10 @@
                             [strongSelf clearActiveDownloadInformation];
                         }
                    }];
+        
+        if ([self isActiveTaskURLEqualToURLRequest:urlRequest]) {
+            [self cancelImageDownloadTask];
+        }
 
         self.af_activeImageDownloadReceipt = receipt;
     }


### PR DESCRIPTION
### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->
when UIImageView download same URL twice, the second callback never get called. This behavior is different from the normal logic (normally, the first request will not call back, the second will call back when the request is not equal).

* different URL

```Objective-C
    [self.imageView
     setImageWithURLRequest:urlRequest1
     placeholderImage:nil
     success:^(NSURLRequest * _Nonnull request, NSHTTPURLResponse * _Nullable response, UIImage * _Nonnull image) {
        NSLog(@"first callback");// never be called
     }
     failure:nil];
    
    [self.imageView
     setImageWithURLRequest:urlRequest2
     placeholderImage:nil
     success:^(NSURLRequest * _Nonnull request, NSHTTPURLResponse * _Nullable response, UIImage * _Nonnull image) {
        NSLog(@"second callback");// will be called here
     }
     failure:nil];
```

* same URL

```Objective-C
    [self.imageView
     setImageWithURLRequest:self.jpegURLRequest
     placeholderImage:nil
     success:^(NSURLRequest * _Nonnull request, NSHTTPURLResponse * _Nullable response, UIImage * _Nonnull image) {
        NSLog(@"first callback");// will be called here
     }
     failure:nil];
    
    [self.imageView
     setImageWithURLRequest:self.jpegURLRequest
     placeholderImage:nil
     success:^(NSURLRequest * _Nonnull request, NSHTTPURLResponse * _Nullable response, UIImage * _Nonnull image) {
        NSLog(@"second callback");// never be called
     }
     failure:nil];
```

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

```Objective-C
- (void)setImageWithURLRequest:(NSURLRequest *)urlRequest
              placeholderImage:(UIImage *)placeholderImage
                       success:(void (^)(NSURLRequest *request, NSHTTPURLResponse * _Nullable response, UIImage *image))success
                       failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse * _Nullable response, NSError *error))failure
{
....

// cancel Image download when activeTaskURL is not equal to previous request
// but if activeTaskURL is equal to previous request, not return, just continue.
    if (![self isActiveTaskURLEqualToURLRequest:urlRequest]) {
        [self cancelImageDownloadTask];
    }

....
// cancel last same url request task, because you already add a new AFImageDownloaderResponseHandler to AFImageDownloaderMergedTask. here you cancel the previous task will not cancel the AFImageDownloaderMergedTask
        if ([self isActiveTaskURLEqualToURLRequest:urlRequest]) {
            [self cancelImageDownloadTask];
        }

        self.af_activeImageDownloadReceipt = receipt;
....
}
```


### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->

[AFNetworking UIKit Tests] folder

AFUIImageViewTests.m

```Objective-C
- (void)testThatDuplicateRequestOnlyCalledLastTime
- (void)testThatDuplicateSameRequestOnlyCalledLastTime
```