### PR TITLE
[AFImageDownloader defaultURLCache] is broken and can exceed disk cache limit

### DIFF
--- a/UIKit+AFNetworking/AFImageDownloader.m
+++ b/UIKit+AFNetworking/AFImageDownloader.m
@@ -111,21 +111,21 @@
 + (NSURLCache *)defaultURLCache {
     NSUInteger memoryCapacity = 20 * 1024 * 1024; // 20MB
     NSUInteger diskCapacity = 150 * 1024 * 1024; // 150MB
+    NSString *diskPath = @"com.alamofire.imagedownloader";
+#if TARGET_OS_MACCATALYST
     NSURL *cacheURL = [[[NSFileManager defaultManager] URLForDirectory:NSCachesDirectory
                                                               inDomain:NSUserDomainMask
                                                      appropriateForURL:nil
                                                                 create:YES
                                                                  error:nil]
-                       URLByAppendingPathComponent:@"com.alamofire.imagedownloader"];
-    
-#if TARGET_OS_MACCATALYST
+                       URLByAppendingPathComponent:diskPath];
     return [[NSURLCache alloc] initWithMemoryCapacity:memoryCapacity
                                          diskCapacity:diskCapacity
                                          directoryURL:cacheURL];
 #else
     return [[NSURLCache alloc] initWithMemoryCapacity:memoryCapacity
                                          diskCapacity:diskCapacity
-                                             diskPath:[cacheURL path]];
+                                             diskPath:diskPath];
 #endif
 }
 


### PR DESCRIPTION
### Goals :soccer:

This fixes an issue introduced in https://github.com/AFNetworking/AFNetworking/pull/4523

In [Apple's documentation](https://developer.apple.com/documentation/foundation/nsurlcache/1415637-initwithmemorycapacity), the diskPath in `[NSURLCache initWithMemoryCapacity:diskCapacity:diskPath:]` is 
> the name of a subdirectory of the application’s default cache directory in which to store the on-disk cache (the subdirectory is created if it does not exist).

In existing code, we're feeding the entire path (including the absolute cache path). This will break because as the nature of sandboxing, the absolute path to the cache directory will change on every launch. Therefore, essentially every launch there will be a new cache directory created, and we won't be able to holistically control the total disk size of the NSURLCache.

See below screenshot for an example
![image](https://user-images.githubusercontent.com/11301126/149286709-5697f81c-8e4c-48e1-a336-cd684dcabf24.png)


### Implementation Details :construction:
The newer initializer (used in `#if TARGET_OS_MACCATALYST`) `initWithMemoryCapacity:diskCapacity:directoryURL:` indeed asks for absolute path, so we will not touch that. But in the initializer using `diskPath` only pass in the `diskPath` rather than the absolute path to the cache directory.

### Testing Details :mag:
After the change, the NSURLCache control of the total disk size limit is fixed and we're hitting caches more frequently.
